### PR TITLE
Fix CORS errors in development mode

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -129,6 +129,7 @@ func Start() {
 		corsConfig = cors.New(cors.Options{
 			AllowOriginFunc:  func(origin string) bool { return true },
 			AllowCredentials: true,
+			AllowedHeaders:   []string{"*"},
 		})
 	}
 


### PR DESCRIPTION
When running in stash-box development mode and running the UI using `yarn start`, the login did not work.
After investigating, I found that the preflight requests to the Apollo client requests were failing due to the `Content-Type` and `ApiKey` headers not being allowed.
Since this is development, allowing all should be fine.