### PR TITLE
Fix integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ TODO
 * `make test` - Runs the unit tests
 * `make it` - Runs the unit and integration tests
 
+**Note:** the integration tests run against a temporary sqlite3 database by default. They can be run against a postgres server by setting the environment variable `POSTGRES_DB` to the postgres connection string. For example: `postgres@localhost/stash-box-test?sslmode=disable`. **Be aware that the integration tests drop all tables before and after the tests.**
+
 ## Building a release
 
 1. Run `make generate` to create generated files 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.3.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/h2non/filetype v1.0.8
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.10.0

--- a/pkg/api/integration_test.go
+++ b/pkg/api/integration_test.go
@@ -167,6 +167,20 @@ func (s *testRunner) generateSceneFingerprint() *models.FingerprintInput {
 	}
 }
 
+func compareUrls(input []*models.URLInput, urls []*models.URL) bool {
+	if len(urls) != len(input) {
+		return false
+	}
+
+	for i, v := range urls {
+		if v.URL != input[i].URL || v.Type != input[i].Type {
+			return false
+		}
+	}
+
+	return true
+}
+
 func oneNil(l interface{}, r interface{}) bool {
 	return l != r && (l == nil || r == nil)
 }

--- a/pkg/api/performer_integration_test.go
+++ b/pkg/api/performer_integration_test.go
@@ -321,71 +321,6 @@ func (s *performerTestRunner) testUpdatePerformer() {
 	s.verifyUpdatedPerformer(updateInput, updatedPerformer)
 }
 
