### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       postgres:
         image: postgres:13.2
         env:
-          POSTGRES_DB: postgres        
+          POSTGRES_DB: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
         ports:
@@ -81,7 +81,9 @@ jobs:
       run: make generate
 
     - name: Run tests
-      run: POSTGRES_DB=postgres:postgres@localhost/postgres?sslmode=disable make lint it
+      env:
+        POSTGRES_DB: postgres:postgres@localhost/postgres?sslmode=disable
+      run: make lint it
 
     - name: Build UI
       # skip UI build for pull requests if UI is unchanged (UI was cached)
@@ -126,12 +128,12 @@ jobs:
       with:
         name: stash-box-linux
         path: dist/stash-box_static_linux_amd64/stash-box-linux
-        
+
     - name: Update latest_develop tag
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       run : git tag -f latest_develop; git push -f --tags
     - name: Development Release
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}      
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       uses: meeDamian/github-release@2.0
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"
@@ -158,7 +160,7 @@ jobs:
           dist/stash-box_darwin_amd64/stash-box-darwin
           CHECKSUMS_SHA1
         gzip: false
-    
+
     - name: Login to DockerHub
       if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Install Go
       uses: actions/setup-go@v2
@@ -40,9 +43,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '14'
-
-    - name: Checkout
-      run: git fetch --prune --unshallow --tags
 
     - name: Cache node modules
       uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@
 node_modules
 
 *.db
+.go-cache/
 
 stashdb
 stash-box

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 project_name: stash-box
 
+before:
+  hooks:
+    - go mod tidy
+
 builds:
   - id: stash-box
     binary: stash-box-{{.Os}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,32 +1,33 @@
 project_name: stash-box
+
 builds:
-- id: stash-box
-  binary: stash-box-{{.Os}}
-  goos:
-    - windows
-    - darwin
-  goarch:
-    - amd64
-  env:
-  - CGO_ENABLED=0
-  ldflags:
-    - -s -w
-    - -X github.com/stashapp/stash-box/pkg/api.version={{.Version}}
-    - -X github.com/stashapp/stash-box/pkg/api.buildstamp={{.Date}}
-    - -X github.com/stashapp/stash-box/pkg/api.githash={{.ShortCommit}}
-- id: stash-box_static
-  binary: stash-box-{{.Os}}
-  goos:
-    - linux
-  goarch:
-    - amd64
-  env:
-  - CGO_ENABLED=0
-  ldflags:
-    - -extldflags=-static -s -w
-    - -X github.com/stashapp/stash-box/pkg/api.version={{.Version}}
-    - -X github.com/stashapp/stash-box/pkg/api.buildstamp={{.Date}}
-    - -X github.com/stashapp/stash-box/pkg/api.githash={{.ShortCommit}}
+  - id: stash-box
+    binary: stash-box-{{.Os}}
+    goos:
+      - windows
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/stashapp/stash-box/pkg/api.version={{.Version}}
+      - -X github.com/stashapp/stash-box/pkg/api.buildstamp={{.Date}}
+      - -X github.com/stashapp/stash-box/pkg/api.githash={{.ShortCommit}}
+  - id: stash-box_static
+    binary: stash-box-{{.Os}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -extldflags=-static -s -w
+      - -X github.com/stashapp/stash-box/pkg/api.version={{.Version}}
+      - -X github.com/stashapp/stash-box/pkg/api.buildstamp={{.Date}}
+      - -X github.com/stashapp/stash-box/pkg/api.githash={{.ShortCommit}}
 
 archives:
-- format: binary
+  - format: binary

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ generate-dataloaders:
 		go run github.com/vektah/dataloaden TagCategoryLoader github.com/gofrs/uuid.UUID "*github.com/stashapp/stash-box/pkg/models.TagCategory";
 
 .PHONY: test
-test: 
+test:
 	go test ./...
 
 # Runs the integration tests. -count=1 is used to ensure results are not
@@ -61,7 +61,7 @@ test:
 .PHONY: it
 it:
 	go test -tags=integration -count=1 ./...
-	
+
 # Runs gofmt -w on the project's source code, modifying any files that do not match its style.
 .PHONY: fmt
 fmt:
@@ -97,7 +97,7 @@ ui-only:
 ui: ui-only
 	packr2
 
-# just repacks the packr files - use when updating migrations and packed files without 
+# just repacks the packr files - use when updating migrations and packed files without
 # rebuilding the UI
 .PHONY: packr
 packr:
@@ -110,7 +110,10 @@ ui-validate:
 
 .PHONY: cross-compile
 cross-compile:
-	docker run --rm --privileged \
+ifdef CI
+	$(eval CI_ARGS := -v $(PWD)/.go-cache:/root/.cache/go-build)
+endif
+	docker run --rm --privileged $(CI_ARGS) \
 				-v $(PWD):/go/src/github.com/stashapp/stash-box \
 				-v /var/run/docker.sock:/var/run/docker.sock \
 				-w /go/src/github.com/stashapp/stash-box \


### PR DESCRIPTION
This fixes no go build cache being stored - [the cache size was always tiny](https://github.com/stashapp/stash-box/runs/2916866117#step:10:9),
it was missing a volume mount to the cross-build container's go cache.
~~The build is *still* failing for some reason, I'm unable to reproduce it locally. 😕~~
Apparently what caused the error was both builds (Windows and OSX) trying to download the same dependencies in parallel.
Adding a `go mod tidy` pre-hook fixed it.
https://goreleaser.com/customization/build/#go-modules

`fetch-depth: 0` on the checkout action is also recommended by goreleaser docs:
https://goreleaser.com/ci/actions/#workflow