### PR TITLE
Fix homepage scene cards columns

### DIFF
--- a/frontend/src/pages/home/styles.scss
+++ b/frontend/src/pages/home/styles.scss
@@ -1,7 +1,7 @@
 .HomePage {
   &-scenes {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     grid-template-rows: auto auto;
     grid-auto-rows: 0;
     overflow: hidden;


### PR DESCRIPTION
When less than* some threshold (4 per row, maybe?), the columns are stretched to the max.
This tweak seems to satisfy both the low count and the high count of scenes correctly.

### Before:
![before](https://user-images.githubusercontent.com/66393006/142260235-b689a6c5-0e2a-445b-b0a1-0a0874d28a7f.png)

### After (below threshold):
![after](https://user-images.githubusercontent.com/66393006/142260247-d905c002-21f6-4913-b85e-fbb808e7dc9c.png)

### After (max width on 1080p resolution):
![after-max](https://user-images.githubusercontent.com/66393006/142260252-802614f6-fd3d-4e8e-983c-3058fda696d6.png)

