### PR TITLE
Fix issue when using `parentStudio` filter

### DIFF
--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -47,7 +47,7 @@ func NewDeleteQueryBuilder(table Table) *QueryBuilder {
 }
 
 func (qb *QueryBuilder) AddJoin(joinTable Table, on string) {
-	qb.Body += "JOIN " + joinTable.Name() + " ON " + on
+	qb.Body += " JOIN " + joinTable.Name() + " ON " + on
 	qb.Distinct = true
 }
 

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -195,8 +195,8 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Que
 	}
 
 	if sceneFilter.ParentStudio != nil {
-		query.AddJoin(studioDBTable, "scenes."+studioJoinKey+" = "+studioTable+".id")
-		query.AddWhere("("+studioTable+".parent_studio_id = ? OR "+studioTable+".id = ?)")
+		query.Body += "LEFT JOIN studios ON scenes.studio_id = studios.id"
+		query.AddWhere("(studios.parent_studio_id = ? OR studios.id = ?)")
 		query.AddArg(*sceneFilter.ParentStudio, *sceneFilter.ParentStudio)
 	}
 

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -195,8 +195,8 @@ func (qb *SceneQueryBuilder) Query(sceneFilter *SceneFilterType, findFilter *Que
 	}
 
 	if sceneFilter.ParentStudio != nil {
-		query.Body += "LEFT JOIN studios ON scenes.studio_id = studios.id"
-		query.AddWhere("(studios.parent_studio_id = ? OR studios.id = ?)")
+		query.AddJoin(studioDBTable, "scenes."+studioJoinKey+" = "+studioTable+".id")
+		query.AddWhere("("+studioTable+".parent_studio_id = ? OR "+studioTable+".id = ?)")
 		query.AddArg(*sceneFilter.ParentStudio, *sceneFilter.ParentStudio)
 	}
 


### PR DESCRIPTION
I forgot I made this commit...
~I still need to test this, but you can merge it if it's good.~
Tested and it does not fix the issue.

---

for example, when used in conjunction with performers filter, it fails due to invalid SQL query
(is missing a space after the body concatenation that is replaced in this commit)

For example query:
```gql
{
  queryScenes(
    scene_filter: {
      parentStudio: "<studio id>"
      performers: {
        modifier: INCLUDES
        value: ["<performer id>"]
      }
    }
  ) {
    count
    scenes {
      title
      performers {
        as
        performer {
          name
        }
      }
    }
  }
}
```

Error:
`Error executing query: SELECT COUNT(*) as count FROM (SELECT scenes.* FROM scenes LEFT JOIN studios ON scenes.studio_id = studios.idJOIN scene_performers ON scene_performers.scene_id = scenes.id WHERE (studios.parent_studio_id = $1 OR studios.id = $2) AND scene_performers.performer_id IN ($3) GROUP BY scenes.id ) as temp, with args: [<studio id> <studio id> <performer id>]: pq: syntax error at or near "scene_performers"`