### PR TITLE
Fix adding comments to existing edits

### DIFF
--- a/frontend/src/components/editCard/AddComment.tsx
+++ b/frontend/src/components/editCard/AddComment.tsx
@@ -68,7 +68,7 @@ const AddComment: React.FC<IProps> = ({ editID }) => {
         <Button
           variant="primary"
           className="ml-2"
-          disabled={saving}
+          disabled={saving || !comment.trim()}
           onClick={handleSaveComment}
         >
           Save

--- a/frontend/src/components/form/EditNote.tsx
+++ b/frontend/src/components/form/EditNote.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Form } from "react-bootstrap";
 import cx from "classnames";
-import { FieldError } from "react-hook-form";
+import { FieldError, UseFormRegister } from "react-hook-form";
 
 import NoteInput from "./NoteInput";
 
 interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  register: any;
+  register: UseFormRegister<any>;
   error?: FieldError;
 }
 

--- a/frontend/src/components/form/NoteInput.tsx
+++ b/frontend/src/components/form/NoteInput.tsx
@@ -4,12 +4,13 @@ import cx from "classnames";
 
 import AuthContext from "src/AuthContext";
 import EditComment from "src/components/editCard/EditComment";
+import { UseFormRegister } from "react-hook-form";
 
 interface IProps {
   onChange?: (text: string) => void;
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  register?: any;
+  register?: UseFormRegister<any>;
   hasError?: boolean;
 }
 
@@ -27,6 +28,8 @@ const NoteInput: React.FC<IProps> = ({
     onChange?.(e.currentTarget.value);
   };
 
+  const textareaProps = register ? register("note") : { name: "note" };
+
   return (
     <div className={cx("NoteInput", { "is-invalid": hasError })}>
       <Tabs id="add-comment">
@@ -36,7 +39,7 @@ const NoteInput: React.FC<IProps> = ({
             className={className}
             onInput={handleChange}
             rows={5}
-            {...register("note")}
+            {...textareaProps}
           />
         </Tab>
         <Tab eventKey="preview" title="Preview" unmountOnExit mountOnEnter>


### PR DESCRIPTION
Adding comments to existing edits was broken, because no form `register` function was provided (there is no form).
Also, disable the Save button if the comment is empty.