### PR TITLE
Update cross build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,4 @@ cross-compile:
 				-v $(PWD):/go/src/github.com/stashapp/stash-box \
 				-v /var/run/docker.sock:/var/run/docker.sock \
 				-w /go/src/github.com/stashapp/stash-box \
-				goreng/golang-cross:latest --snapshot --rm-dist
+				docker.pkg.github.com/gythialy/golang-cross/xcgo:latest --snapshot --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,4 @@ cross-compile:
 				-v $(PWD):/go/src/github.com/stashapp/stash-box \
 				-v /var/run/docker.sock:/var/run/docker.sock \
 				-w /go/src/github.com/stashapp/stash-box \
-				docker.pkg.github.com/gythialy/golang-cross/xcgo:latest --snapshot --rm-dist
+				ghcr.io/gythialy/golang-cross:latest --snapshot --rm-dist


### PR DESCRIPTION
`golang-cross` now uses the GitHub Package Registry.
https://github.com/gythialy/golang-cross/commit/f205a9b10332342266099850058c402cd22bf2b1