### PR TITLE
Add basic sorting functionality to the edits page

### DIFF
--- a/frontend/src/components/editCard/EditCard.tsx
+++ b/frontend/src/components/editCard/EditCard.tsx
@@ -20,7 +20,8 @@ interface EditsProps {
 
 const EditCardComponent: React.FC<EditsProps> = ({ edit }) => {
   const title = `${edit.operation.toLowerCase()} ${edit.target_type.toLowerCase()}`;
-  const date = new Date(edit.created);
+  const created = new Date(edit.created);
+  const updated = new Date(edit.updated);
   let editVariant: BadgeProps["variant"] = "warning";
   if (
     edit.status === VoteStatusEnum.REJECTED ||
@@ -74,7 +75,11 @@ const EditCardComponent: React.FC<EditsProps> = ({ edit }) => {
         <div className="flex-column col-4 ml-auto text-right">
           <div>
             <b className="mr-2">Created:</b>
-            <span>{formatDateTime(date)}</span>
+            <span>{formatDateTime(created)}</span>
+          </div>
+          <div>
+            <b className="mr-2">Updated:</b>
+            <span>{formatDateTime(updated)}</span>
           </div>
           <div>
             <b className="mr-2">Status:</b>

--- a/frontend/src/components/list/EditList.tsx
+++ b/frontend/src/components/list/EditList.tsx
@@ -13,8 +13,10 @@ import EditCard from "src/components/editCard";
 import List from "./List";
 
 interface EditsProps {
-  type?: TargetTypeEnum;
   id?: string;
+  sort?: string;
+  direction?: SortDirectionEnum;
+  type?: TargetTypeEnum;
   status?: VoteStatusEnum;
   operation?: OperationEnum;
 }
@@ -23,6 +25,8 @@ const PER_PAGE = 20;
 
 const EditListComponent: React.FC<EditsProps> = ({
   id,
+  sort,
+  direction,
   type,
   status,
   operation,
@@ -30,10 +34,14 @@ const EditListComponent: React.FC<EditsProps> = ({
   const { page, setPage } = usePagination();
   const {
     editFilter,
+    selectedSort,
+    selectedDirection,
     selectedType,
     selectedOperation,
     selectedStatus,
   } = useEditFilter({
+    sort,
+    direction,
     type,
     status,
     operation,
@@ -42,8 +50,8 @@ const EditListComponent: React.FC<EditsProps> = ({
     filter: {
       page,
       per_page: PER_PAGE,
-      sort: "created_at",
-      direction: SortDirectionEnum.DESC,
+      sort: selectedSort || "created_at",
+      direction: selectedDirection,
     },
     editFilter: {
       target_type: selectedType,

--- a/frontend/src/components/pagination/Pagination.tsx
+++ b/frontend/src/components/pagination/Pagination.tsx
@@ -47,7 +47,7 @@ const PaginationComponent: React.FC<PaginationProps> = ({
   };
 
   return (
-    <div className="ml-auto d-flex">
+    <div className="ml-auto mt-auto d-flex">
       {showCount && count > 0 && (
         <b className="mr-4 mt-2">
           {new Intl.NumberFormat().format(count)} results

--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -364,6 +364,7 @@ export interface ApplyEdit_applyEdit {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: ApplyEdit_applyEdit_comments[];
   user: ApplyEdit_applyEdit_user;
   /**

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -364,6 +364,7 @@ export interface Edit_findEdit {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: Edit_findEdit_comments[];
   user: Edit_findEdit_user;
   /**

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -364,6 +364,7 @@ export interface EditFragment {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: EditFragment_comments[];
   user: EditFragment_user;
   /**

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -364,6 +364,7 @@ export interface Edits_queryEdits_edits {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: Edits_queryEdits_edits_comments[];
   user: Edits_queryEdits_edits_user;
   /**

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -364,6 +364,7 @@ export interface PerformerEdit_performerEdit {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: PerformerEdit_performerEdit_comments[];
   user: PerformerEdit_performerEdit_user;
   /**

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -364,6 +364,7 @@ export interface TagEdit_tagEdit {
   status: VoteStatusEnum;
   applied: boolean;
   created: any;
+  updated: any;
   comments: TagEdit_tagEdit_comments[];
   user: TagEdit_tagEdit_user;
   /**

--- a/frontend/src/graphql/fragments/EditFragment.gql
+++ b/frontend/src/graphql/fragments/EditFragment.gql
@@ -8,6 +8,7 @@ fragment EditFragment on Edit {
   status
   applied
   created
+  updated
   comments {
     ...CommentFragment
   }

--- a/frontend/src/hooks/UseEditFilter.tsx
+++ b/frontend/src/hooks/UseEditFilter.tsx
@@ -95,38 +95,40 @@ const useEditFilter = ({
     <Form className="d-flex align-items-center font-weight-bold mx-0">
       <Form.Group className="mr-2 d-flex flex-column align-items-left">
         <Form.Label>Order</Form.Label>
-        <Form.Control
-          as="select"
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            handleChange("sort", e.currentTarget.value)
-          }
-          defaultValue={selectedSort ?? defaultSort}
-        >
-          {sortOptions.map((s) => (
-            <option value={s.value}>{s.label}</option>
-          ))}
-        </Form.Control>
-        <InputGroup.Append>
-          <Button
-            variant="secondary"
-            onClick={() =>
-              handleChange(
-                "dir",
-                selectedDirection === SortDirectionEnum.DESC
-                  ? SortDirectionEnum.ASC
-                  : undefined
-              )
+        <div className="d-flex">
+          <Form.Control
+            as="select"
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              handleChange("sort", e.currentTarget.value)
             }
+            defaultValue={selectedSort ?? defaultSort}
           >
-            <Icon
-              icon={
-                selectedDirection === SortDirectionEnum.ASC
-                  ? "sort-amount-up"
-                  : "sort-amount-down"
+            {sortOptions.map((s) => (
+              <option value={s.value}>{s.label}</option>
+            ))}
+          </Form.Control>
+          <InputGroup.Append>
+            <Button
+              variant="secondary"
+              onClick={() =>
+                handleChange(
+                  "dir",
+                  selectedDirection === SortDirectionEnum.DESC
+                    ? SortDirectionEnum.ASC
+                    : undefined
+                )
               }
-            />
-          </Button>
-        </InputGroup.Append>
+            >
+              <Icon
+                icon={
+                  selectedDirection === SortDirectionEnum.ASC
+                    ? "sort-amount-up"
+                    : "sort-amount-down"
+                }
+              />
+            </Button>
+          </InputGroup.Append>
+        </div>
       </Form.Group>
       <Form.Group className="mx-2 d-flex flex-column align-items-left">
         <Form.Label>Type</Form.Label>

--- a/frontend/src/hooks/UseEditFilter.tsx
+++ b/frontend/src/hooks/UseEditFilter.tsx
@@ -93,7 +93,8 @@ const useEditFilter = ({
 
   const editFilter = (
     <Form className="d-flex align-items-center font-weight-bold mx-0">
-      <Form.Group className="d-flex align-items-center">
+      <Form.Group className="mr-2 d-flex flex-column align-items-left">
+        <Form.Label>Order</Form.Label>
         <Form.Control
           as="select"
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -127,8 +128,8 @@ const useEditFilter = ({
           </Button>
         </InputGroup.Append>
       </Form.Group>
-      <Form.Group className="d-flex align-items-center">
-        <Form.Label className="mx-4 mb-0">Type</Form.Label>
+      <Form.Group className="mx-2 d-flex flex-column align-items-left">
+        <Form.Label>Type</Form.Label>
         <Form.Control
           as="select"
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -143,8 +144,8 @@ const useEditFilter = ({
           {enumToOptions(EditTargetTypes)}
         </Form.Control>
       </Form.Group>
-      <Form.Group className="d-flex align-items-center">
-        <Form.Label className="mx-4 mb-0">Status</Form.Label>
+      <Form.Group className="mx-2 d-flex flex-column align-items-left">
+        <Form.Label>Status</Form.Label>
         <Form.Control
           as="select"
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
@@ -159,8 +160,8 @@ const useEditFilter = ({
           {enumToOptions(EditStatusTypes)}
         </Form.Control>
       </Form.Group>
-      <Form.Group className="d-flex align-items-center">
-        <Form.Label className="mx-4 mb-0">Operation</Form.Label>
+      <Form.Group className="mx-2 d-flex flex-column align-items-left">
+        <Form.Label>Operation</Form.Label>
         <Form.Control
           as="select"
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>

--- a/frontend/src/hooks/UseEditFilter.tsx
+++ b/frontend/src/hooks/UseEditFilter.tsx
@@ -94,7 +94,6 @@ const useEditFilter = ({
   const editFilter = (
     <Form className="d-flex align-items-center font-weight-bold mx-0">
       <Form.Group className="d-flex align-items-center">
-        <Form.Label className="mr-4 mb-0">Order</Form.Label>
         <Form.Control
           as="select"
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>

--- a/graphql/schema/types/edit.graphql
+++ b/graphql/schema/types/edit.graphql
@@ -68,6 +68,7 @@ type Edit {
     status: VoteStatusEnum!
     applied: Boolean!
     created: Time!
+    updated: Time!
 }
 
 input EditInput {

--- a/pkg/api/resolver_model_edit.go
+++ b/pkg/api/resolver_model_edit.go
@@ -30,6 +30,10 @@ func (r *editResolver) Created(ctx context.Context, obj *models.Edit) (*time.Tim
 	return &obj.CreatedAt.Timestamp, nil
 }
 
+func (r *editResolver) Updated(ctx context.Context, obj *models.Edit) (*time.Time, error) {
+	return &obj.UpdatedAt.Timestamp, nil
+}
+
 func (r *editResolver) Target(ctx context.Context, obj *models.Edit) (models.EditTarget, error) {
 	var operation models.OperationEnum
 	var status models.VoteStatusEnum


### PR DESCRIPTION
This PR adds basic sorting functionality to the edits page.
The default order of `created_at DESC` was kept.
`updated_at` was added to the GraphQL Edit type and displayed on the `EditCard` component.