### PR TITLE
UI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         cache-name: cache-ui
       with:
         path: frontend/build
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('frontend/yarn.lock', 'frontend/src/**', 'graphql/**/*.graphql') }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('frontend/yarn.lock', 'frontend/vite.config.js', 'frontend/src/**', 'graphql/**/*.graphql') }}
 
     - name: Cache go build
       uses: actions/cache@v2

--- a/frontend/src/components/checkboxSelect/CheckboxSelect.tsx
+++ b/frontend/src/components/checkboxSelect/CheckboxSelect.tsx
@@ -37,12 +37,18 @@ const CheckboxSelect: FC<MultiSelectProps> = ({
     if (meta.context === "menu")
       return option.subValues === null ? (
         <div className="d-flex ms-3">
-          <Form.Check checked={unselected.includes(option.value)} />
+          <Form.Check
+            className="me-2"
+            checked={unselected.includes(option.value)}
+          />
           {option.label}
         </div>
       ) : (
         <div className="d-flex">
-          <Form.Check checked={unselected.includes(option.value)} />
+          <Form.Check
+            className="me-2"
+            checked={unselected.includes(option.value)}
+          />
           <span className="text-muted">{option.label}</span>
         </div>
       );

--- a/frontend/src/components/fragments/Tooltip.tsx
+++ b/frontend/src/components/fragments/Tooltip.tsx
@@ -22,7 +22,7 @@ const Tooltip: FC<Props> = ({
     delay={{ show: delay, hide: 0 }}
     overlay={<BSTooltip id="tooltip">{text}</BSTooltip>}
     placement={placement}
-    trigger="hover"
+    trigger={["hover", "focus"]}
   >
     {children}
   </OverlayTrigger>

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Row } from "react-bootstrap";
+import { Col, Row } from "react-bootstrap";
 
 import { ImageFragment as Image } from "src/graphql/definitions/ImageFragment";
 
@@ -16,11 +16,16 @@ const Images: FC<{
   images: (Pick<Image, "id" | "url"> | null)[] | null | undefined;
 }> = ({ images }) => (
   <>
-    {(images ?? []).map((image) =>
+    {(images ?? []).map((image, i) =>
       image === null ? (
-        <img className={CLASSNAME_IMAGE} alt="Deleted" />
+        <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
       ) : (
-        <img src={image.url} className={CLASSNAME_IMAGE} alt="" />
+        <img
+          src={image.url}
+          className={CLASSNAME_IMAGE}
+          alt=""
+          key={image.id}
+        />
       )
     )}
   </>
@@ -35,7 +40,7 @@ const ImageChangeRow: FC<ImageChangeRowProps> = ({
     <Row className={CLASSNAME}>
       <b className="col-2 text-end">Images</b>
       {showDiff && (
-        <div className="col-5">
+        <Col xs={5}>
           {(oldImages ?? []).length > 0 && (
             <>
               <h6>Removed</h6>
@@ -44,9 +49,9 @@ const ImageChangeRow: FC<ImageChangeRowProps> = ({
               </div>
             </>
           )}
-        </div>
+        </Col>
       )}
-      <span className="col-5">
+      <Col xs={5}>
         {(newImages ?? []).length > 0 && (
           <>
             {showDiff && <h6>Added</h6>}
@@ -55,7 +60,7 @@ const ImageChangeRow: FC<ImageChangeRowProps> = ({
             </div>
           </>
         )}
-      </span>
+      </Col>
     </Row>
   ) : (
     <></>

--- a/frontend/src/components/list/TagList.tsx
+++ b/frontend/src/components/list/TagList.tsx
@@ -63,6 +63,7 @@ const TagList: FC<TagListProps> = ({ tagFilter, showCategoryLink = false }) => {
       id="tag-query"
       onChange={(e) => debouncedHandler(e.currentTarget.value)}
       placeholder="Filter tag name"
+      defaultValue={query ?? ""}
       className="w-25"
     />
   );

--- a/frontend/src/components/sceneCard/SceneCard.tsx
+++ b/frontend/src/components/sceneCard/SceneCard.tsx
@@ -9,39 +9,38 @@ import { Icon } from "src/components/fragments";
 
 const CLASSNAME = "SceneCard";
 const CLASSNAME_IMAGE = `${CLASSNAME}-image`;
-const CLASSNAME_TITLE = `${CLASSNAME}-title`;
 const CLASSNAME_BODY = `${CLASSNAME}-body`;
 
 const SceneCard: FC<{ performance: Performance }> = ({ performance }) => (
-  <Link className={CLASSNAME} to={sceneHref(performance)}>
-    <Card>
-      <Card.Body className={CLASSNAME_BODY}>
-        <div className={CLASSNAME_IMAGE}>
-          <img alt="" src={getImage(performance.images, "landscape")} />
-        </div>
-      </Card.Body>
-      <Card.Footer>
-        <div className="d-flex">
-          <h6 className={CLASSNAME_TITLE}>{performance.title}</h6>
-          <span className="text-muted">
-            {performance.duration ? formatDuration(performance.duration) : ""}
-          </span>
-        </div>
-        <div className="text-muted">
-          {performance.studio && (
-            <Link
-              to={studioHref(performance.studio)}
-              className="float-end text-truncate SceneCard-studio-name"
-            >
-              <Icon icon={faVideo} className="me-1" />
-              {performance.studio.name}
-            </Link>
-          )}
-          <strong>{performance.date}</strong>
-        </div>
-      </Card.Footer>
-    </Card>
-  </Link>
+  <Card className={CLASSNAME}>
+    <Card.Body className={CLASSNAME_BODY}>
+      <Link className={CLASSNAME_IMAGE} to={sceneHref(performance)}>
+        <img alt="" src={getImage(performance.images, "landscape")} />
+      </Link>
+    </Card.Body>
+    <Card.Footer>
+      <div className="d-flex">
+        <Link className="text-truncate w-100" to={sceneHref(performance)}>
+          <h6 className="text-truncate">{performance.title}</h6>
+        </Link>
+        <span className="text-muted">
+          {performance.duration ? formatDuration(performance.duration) : ""}
+        </span>
+      </div>
+      <div className="text-muted">
+        {performance.studio && (
+          <Link
+            to={studioHref(performance.studio)}
+            className="float-end text-truncate SceneCard-studio-name"
+          >
+            <Icon icon={faVideo} className="me-1" />
+            {performance.studio.name}
+          </Link>
+        )}
+        <strong>{performance.date}</strong>
+      </div>
+    </Card.Footer>
+  </Card>
 );
 
 export default SceneCard;

--- a/frontend/src/components/sceneCard/styles.scss
+++ b/frontend/src/components/sceneCard/styles.scss
@@ -1,20 +1,5 @@
 .SceneCard {
-  &-title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    width: 100%;
-  }
-
-  &:hover {
-    text-decoration: none;
-
-    .SceneCard-title {
-      text-decoration: underline;
-    }
-  }
-
-  .card {
+  &.card {
     box-shadow: none;
     border-radius: 0;
     background-color: transparent;

--- a/frontend/src/pages/categories/Category.tsx
+++ b/frontend/src/pages/categories/Category.tsx
@@ -41,18 +41,25 @@ const CategoryComponent: FC<Props> = ({ category }) => {
         <h3 className="me-auto">
           <em>{category.name}</em>
         </h3>
-        {canEdit(auth.user) && (
-          <Link to={createHref(ROUTE_CATEGORY_EDIT, category)} className="me-2">
-            <Button>Edit</Button>
-          </Link>
-        )}
-        {isAdmin(auth.user) && (
-          <DeleteButton
-            onClick={handleDelete}
-            disabled={deleting}
-            message="Do you want to delete category? This is only possible if no tags are attached."
-          />
-        )}
+        <div className="ms-auto">
+          <>
+            {canEdit(auth.user) && (
+              <Link
+                to={createHref(ROUTE_CATEGORY_EDIT, category)}
+                className="me-2"
+              >
+                <Button>Edit</Button>
+              </Link>
+            )}
+            {isAdmin(auth.user) && (
+              <DeleteButton
+                onClick={handleDelete}
+                disabled={deleting}
+                message="Do you want to delete category? This is only possible if no tags are attached."
+              />
+            )}
+          </>
+        </div>
       </div>
       {category.description && (
         <Row className="g-0">

--- a/frontend/src/pages/categories/Category.tsx
+++ b/frontend/src/pages/categories/Category.tsx
@@ -5,7 +5,7 @@ import { Button, Row } from "react-bootstrap";
 import { Category_findTagCategory as Category } from "src/graphql/definitions/Category";
 import { useDeleteCategory } from "src/graphql";
 import AuthContext from "src/AuthContext";
-import { canEdit, isAdmin, createHref } from "src/utils";
+import { isAdmin, createHref } from "src/utils";
 import DeleteButton from "src/components/deleteButton";
 import { TagList } from "src/components/list";
 import { ROUTE_CATEGORIES, ROUTE_CATEGORY_EDIT } from "src/constants/route";
@@ -42,23 +42,21 @@ const CategoryComponent: FC<Props> = ({ category }) => {
           <em>{category.name}</em>
         </h3>
         <div className="ms-auto">
-          <>
-            {canEdit(auth.user) && (
+          {isAdmin(auth.user) && (
+            <>
               <Link
                 to={createHref(ROUTE_CATEGORY_EDIT, category)}
                 className="me-2"
               >
                 <Button>Edit</Button>
               </Link>
-            )}
-            {isAdmin(auth.user) && (
               <DeleteButton
                 onClick={handleDelete}
                 disabled={deleting}
                 message="Do you want to delete category? This is only possible if no tags are attached."
               />
-            )}
-          </>
+            </>
+          )}
         </div>
       </div>
       {category.description && (

--- a/frontend/src/pages/performers/PerformerDelete.tsx
+++ b/frontend/src/pages/performers/PerformerDelete.tsx
@@ -50,42 +50,37 @@ const PerformerDelete: FC<Props> = ({ performer }) => {
     });
 
   return (
-    <>
-      <Form
-        className="PerformerDeleteForm"
-        onSubmit={handleSubmit(handleDelete)}
-      >
-        <Row>
-          <h4>
-            Delete performer <em>{performer.name}</em>
-          </h4>
-        </Row>
-        <Form.Control type="hidden" value={performer.id} {...register("id")} />
-        <Row className="my-4">
-          <Col md={6}>
-            <EditNote register={register} error={errors.note} />
-          </Col>
-        </Row>
-        <Row className="mt-2">
-          <Button
-            variant="danger"
-            className="ms-auto me-2"
-            onClick={() => history.goBack()}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            disabled
-            className="d-none"
-            aria-hidden="true"
-          />
-          <Button type="submit" disabled={deleting}>
-            Submit Edit
-          </Button>
-        </Row>
-      </Form>
-    </>
+    <Form className="PerformerDeleteForm" onSubmit={handleSubmit(handleDelete)}>
+      <Row>
+        <h4>
+          Delete performer <em>{performer.name}</em>
+        </h4>
+      </Row>
+      <Form.Control type="hidden" value={performer.id} {...register("id")} />
+      <Row className="my-4">
+        <Col md={6}>
+          <EditNote register={register} error={errors.note} />
+          <div className="d-flex mt-2">
+            <Button
+              variant="danger"
+              className="ms-auto me-2"
+              onClick={() => history.goBack()}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled
+              className="d-none"
+              aria-hidden="true"
+            />
+            <Button type="submit" disabled={deleting}>
+              Submit Edit
+            </Button>
+          </div>
+        </Col>
+      </Row>
+    </Form>
   );
 };
 

--- a/frontend/src/pages/performers/styles.scss
+++ b/frontend/src/pages/performers/styles.scss
@@ -35,6 +35,7 @@
 
 .PerformerScenes {
   .CheckboxSelect {
-    position: absolute;
+    float: left;
+    margin-right: 0.5rem;
   }
 }

--- a/frontend/src/pages/scenes/Scene.tsx
+++ b/frontend/src/pages/scenes/Scene.tsx
@@ -205,7 +205,7 @@ const SceneComponent: FC<Props> = ({ scene }) => {
             </div>
           </div>
         </Tab>
-        <Tab eventKey="fingerprints" title="Fingerprints">
+        <Tab eventKey="fingerprints" title="Fingerprints" mountOnEnter={false}>
           <div className="scene-fingerprints my-4">
             <h4>Fingerprints:</h4>
             {fingerprints.length === 0 ? (

--- a/frontend/src/pages/scenes/SceneDelete.tsx
+++ b/frontend/src/pages/scenes/SceneDelete.tsx
@@ -50,39 +50,37 @@ const SceneDelete: FC<Props> = ({ scene }) => {
     });
 
   return (
-    <>
-      <Form className="SceneDeleteForm" onSubmit={handleSubmit(handleDelete)}>
-        <Row>
-          <h4>
-            Delete scene <em>{scene.title}</em>
-          </h4>
-        </Row>
-        <Form.Control type="hidden" value={scene.id} {...register("id")} />
-        <Row className="my-4">
-          <Col md={6}>
-            <EditNote register={register} error={errors.note} />
-          </Col>
-        </Row>
-        <Row className="mt-2">
-          <Button
-            variant="danger"
-            className="ms-auto me-2"
-            onClick={() => history.goBack()}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            disabled
-            className="d-none"
-            aria-hidden="true"
-          />
-          <Button type="submit" disabled={deleting}>
-            Submit Edit
-          </Button>
-        </Row>
-      </Form>
-    </>
+    <Form className="SceneDeleteForm" onSubmit={handleSubmit(handleDelete)}>
+      <Row>
+        <h4>
+          Delete scene <em>{scene.title}</em>
+        </h4>
+      </Row>
+      <Form.Control type="hidden" value={scene.id} {...register("id")} />
+      <Row className="my-4">
+        <Col md={6}>
+          <EditNote register={register} error={errors.note} />
+          <div className="d-flex mt-2">
+            <Button
+              variant="danger"
+              className="ms-auto me-2"
+              onClick={() => history.goBack()}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled
+              className="d-none"
+              aria-hidden="true"
+            />
+            <Button type="submit" disabled={deleting}>
+              Submit Edit
+            </Button>
+          </div>
+        </Col>
+      </Row>
+    </Form>
   );
 };
 

--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -117,7 +117,12 @@ const StudioComponent: FC<Props> = ({ studio }) => {
           </div>
         </>
       )}
-      <Tabs activeKey={activeTab} id="tag-tabs" mountOnEnter onSelect={setTab}>
+      <Tabs
+        activeKey={activeTab}
+        id="studio-tabs"
+        mountOnEnter
+        onSelect={setTab}
+      >
         <Tab
           eventKey="scenes"
           title={subStudios.length > 0 ? "All Scenes" : "Scenes"}

--- a/frontend/src/pages/studios/StudioDelete.tsx
+++ b/frontend/src/pages/studios/StudioDelete.tsx
@@ -50,39 +50,37 @@ const StudioDelete: FC<Props> = ({ studio }) => {
     });
 
   return (
-    <>
-      <Form className="StudioDeleteForm" onSubmit={handleSubmit(handleDelete)}>
-        <Row>
-          <h4>
-            Delete studio <em>{studio.name}</em>
-          </h4>
-        </Row>
-        <Form.Control type="hidden" value={studio.id} {...register("id")} />
-        <Row className="my-4">
-          <Col md={6}>
-            <EditNote register={register} error={errors.note} />
-          </Col>
-        </Row>
-        <Row className="mt-2">
-          <Button
-            variant="danger"
-            className="ms-auto me-2"
-            onClick={() => history.goBack()}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            disabled
-            className="d-none"
-            aria-hidden="true"
-          />
-          <Button type="submit" disabled={deleting}>
-            Submit Edit
-          </Button>
-        </Row>
-      </Form>
-    </>
+    <Form className="StudioDeleteForm" onSubmit={handleSubmit(handleDelete)}>
+      <Row>
+        <h4>
+          Delete studio <em>{studio.name}</em>
+        </h4>
+      </Row>
+      <Form.Control type="hidden" value={studio.id} {...register("id")} />
+      <Row className="my-4">
+        <Col md={6}>
+          <EditNote register={register} error={errors.note} />
+          <div className="d-flex mt-2">
+            <Button
+              variant="danger"
+              className="ms-auto me-2"
+              onClick={() => history.goBack()}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled
+              className="d-none"
+              aria-hidden="true"
+            />
+            <Button type="submit" disabled={deleting}>
+              Submit Edit
+            </Button>
+          </div>
+        </Col>
+      </Row>
+    </Form>
   );
 };
 

--- a/frontend/src/pages/studios/Studios.tsx
+++ b/frontend/src/pages/studios/Studios.tsx
@@ -53,9 +53,10 @@ const StudiosComponent: FC = () => {
 
   const filters = (
     <Form.Control
-      id="tag-query"
+      id="studio-query"
       onChange={(e) => debouncedHandler(e.currentTarget.value)}
       placeholder="Filter studio name"
+      defaultValue={query ?? ""}
       className="w-25"
     />
   );

--- a/frontend/src/pages/tags/TagDelete.tsx
+++ b/frontend/src/pages/tags/TagDelete.tsx
@@ -60,20 +60,25 @@ const TagDelete: FC<Props> = ({ tag }) => {
       <Row className="my-4">
         <Col md={6}>
           <EditNote register={register} error={errors.note} />
+          <div className="d-flex mt-2">
+            <Button
+              variant="danger"
+              className="ms-auto me-2"
+              onClick={() => history.goBack()}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled
+              className="d-none"
+              aria-hidden="true"
+            />
+            <Button type="submit" disabled={deleting}>
+              Submit Edit
+            </Button>
+          </div>
         </Col>
-      </Row>
-      <Row className="mt-2">
-        <Button
-          variant="danger"
-          className="ms-auto me-2"
-          onClick={() => history.goBack()}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" disabled className="d-none" aria-hidden="true" />
-        <Button type="submit" disabled={deleting}>
-          Submit Edit
-        </Button>
       </Row>
     </Form>
   );

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -73,13 +73,13 @@ $textfield-bg: rgba(16 22 26 / 30%);
 */
 
 :root {
-  --bs-primary: #137cbd;
-  --bs-secondary: #394b59;
-  --bs-success: #0f9960;
-  --bs-warning: #d9822b;
-  --bs-danger: #db3737;
+  --bs-primary: #{$primary};
+  --bs-secondary: #{$secondary};
+  --bs-success: #{$success};
+  --bs-warning: #{$warning};
+  --bs-danger: #{$danger};
   --bs-body-bg: #202b33;
-  --bs-dark: #394b59;
+  --bs-dark: #{$dark};
   --bs-dark-rgb: 57, 75, 89;
 }
 

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -292,9 +292,11 @@ hr {
   z-index: 1;
 }
 
-.page-item:first-child .page-link,
+.page-item:first-child .page-link {
+  border-left-color: var(--bs-secondary);
+}
 .page-item:last-child .page-link {
-  border-color: var(--bs-secondary);
+  border-right-color: var(--bs-secondary);
 }
 
 .page-item.disabled .page-link {

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -19,7 +19,14 @@ $theme-colors: (
   "danger": $danger,
   "dark": $dark,
 );
+$link-color: #48aff0;
+$link-hover-color: $link-color;
+$pre-color: $text-color;
 $popover-bg: $secondary;
+
+// Custom variables
+$dark-text: #182026;
+$textfield-bg: rgba(16 22 26 / 30%);
 
 // 3. Include remainder of required Bootstrap stylesheets
 @import "bootstrap/scss/variables";
@@ -100,12 +107,6 @@ body {
     }
   }
 }
-
-$link-color: #48aff0;
-$link-hover-color: $link-color;
-$pre-color: $text-color;
-$dark-text: #182026;
-$textfield-bg: rgba(16 22 26 / 30%);
 
 .btn.active:not(.disabled),
 .btn.active.minimal:not(.disabled) {

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -295,6 +295,7 @@ hr {
 .page-item:first-child .page-link {
   border-left-color: var(--bs-secondary);
 }
+
 .page-item:last-child .page-link {
   border-right-color: var(--bs-secondary);
 }

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -279,17 +279,17 @@ hr {
   color: white;
 }
 
+.page-link:focus {
+  background-color: var(--bs-secondary);
+  color: white;
+}
+
 .page-link:hover,
 .page-item.active .page-link {
   background-color: #2a3742;
   border-color: #25313a;
   color: white;
   z-index: 1;
-}
-
-.page-link:focus {
-  background-color: var(--bs-secondary);
-  color: white;
 }
 
 .page-item:first-child .page-link,

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -287,6 +287,11 @@ hr {
   z-index: 1;
 }
 
+.page-link:focus {
+  background-color: var(--bs-secondary);
+  color: white;
+}
+
 .page-item:first-child .page-link,
 .page-item:last-child .page-link {
   border-color: var(--bs-secondary);

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -55,6 +55,7 @@ $textfield-bg: rgba(16 22 26 / 30%);
 @import "bootstrap/scss/tooltip";
 @import "bootstrap/scss/popover";
 @import "bootstrap/scss/spinners";
+@import "bootstrap/scss/close";
 
 /*
 @import "bootstrap/scss/images";
@@ -66,7 +67,6 @@ $textfield-bg: rgba(16 22 26 / 30%);
 @import "bootstrap/scss/alert";
 @import "bootstrap/scss/progress";
 @import "bootstrap/scss/list-group";
-@import "bootstrap/scss/close";
 @import "bootstrap/scss/toasts";
 @import "bootstrap/scss/carousel";
 @import "bootstrap/scss/offcanvas";

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -19,6 +19,7 @@ $theme-colors: (
   "danger": $danger,
   "dark": $dark,
 );
+$popover-bg: $secondary;
 
 // 3. Include remainder of required Bootstrap stylesheets
 @import "bootstrap/scss/variables";
@@ -103,7 +104,6 @@ body {
 $link-color: #48aff0;
 $link-hover-color: $link-color;
 $pre-color: $text-color;
-$popover-bg: var(--bs-secondary);
 $dark-text: #182026;
 $textfield-bg: rgba(16 22 26 / 30%);
 

--- a/frontend/src/utils/transforms.ts
+++ b/frontend/src/utils/transforms.ts
@@ -10,7 +10,7 @@ export const formatMeasurements = (val?: Measurements): string | undefined => {
   if ((val?.cup_size && val.band_size) || val?.hip || val?.waist) {
     const bust =
       val.cup_size && val.band_size ? `${val.band_size}${val.cup_size}` : "??";
-    return `${bust}-${val.waist ?? ""}-${val.hip ?? ""}`;
+    return `${bust}-${val.waist ?? "??"}-${val.hip ?? "??"}`;
   }
   return undefined;
 };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => {
   const config = {
     build: {
       outDir: "build",
+      sourcemap: mode === "production",
     },
     optimizeDeps: {
       entries: "src/index.tsx",


### PR DESCRIPTION
- Popover content had light-colored text over a light background (see `<Help />` on performer form when changing the name).
- The studio names on the studio selector (performer page) needed to be nudged slightly away from the check-boxes.
- Grouped together the rest of the default SCSS variables overrides.
- Set the default value of the studio/tag lists search box from query.
- Fix missing question marks in `formatMeasurements`.
- Fix styling of entity delete pages (buttons stretched across the width of the page).
- Fix missing close button on modals.
- Restore sourcemaps on production builds (only TS/JS. seems CSS is not supported ATM).
- Fix warning on `ImageChangeRow`
- Fix pagination links focus colors
- Always mount the scene fingerprints tab
- Fix hidden performer scenes filters (the new sort order select was hidden behind the studio select)
- Use `SceneList` on tag page