### PR TITLE
Fix goreleaser semver issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,9 @@ jobs:
 
     - name: Generate checksums
       run: |
-        git describe --tags --exclude latest_develop | tee CHECKSUMS_SHA1
+        git describe --tags --exclude 0.0.0-latest-develop | tee CHECKSUMS_SHA1
         sha1sum dist/*/stash-box-* | sed 's/dist\/.*\///g' | tee -a CHECKSUMS_SHA1
-        echo "STASH_BOX_VERSION=$(git describe --tags --exclude latest_develop)" >> $GITHUB_ENV
+        echo "STASH_BOX_VERSION=$(git describe --tags --exclude 0.0.0-latest-develop)" >> $GITHUB_ENV
         echo "RELEASE_DATE=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_ENV
 
     - name: Upload Windows binary
@@ -124,9 +124,9 @@ jobs:
         name: stash-box-linux
         path: dist/stash-box_static_linux_amd64/stash-box-linux
 
-    - name: Update latest_develop tag
+    - name: Update latest-develop tag
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      run : git tag -f latest_develop; git push -f --tags
+      run : git tag -f 0.0.0-latest-develop; git push -f --tags
     - name: Development Release
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       uses: meeDamian/github-release@2.0
@@ -134,7 +134,7 @@ jobs:
         token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: true
         allow_override: true
-        tag: latest_develop
+        tag: 0.0.0-latest-develop
         name: "${{ env.STASH_BOX_VERSION }}: Latest development build"
         body: "**${{ env.RELEASE_DATE }}**\n This is always the latest committed version on the develop branch. Use as your own risk!"
         files: |
@@ -144,7 +144,7 @@ jobs:
           CHECKSUMS_SHA1
         gzip: false
     - name: Master release
-      if: ${{ github.event_name == 'release' && github.ref != 'refs/tags/latest_develop' }}
+      if: ${{ github.event_name == 'release' && github.ref != 'refs/tags/0.0.0-latest-develop' }}
       uses: meeDamian/github-release@2.0
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"
@@ -170,7 +170,7 @@ jobs:
         docker push stashapp/stash-box:development
 
     - name: Release Docker
-      if: ${{ github.event_name == 'release' && github.ref != 'refs/tags/latest_develop' }}
+      if: ${{ github.event_name == 'release' && github.ref != 'refs/tags/0.0.0-latest-develop' }}
       run: |
         docker build -t stashapp/stash-box:latest -f ./docker/ci/x86_64/Dockerfile ./dist
         docker push stashapp/stash-box:latest


### PR DESCRIPTION
Renames `latest_develop` tag to `0.0.0-latest-develop` to make goreleaser happy.