### PR TITLE
Add formatted duration to fingerprints

### DIFF
--- a/frontend/src/pages/scenes/Scene.tsx
+++ b/frontend/src/pages/scenes/Scene.tsx
@@ -67,7 +67,11 @@ const SceneComponent: React.FC = () => {
           {fingerprint.hash}
         </Link>
       </td>
-      <td>{fingerprint.duration}</td>
+      <td>
+        <span title={formatDuration(fingerprint.duration)}>
+          {fingerprint.duration}
+        </span>
+      </td>
       <td>{fingerprint.submissions}</td>
       <td>{formatDateTime(fingerprint.created)}</td>
       <td>{formatDateTime(fingerprint.updated)}</td>
@@ -125,7 +129,7 @@ const SceneComponent: React.FC = () => {
         <Card.Footer className="row mx-1">
           <div className="scene-performers mr-auto">{performers}</div>
           {scene.duration && (
-            <div>
+            <div title={`${scene.duration} seconds`}>
               Duration: <b>{formatDuration(scene.duration)}</b>
             </div>
           )}


### PR DESCRIPTION
Add formatted duration to fingerprints and duration in seconds to scene duration,
instead of having to calculate the values each time.
Especially useful when comparing submitted fingerprints to scene duration or vice-versa.