### PR TITLE
Expand edit note on performer form

### DIFF
--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -756,7 +756,7 @@ const PerformerForm: React.FC<PerformerProps> = ({
             <ChangeRow {...c} />
           ))}
           <Form.Row className="my-4">
-            <Col md={{ span: 6, offset: 6 }}>
+            <Col md={{ span: 8, offset: 4 }}>
               <EditNote register={register} error={errors.note} />
             </Col>
           </Form.Row>


### PR DESCRIPTION
Gives a little bit more "room" to write info.

![example](https://user-images.githubusercontent.com/66393006/116761858-65977700-aa21-11eb-824c-ee1b846cbc05.png)
