### PR TITLE
Fix manually edited `go.mod/go.sum`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/karrick/godirwalk v1.16.1 // indirect
-	github.com/kisielk/errcheck v1.6.0 // indirect
+	github.com/kisielk/errcheck v1.6.0
 	github.com/lib/pq v1.3.0
 	github.com/markbates/oncer v1.0.0 // indirect
 	github.com/minio/minio-go/v7 v7.0.7
@@ -34,7 +34,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0 // indirect
-	github.com/vektah/dataloaden v0.3.0 // indirect
+	github.com/vektah/dataloaden v0.3.0
 	github.com/vektah/gqlparser/v2 v2.1.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8
@@ -42,5 +42,5 @@ require (
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	honnef.co/go/tools v0.2.0 // indirect
+	honnef.co/go/tools v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,6 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.1.4 h1:SadWOkti5uVN1FAMgxn165+Mw00fuQKyk4Gyn/inxNQ=
-honnef.co/go/tools v0.1.4/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
 honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,10 @@
+// +build tools
+
+package main
+
+import (
+	_ "github.com/99designs/gqlgen/cmd"
+	_ "github.com/kisielk/errcheck"
+	_ "github.com/vektah/dataloaden"
+	_ "honnef.co/go/tools/cmd/staticcheck"
+)


### PR DESCRIPTION
Should be able to run `go mod tidy` safely now.
(I did on this branch and the result is what's been committed)
Resolves the issue we encountered here: https://github.com/stashapp/stash-box/pull/84#pullrequestreview-666622936