### PR TITLE
Refactor scene form and add duration and director

### DIFF
--- a/frontend/src/graphql/definitions/UpdateScene.ts
+++ b/frontend/src/graphql/definitions/UpdateScene.ts
@@ -52,6 +52,9 @@ export interface UpdateScene_sceneUpdate {
   __typename: "Scene";
   id: string;
   date: any | null;
+  details: string | null;
+  director: string | null;
+  duration: number | null;
   title: string | null;
   urls: UpdateScene_sceneUpdate_urls[];
   studio: UpdateScene_sceneUpdate_studio | null;

--- a/frontend/src/graphql/mutations/UpdateScene.gql
+++ b/frontend/src/graphql/mutations/UpdateScene.gql
@@ -2,9 +2,12 @@ mutation UpdateScene($updateData: SceneUpdateInput!) {
   sceneUpdate(input: $updateData) {
       id
       date
-      title,
+      details
+      director
+      duration
+      title
       urls {
-        url,
+        url
         type
       }
       studio {

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -29,6 +29,8 @@ import EditImages from "src/components/editImages";
 
 const nullCheck = (input: string | null) =>
   input === "" || input === "null" ? null : input;
+const zeroCheck = (input: number | null) =>
+  input === 0 || Number.isNaN(input) ? null : input;
 
 const schema = yup.object().shape({
   id: yup.string().defined(),
@@ -42,6 +44,8 @@ const schema = yup.object().shape({
       message: "Invalid date",
     })
     .nullable(),
+  duration: yup.number().positive().transform(zeroCheck).nullable(),
+  director: yup.string().trim().nullable(),
   studio: yup
     .string()
     .typeError("Studio is required")
@@ -161,6 +165,8 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
       id: data.id,
       title: data.title,
       date: data.date,
+      duration: data.duration,
+      director: data.director,
       details: data.details,
       studio_id: data.studio,
       performers: (data.performers ?? []).map((performance) => ({
@@ -378,7 +384,7 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
               </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group controlId="date" className="col-4">
+            <Form.Group controlId="date" className="col-2">
               <Form.Label>Date</Form.Label>
               <Form.Control
                 as="input"
@@ -391,6 +397,22 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
               />
               <Form.Control.Feedback type="invalid">
                 {errors?.date?.message}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group controlId="duration" className="col-2">
+              <Form.Label>Duration</Form.Label>
+              <Form.Control
+                as="input"
+                className={cx({ "is-invalid": errors.duration })}
+                type="number"
+                placeholder="Duration"
+                name="duration"
+                defaultValue={scene?.duration ?? ""}
+                ref={register}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors?.duration?.message}
               </Form.Control.Feedback>
             </Form.Group>
           </Form.Row>
@@ -448,6 +470,26 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
                 ref={register}
               />
             </Form.Group>
+          </Form.Row>
+
+          <Form.Row>
+            <Form.Group controlId="director" className="col-4">
+              <Form.Label>Director</Form.Label>
+              <Form.Control
+                as="input"
+                className={cx({ "is-invalid": errors.director })}
+                type="text"
+                placeholder="Director"
+                name="director"
+                defaultValue={scene?.director ?? ""}
+                ref={register}
+              />
+              <Form.Control.Feedback type="invalid">
+                {errors?.director?.message}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="col-8" />
           </Form.Row>
 
           <Form.Group>

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -106,6 +106,7 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
   } = useForm<SceneFormData>({
     resolver: yupResolver(schema),
     defaultValues: {},
+    mode: "onBlur",
   });
   const {
     fields: performerFields,
@@ -359,36 +360,43 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
       />
       <Row>
         <Col xs={10}>
-          <div className="form-group row">
-            <label htmlFor="title" className="col-8">
-              <div>Title</div>
-              <input
-                className={cx("form-control", { "is-invalid": errors.title })}
+          <Form.Row>
+            <Form.Group controlId="title" className="col-8">
+              <Form.Label>Title</Form.Label>
+              <Form.Control
+                as="input"
+                className={cx({ "is-invalid": errors.title })}
                 type="text"
                 placeholder="Title"
                 name="title"
                 defaultValue={scene?.title ?? ""}
                 ref={register({ required: true })}
               />
-              <div className="invalid-feedback">{errors?.title?.message}</div>
-            </label>
-            <label htmlFor="date" className="col-4">
-              <div>Date</div>
-              <input
-                className={cx("form-control", { "is-invalid": errors.date })}
+              <Form.Control.Feedback type="invalid">
+                {errors?.title?.message}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group controlId="date" className="col-4">
+              <Form.Label>Date</Form.Label>
+              <Form.Control
+                as="input"
+                className={cx({ "is-invalid": errors.date })}
                 type="text"
                 placeholder="YYYY-MM-DD"
                 name="date"
                 defaultValue={scene.date}
                 ref={register}
               />
-              <div className="invalid-feedback">{errors?.date?.message}</div>
-            </label>
-          </div>
+              <Form.Control.Feedback type="invalid">
+                {errors?.date?.message}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Form.Row>
 
-          <div className="form-group row">
-            <div className="col">
-              <div className="label">Performers</div>
+          <Form.Row>
+            <Form.Group className="col">
+              <Form.Label>Performers</Form.Label>
               {performerList}
               <div className="add-performer">
                 <span>Add performer:</span>
@@ -399,44 +407,47 @@ const SceneForm: React.FC<SceneProps> = ({ scene, callback }) => {
                   searchType={SearchType.Performer}
                 />
               </div>
-            </div>
-          </div>
+            </Form.Group>
+          </Form.Row>
 
-          <div className="form-group row">
-            <label htmlFor="studioId" className="studio-select col-6">
-              <div>Studio</div>
+          <Form.Row>
+            <Form.Group controlId="studioId" className="studio-select col-6">
+              <Form.Label>Studio</Form.Label>
               <StudioSelect initialStudio={scene.studio} control={control} />
-              <div className="invalid-feedback">{errors?.studio?.message}</div>
-            </label>
-            <label htmlFor="studioURL" className="col-6">
-              <div>Studio URL</div>
-              <input
+              <Form.Control.Feedback type="invalid">
+                {errors?.studio?.message}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group controlId="studioURL" className="col-6">
+              <Form.Label>Studio URL</Form.Label>
+              <Form.Control
+                as="input"
+                className={cx({ "is-invalid": errors.studioURL })}
                 type="url"
-                className={cx("form-control", {
-                  "is-invalid": errors.studioURL,
-                })}
                 name="studioURL"
                 defaultValue={getUrlByType(scene.urls, "STUDIO")}
                 ref={register}
               />
-              <div className="invalid-feedback">
+              <Form.Control.Feedback type="invalid">
                 {errors?.studioURL?.message}
-              </div>
-            </label>
-          </div>
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Form.Row>
 
-          <div className="form-group row">
-            <label htmlFor="details" className="col">
-              <div>Details</div>
-              <textarea
-                className="form-control description"
+          <Form.Row>
+            <Form.Group controlId="details" className="col">
+              <Form.Label>Details</Form.Label>
+              <Form.Control
+                as="textarea"
+                className="description"
                 placeholder="Details"
                 name="details"
                 defaultValue={scene?.details ?? ""}
                 ref={register}
               />
-            </label>
-          </div>
+            </Form.Group>
+          </Form.Row>
 
           <Form.Group>
             <Form.Label>Tags</Form.Label>

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -65,6 +65,7 @@ const schema = yup.object().shape({
             .oneOf(Object.keys(FingerprintAlgorithm))
             .required(),
           hash: yup.string().required(),
+          duration: yup.number().min(1).required(),
         })
         .required()
     )

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -45,7 +45,7 @@ const schema = yup.object().shape({
     })
     .nullable(),
   duration: yup.number().positive().transform(zeroCheck).nullable(),
-  director: yup.string().trim().nullable(),
+  director: yup.string().trim().transform(nullCheck).nullable(),
   studio: yup
     .string()
     .typeError("Studio is required")

--- a/pkg/models/querybuilder_scene.go
+++ b/pkg/models/querybuilder_scene.go
@@ -34,7 +34,7 @@ func (qb *SceneQueryBuilder) Create(newScene Scene) (*Scene, error) {
 }
 
 func (qb *SceneQueryBuilder) Update(updatedScene Scene) (*Scene, error) {
-	ret, err := qb.dbi.Update(updatedScene, false)
+	ret, err := qb.dbi.Update(updatedScene, true)
 	return qb.toModel(ret), err
 }
 


### PR DESCRIPTION
- Refactored the scene form a little bit to use the `react-bootstrap` elements,
and the "invalid input" errors should now show up on blur, like the performer form.

- Added scene duration and director as editable fields.
  Layout is of course open to change, but since only admins can use this page and because it will probably get overhauled once the edit functionality is implemented for scenes, this should be fine for now.

~**One issue** that perhaps you can help solve, can't clear a duration (can't set it to `NULL` in the database).
I couldn't figure out how to do that...~

![image](https://user-images.githubusercontent.com/66393006/119233506-2c3ebc80-bb32-11eb-8bac-53904bb03b69.png)