### PR TITLE
Studio Scenes tab (excluding sub-studios)

### DIFF
--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -8,6 +8,7 @@ import {
   useEdits,
   useStudio,
   VoteStatusEnum,
+  CriterionModifier,
 } from "src/graphql";
 import { ErrorMessage, LoadingIndicator } from "src/components/fragments";
 import { EditList, SceneList } from "src/components/list";
@@ -122,9 +123,21 @@ const StudioComponent: React.FC = () => {
         </>
       )}
       <Tabs activeKey={activeTab} id="tag-tabs" mountOnEnter onSelect={setTab}>
-        <Tab eventKey="scenes" title="Scenes">
+        <Tab
+          eventKey="scenes"
+          title={subStudios.length > 0 ? "All Scenes" : "Scenes"}
+        >
           <SceneList filter={{ parentStudio: id }} />
         </Tab>
+        {subStudios.length > 0 && (
+          <Tab eventKey="studio-scenes" title="Studio Scenes">
+            <SceneList
+              filter={{
+                studios: { value: [id], modifier: CriterionModifier.INCLUDES },
+              }}
+            />
+          </Tab>
+        )}
         <Tab
           eventKey="edits"
           title={`Edits${formatPendingEdits(pendingEditCount)}`}

--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -123,7 +123,6 @@ const StudioComponent: React.FC = () => {
       )}
       <Tabs activeKey={activeTab} id="tag-tabs" mountOnEnter onSelect={setTab}>
         <Tab eventKey="scenes" title="Scenes">
-          {subStudios.length > 0 && <h4>Scenes</h4>}
           <SceneList filter={{ parentStudio: id }} />
         </Tab>
         <Tab

--- a/frontend/src/pages/studios/styles.scss
+++ b/frontend/src/pages/studios/styles.scss
@@ -11,10 +11,12 @@
 }
 
 .sub-studio-list {
+  margin-bottom: 1rem;
   max-height: 15rem;
   overflow-y: auto;
 
   ul {
     column-count: 3;
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
- Fix studio page style:
	- Fix margin between sub-studios and scenes)
	- Remove duplicate "Scenes" heading
- Add a "Studio Scenes" tab to studios with sub-studios, that only fetches the parent studio's scenes, excluding the sub-studios.

	- Studio without sub-studios
	  ![](https://user-images.githubusercontent.com/66393006/137314275-54b2a5ab-0707-40d1-bcf4-c2d704b4a2a5.png)
	- Studio with sub-studios (all scenes)
	  ![](https://user-images.githubusercontent.com/66393006/137314377-88631a1b-baee-4720-83d3-42bf7744fe6e.png)
	- Studio with sub-studios (studio scenes - new tab)
	  ![](https://user-images.githubusercontent.com/66393006/137314428-5715befa-6449-405e-a09f-377df3816741.png)