### PR TITLE
Fix `yarn generate` "spurious results" error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,9 @@
     "node": ">=8.10.0",
     "yarn": ">=1.15.2"
   },
+  "resolutions": {
+    "**/graphql": "^15.5.1"
+  },
   "devDependencies": {
     "@types/lodash": "^4.14.172",
     "@types/node": "^16.6.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6995,12 +6995,7 @@ graphql.macro@^1.4.2:
     babel-plugin-macros "^2.5.0"
     graphql-tag "^2.10.1"
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@^15.3.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
-  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
-
-graphql@^15.5.1:
+"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@^15.3.0, graphql@^15.5.1:
   version "15.5.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
   integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==


### PR DESCRIPTION
```
$ yarn generate
yarn run v1.22.5
$ apollo client:codegen --target typescript --outputFlat src/graphql/definitions
  ✔ Loading Apollo Project
  ✖ Generating query files with 'typescript' target
    → spurious results.
    Error: Cannot use GraphQLInputObjectType "ActivateNewUserInput" from another module or realm.

    Ensure that there is only one instance of "graphql" in the node_modules
    directory. If different versions of "graphql" are the dependencies of other
    relied on modules, use "resolutions" to ensure only one version is installed.

    https://yarnpkg.com/en/docs/selective-version-resolutions

    Duplicate "graphql" modules cannot be used at the same time since different
    versions may have different capabilities and behavior. The data from one
    version used in the function from another could produce confusing and
    spurious results.
```