-func (s *performerTestRunner) testUpdatePerformerName() {
-	cupSize := "C"
-	bandSize := 32
-	tattooDesc := "Foobar"
-
-	input := &models.PerformerCreateInput{
-		Name:    s.generatePerformerName(),
-		Aliases: []string{"Alias1", "Alias2"},
-		Urls: []*models.URLInput{
-			&models.URLInput{
-				URL:  "URL",
-				Type: "Type",
-			},
-		},
-		Birthdate: &models.FuzzyDateInput{
-			Date:     "2001-02-03",
-			Accuracy: models.DateAccuracyEnumDay,
-		},
-		Measurements: &models.MeasurementsInput{
-			CupSize:  &cupSize,
-			BandSize: &bandSize,
-			Waist:    &bandSize,
-			Hip:      &bandSize,
-		},
-		Tattoos: []*models.BodyModificationInput{
-			&models.BodyModificationInput{
-				Location:    "Inner thigh",
-				Description: &tattooDesc,
-			},
-		},
-		Piercings: []*models.BodyModificationInput{
-			&models.BodyModificationInput{
-				Location:    "Nose",
-				Description: nil,
-			},
-		},
-	}
-
-	createdPerformer, err := s.createTestPerformer(input)
-	if err != nil {
-		return
-	}
-
-	performerID := createdPerformer.ID.String()
-
-	updatedName := s.generatePerformerName()
-	updateInput := models.PerformerUpdateInput{
-		ID:   performerID,
-		Name: &updatedName,
-	}
-
-	// need some mocking of the context to make the field ignore behaviour work
-	ctx := s.updateContext([]string{
-		"name",
-	})
-	updatedPerformer, err := s.resolver.Mutation().PerformerUpdate(ctx, updateInput)
-	if err != nil {
-		s.t.Errorf("Error updating performer: %s", err.Error())
-		return
-	}
-
-	input.Name = updatedName
-	s.verifyCreatedPerformer(*input, updatedPerformer)
-}
-
 func (s *performerTestRunner) verifyUpdatedPerformer(input models.PerformerUpdateInput, performer *models.Performer) {
 	// ensure basic attributes are set correctly
 	if input.Name != nil && *input.Name != performer.Name {
@@ -478,10 +413,8 @@ func TestUpdatePerformer(t *testing.T) {
 	pt.testUpdatePerformer()
 }
 
-func TestUpdatePerformerName(t *testing.T) {
-	pt := createPerformerTestRunner(t)
-	pt.testUpdatePerformerName()
-}
+// TestUpdatePerformerName is removed due to no longer allowing
+// partial updates
 
 func TestDestroyPerformer(t *testing.T) {
 	pt := createPerformerTestRunner(t)

--- a/pkg/api/performer_integration_test.go
+++ b/pkg/api/performer_integration_test.go
@@ -112,20 +112,6 @@ func compareBodyMods(input []*models.BodyModificationInput, bodyMods []*models.B
 	return true
 }
 
-func compareUrls(input []*models.URLInput, urls []*models.URL) bool {
-	if len(urls) != len(input) {
-		return false
-	}
-
-	for i, v := range urls {
-		if v.URL != input[i].URL || v.Type != input[i].Type {
-			return false
-		}
-	}
-
-	return true
-}
-
 func (s *performerTestRunner) verifyCreatedPerformer(input models.PerformerCreateInput, performer *models.Performer) {
 	// ensure basic attributes are set correctly
 	if input.Name != performer.Name {

--- a/pkg/api/scene_integration_test.go
+++ b/pkg/api/scene_integration_test.go
@@ -335,74 +335,6 @@ func (s *sceneTestRunner) testUpdateScene() {
 	s.verifyUpdatedScene(updateInput, updatedScene)
 }
 
-func (s *sceneTestRunner) testUpdateSceneTitle() {
-	title := "Title"
-	details := "Details"
-	date := "2003-02-01"
-
-	performer, _ := s.createTestPerformer(nil)
-	studio, _ := s.createTestStudio(nil)
-	tag, _ := s.createTestTag(nil)
-
-	performerID := performer.ID.String()
-	studioID := studio.ID.String()
-	tagID := tag.ID.String()
-
-	performerAlias := "alias"
-
-	input := models.SceneCreateInput{
-		Title:   &title,
-		Details: &details,
-		Date:    &date,
-		Fingerprints: []*models.FingerprintInput{
-			s.generateSceneFingerprint(),
-			s.generateSceneFingerprint(),
-		},
-		Performers: []*models.PerformerAppearanceInput{
-			&models.PerformerAppearanceInput{
-				PerformerID: performerID,
-				As:          &performerAlias,
-			},
-		},
-		Urls: []*models.URLInput{
-			&models.URLInput{
-				URL:  "URL",
-				Type: "Type",
-			},
-		},
-		StudioID: &studioID,
-		TagIds: []string{
-			tagID,
-		},
-	}
-
-	createdScene, err := s.createTestScene(&input)
-	if err != nil {
-		return
-	}
-
-	sceneID := createdScene.ID.String()
-	newTitle := "NewTitle"
-
-	updateInput := models.SceneUpdateInput{
-		ID:    sceneID,
-		Title: &newTitle,
-	}
-
-	// need some mocking of the context to make the field ignore behaviour work
-	ctx := s.updateContext([]string{
-		"title",
-	})
-	updatedScene, err := s.resolver.Mutation().SceneUpdate(ctx, updateInput)
-	if err != nil {
-		s.t.Errorf("Error updating scene: %s", err.Error())
-		return
-	}
-
-	input.Title = &newTitle
-	s.verifyCreatedScene(input, updatedScene)
-}
-
 func (s *sceneTestRunner) verifyUpdatedScene(input models.SceneUpdateInput, scene *models.Scene) {
 	// ensure basic attributes are set correctly
 	r := s.resolver.Scene()
@@ -799,10 +731,8 @@ func TestUpdateScene(t *testing.T) {
 	pt.testUpdateScene()
 }
 
-func TestUpdateSceneTitle(t *testing.T) {
-	pt := createSceneTestRunner(t)
-	pt.testUpdateSceneTitle()
-}
+// TestUpdateSceneTitle is removed due to no longer allowing
+// partial updates
 
 func TestDestroyScene(t *testing.T) {
 	pt := createSceneTestRunner(t)

--- a/pkg/api/scene_integration_test.go
+++ b/pkg/api/scene_integration_test.go
@@ -72,20 +72,6 @@ func (s *sceneTestRunner) testCreateScene() {
 	s.verifyCreatedScene(input, scene)
 }
 
-func compareUrls(input []*models.URLInput, urls []*models.URL) bool {
-	if len(urls) != len(input) {
-		return false
-	}
-
-	for i, v := range urls {
-		if v.URL != input[i].URL || v.Type != input[i].Type {
-			return false
-		}
-	}
-
-	return true
-}
-
 func comparePerformers(input []*models.PerformerAppearanceInput, performers []*models.PerformerAppearance) bool {
 	if len(performers) != len(input) {
 		return false
@@ -158,7 +144,7 @@ func (s *sceneTestRunner) verifyCreatedScene(input models.SceneCreateInput, scen
 	}
 
 	// ensure urls were set correctly
-	urls, _ := s.resolver.Performer().Urls(s.ctx, performer)
+	urls, _ := s.resolver.Scene().Urls(s.ctx, scene)
 	if !compareUrls(input.Urls, urls) {
 		s.fieldMismatch(input.Urls, urls, "Urls")
 	}
@@ -438,7 +424,7 @@ func (s *sceneTestRunner) verifyUpdatedScene(input models.SceneUpdateInput, scen
 	}
 
 	// ensure urls were set correctly
-	urls, _ := s.resolver.Performer().Urls(s.ctx, performer)
+	urls, _ := s.resolver.Scene().Urls(s.ctx, scene)
 	if !compareUrls(input.Urls, urls) {
 		s.fieldMismatch(input.Urls, urls, "Urls")
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,6 +13,7 @@ var dialect sqlDialect
 type sqlDialect interface {
 	FieldQuote(field string) string
 	SetPlaceholders(sql string) string
+	NullsLast() string
 }
 
 type databaseProvider interface {

--- a/pkg/database/databasetest/database_test_utils.go
+++ b/pkg/database/databasetest/database_test_utils.go
@@ -2,10 +2,13 @@ package databasetest
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/jmoiron/sqlx"
 
 	"github.com/stashapp/stashdb/pkg/database"
 )
@@ -27,7 +30,11 @@ func testTeardown(databaseFile string) {
 	}
 }
 
-func runTests(m *testing.M, populater DatabasePopulater) int {
+func initDatabase() {
+
+}
+
+func initSQLite() func() {
 	// create the database file
 	f, err := ioutil.TempFile("", "*.sqlite")
 	if err != nil {
@@ -39,11 +46,68 @@ func runTests(m *testing.M, populater DatabasePopulater) int {
 	const databaseType = "sqlite3"
 	database.Initialize(databaseType, databaseFile)
 
+	return func() {
+		testTeardown(databaseFile)
+	}
+}
+
+func pgDropAll(conn *sqlx.DB) {
+	// we want to drop all tables so that the migration initialises
+	// the schema
+	rows, err := conn.Queryx(`select 'drop table if exists "' || tablename || '" cascade;' from pg_tables`)
+
+	if err != nil && err != sql.ErrNoRows {
+		panic("Error dropping tables: " + err.Error())
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var stmt string
+		if err := rows.Scan(&stmt); err != nil {
+			panic("Error dropping tables: " + err.Error())
+		}
+
+		conn.Exec(stmt)
+	}
+}
+
+func initPostgres(connString string) func() {
+	const databaseType = "postgres"
+	conn, err := sqlx.Open(databaseType, "postgres://"+connString)
+
+	if err != nil {
+		panic(fmt.Sprintf("Could not connect to postgres database at %s: %s", connString, err.Error()))
+	}
+
+	pgDropAll(conn)
+
+	database.Initialize(databaseType, connString)
+
+	return teardownPostgres
+}
+
+func teardownPostgres() {
+	pgDropAll(database.DB)
+	database.DB.Close()
+}
+
+func runTests(m *testing.M, populater DatabasePopulater) int {
+	var deferFn func()
+
+	pgConnStr := os.Getenv("POSTGRES_DB")
+	if pgConnStr != "" {
+		deferFn = initPostgres(pgConnStr)
+	} else {
+		deferFn = initSQLite()
+	}
+
 	// defer close and delete the database
-	defer testTeardown(databaseFile)
+	if deferFn != nil {
+		defer deferFn()
+	}
 
 	if populater != nil {
-		err = populater.PopulateDB()
+		err := populater.PopulateDB()
 		if err != nil {
 			panic(fmt.Sprintf("Could not populate database: %s", err.Error()))
 		}

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -89,3 +89,7 @@ func (*postgresDialect) SetPlaceholders(sql string) string {
 
 	return sql
 }
+
+func (*postgresDialect) NullsLast() string {
+	return " NULLS LAST "
+}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -95,3 +95,8 @@ func (*sqlite3Dialect) FieldQuote(field string) string {
 func (*sqlite3Dialect) SetPlaceholders(sql string) string {
 	return sql
 }
+
+func (*sqlite3Dialect) NullsLast() string {
+	// TODO - determine a workaround for NULLS LAST support
+	return " "
+}

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -225,7 +225,7 @@ func getMultiCriterionClause(joinTable database.TableJoin, joinTableField string
 	} else if criterion.Modifier == CriterionModifierIncludesAll {
 		// includes all of the provided ids
 		whereClause = joinTableName + "." + joinTableField + " IN " + getInBinding(len(criterion.Value))
-		havingClause = "count(distinct " + joinTableName + "." + joinTableField + ") IS " + strconv.Itoa(len(criterion.Value))
+		havingClause = "count(distinct " + joinTableName + "." + joinTableField + ") = " + strconv.Itoa(len(criterion.Value))
 	} else if criterion.Modifier == CriterionModifierExcludes {
 		// excludes all of the provided ids
 		whereClause = "not exists (select " + joinTableName + ".scene_id from " + joinTableName + " where " + joinTableName + ".scene_id = scenes.id and " + joinTableName + "." + joinTableField + " in " + getInBinding(len(criterion.Value)) + ")"

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -162,7 +162,10 @@ func getSort(sort string, direction string, tableName string) string {
 		if tableName == "scene_markers" {
 			additional = ", scene_markers.scene_id ASC, scene_markers.seconds ASC"
 		}
-		return " ORDER BY " + colName + " " + direction + " NULLS LAST " + additional
+
+		// TODO - NULLS LAST is only supported in postgres, not in sqlite
+		// commenting out for now
+		return " ORDER BY " + colName + " " + direction + /*" NULLS LAST " +*/ additional
 	}
 }
 

--- a/pkg/models/querybuilder_sql.go
+++ b/pkg/models/querybuilder_sql.go
@@ -163,9 +163,9 @@ func getSort(sort string, direction string, tableName string) string {
 			additional = ", scene_markers.scene_id ASC, scene_markers.seconds ASC"
 		}
 
-		// TODO - NULLS LAST is only supported in postgres, not in sqlite
-		// commenting out for now
-		return " ORDER BY " + colName + " " + direction + /*" NULLS LAST " +*/ additional
+		// sqlite3 golang library does not yet support NULLS LAST, so leave it as empty in
+		// its dialect for now.
+		return " ORDER BY " + colName + " " + direction + database.GetDialect().NullsLast() + additional
 	}
 }
 


### PR DESCRIPTION
- Fix test compilation errors
- Remove the integration tests that perform partial modify operations, since these are no longer supported.
- Move `NULLS LAST` into dialect function. This isn't supported in the current golang sqlite library. There is probably a workaround available, but I'll leave it for now.