### PR TITLE
Fix incorrect table reference

### DIFF
--- a/pkg/api/user_integration_test.go
+++ b/pkg/api/user_integration_test.go
@@ -469,6 +469,25 @@ func (s *userTestRunner) testRegenerateAPIKey() {
 	}
 }
 
+func (s *userTestRunner) testUserEditQuery() {
+	createdUser, err := s.createTestUser(nil)
+	if err != nil {
+		return
+	}
+
+	userID := createdUser.ID.String()
+	filter := models.EditFilterType{
+		UserID: &userID,
+	}
+	_, err = s.resolver.Query().QueryEdits(s.ctx, &filter, nil)
+	if err != nil {
+		s.t.Errorf("Error finding user edits: %s", err.Error())
+		return
+	}
+
+	// TODO: Test edits are returned
+}
+
 func TestCreateUser(t *testing.T) {
 	pt := createUserTestRunner(t)
 	pt.testCreateUser()
@@ -538,4 +557,9 @@ func TestChangePassword(t *testing.T) {
 func TestRegenerateAPIKey(t *testing.T) {
 	pt := createUserTestRunner(t)
 	pt.testRegenerateAPIKey()
+}
+
+func TestUserEditQuery(t *testing.T) {
+	pt := createUserTestRunner(t)
+	pt.testUserEditQuery()
 }

--- a/pkg/models/querybuilder_edit.go
+++ b/pkg/models/querybuilder_edit.go
@@ -132,7 +132,7 @@ func (qb *EditQueryBuilder) Query(editFilter *EditFilterType, findFilter *QueryS
 	query := database.NewQueryBuilder(editDBTable)
 
 	if q := editFilter.UserID; q != nil && *q != "" {
-		query.Eq("scenes.user_id", *q)
+		query.Eq(editDBTable.Name() + ".user_id", *q)
 	}
 
 	if q := editFilter.TargetID; q != nil && *q != "" {

--- a/pkg/models/querybuilder_edit.go
+++ b/pkg/models/querybuilder_edit.go
@@ -132,7 +132,7 @@ func (qb *EditQueryBuilder) Query(editFilter *EditFilterType, findFilter *QueryS
 	query := database.NewQueryBuilder(editDBTable)
 
 	if q := editFilter.UserID; q != nil && *q != "" {
-		query.Eq(editDBTable.Name() + ".user_id", *q)
+		query.Eq(editDBTable.Name()+".user_id", *q)
 	}
 
 	if q := editFilter.TargetID; q != nil && *q != "" {


### PR DESCRIPTION
**This change was not tested.**

@InfiniteTF tagging you just in case it's not notifying you

Querying for user edits, like so:
```gql
query {
  queryEdits(edit_filter: { user_id: "<insert user id>" }) {
    count
    edits {
      status
    }
  }
}
```

Failed with error:
`Internal system error. Error <Error executing query: SELECT COUNT(*) as count FROM (SELECT edits.* FROM edits  WHERE scenes.user_id = $1) as temp, with args: [<user id>]: pq: missing FROM-clause entry for table "scenes">`