### PR TITLE
Fix cached performer studio select

### DIFF
--- a/frontend/src/pages/performers/Performer.tsx
+++ b/frontend/src/pages/performers/Performer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { Tab, Tabs } from "react-bootstrap";
 import { groupBy, keyBy, sortBy } from "lodash";
@@ -25,6 +25,11 @@ const PerformerComponent: React.FC = () => {
   const activeTab = history.location.hash?.slice(1) || DEFAULT_TAB;
   const { loading, data } = useFullPerformer({ id });
   const [studioFilter, setStudioFilter] = useState<string[] | null>(null);
+
+  // Clear studio filter on performer change
+  useEffect(() => {
+    setStudioFilter(null);
+  }, [id]);
 
   const { data: editData } = useEdits({
     filter: {
@@ -107,6 +112,7 @@ const PerformerComponent: React.FC = () => {
             onChange={handleStudioSelect}
             placeholder="Filter by studios"
             plural="studios"
+            key={`performer-${id}-studio-select`}
           />
           <SceneList
             perPage={40}


### PR DESCRIPTION
This PR fixes an issue where the selected performer studios are cached (by React) between different performers.

To reproduce:
- Go to performer 1.
- Go to performer 2 **directly** by searching using the global search and clicking on a performer result.
- Select a one or more studios on the studio filter.
- Hit the browser back button.
- Performer 1's scenes are filtered using performer 2's selected studios.

This also happens in the 'forward' direction, when selecting studios on performer 1 then navigating to performer 2.