### PR TITLE
Fix changing description on an existing body mod location

### DIFF
--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -203,7 +203,7 @@ func BodyModCompare(subject []*models.BodyModification, against []*models.BodyMo
 		newMod := true
 		for _, a := range against {
 			if s.Location == a.Location {
-				newMod = false
+				newMod = s.Description != a.Description
 			}
 		}
 
@@ -222,7 +222,7 @@ func BodyModCompare(subject []*models.BodyModification, against []*models.BodyMo
 		removedMod := true
 		for _, a := range subject {
 			if s.Location == a.Location {
-				removedMod = false
+				removedMod = s.Description != a.Description
 			}
 		}
 

--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -203,7 +203,9 @@ func BodyModCompare(subject []*models.BodyModification, against []*models.BodyMo
 		newMod := true
 		for _, a := range against {
 			if s.Location == a.Location {
-				newMod = s.Description != a.Description
+				newMod = (s.Description != nil && a.Description != nil && *s.Description != *a.Description) ||
+					(s.Description == nil && a.Description != nil) ||
+					(a.Description == nil && s.Description != nil)
 			}
 		}
 
@@ -222,7 +224,9 @@ func BodyModCompare(subject []*models.BodyModification, against []*models.BodyMo
 		removedMod := true
 		for _, a := range subject {
 			if s.Location == a.Location {
-				removedMod = s.Description != a.Description
+				removedMod = (s.Description != nil && a.Description != nil && *s.Description != *a.Description) ||
+					(s.Description == nil && a.Description != nil) ||
+					(a.Description == nil && s.Description != nil)
 			}
 		}
 


### PR DESCRIPTION
This fixes the issue I reported on Discord.
>it seems that adding a description to an existing piercing location gets ignored on performer merge (edit, too, probably)
for example, a performer had `Lip` with no description, I added two more piercings and a description to `Lip`, it __showed up on the edit preview__, but it didn't end up in the submitted edit details.

This is the most basic way of fixing it.
I believe this would actually remove and add, instead of updating the current,
but I don't know if it actually needs the extra logic to update the current location (requires changes to `PerformerRepo#ApplyModifyEdit`).