### PR TITLE
Allow creating a new alias with a different casing

### DIFF
--- a/frontend/src/components/multiSelect/MultiSelect.tsx
+++ b/frontend/src/components/multiSelect/MultiSelect.tsx
@@ -32,6 +32,16 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
     onChange(values.map((v) => v.value));
   };
 
+  /** Allow creating a new option with a different casing. */
+  const isValidNewOption = (
+    inputValue: string,
+    selectValue: ValueType<IOptionType, true>
+  ): boolean =>
+    !!inputValue &&
+    !selectValue.some(
+      ({ value }) => value.toLowerCase() === inputValue.toLowerCase()
+    );
+
   return (
     <div>
       <CreatableSelect
@@ -40,6 +50,7 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
         className="react-select"
         defaultValue={options}
         options={options}
+        isValidNewOption={isValidNewOption}
         onChange={handleChange}
         placeholder={placeholder}
         noOptionsMessage={() => null}


### PR DESCRIPTION
Useful for when merging performers (this affects tags as well) that are all lowercase for instance,
and you want to correct that in the aliases.

![hwjniUvWnU](https://user-images.githubusercontent.com/66393006/123140155-a3cc7800-d45f-11eb-85d7-fe6f0a0a0cb0.gif)
