### PR TITLE
Hide performance aliases checkbox when viewing a performer creation edit

### DIFF
--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -87,7 +87,7 @@ const ModifyEdit: React.FC<ModifyEditProps> = ({
             showDiff={showDiff}
           />
         )}
-        {details.name !== oldDetails?.name && (
+        {oldDetails && details.name !== oldDetails.name && (
           <div className="d-flex mb-2">
             <Form.Check
               disabled


### PR DESCRIPTION
When viewing an performer creation edit, this checkbox should not be rendered.
![image](https://user-images.githubusercontent.com/66393006/114532829-e7338a80-9c55-11eb-87b7-1b6ce0485661.png)

**This change is untested.**
Using `oldDetails` instead of importing `operation`, as per:
https://github.com/stashapp/stash-box/blob/3f88ea246534789fd84fb0f9682f991c02dc402b/frontend/src/components/editCard/EditCard.tsx#L43-L52
