### PR TITLE
Update performer search query

### DIFF
--- a/pkg/sqlx/querybuilder_performer.go
+++ b/pkg/sqlx/querybuilder_performer.go
@@ -532,19 +532,20 @@ func (qb *performerQueryBuilder) GetAllPiercings(ids []uuid.UUID) ([][]*models.B
 
 func (qb *performerQueryBuilder) SearchPerformers(term string, limit int) (models.Performers, error) {
 	query := `
+	SELECT DISTINCT ON (T.id) T.* FROM (
 		SELECT P.* FROM performers P
-		LEFT JOIN (
-			SELECT performer_id, string_agg(alias, ' ') aliases
-			FROM performer_aliases
-			GROUP BY performer_id
-		) PA on PA.performer_id = P.id
-		WHERE (
-			to_tsvector('english', coalesce(P.name, '')) ||
-			to_tsvector('english', coalesce(P.disambiguation, '')) ||
-			to_tsvector('english', coalesce(PA.aliases, ''))
-		) @@ plainto_tsquery($1)
-		AND P.deleted = FALSE
-		LIMIT $2`
+		LEFT JOIN performer_aliases PA on PA.performer_id = P.id
+		WHERE
+			P.deleted = FALSE AND (
+				(P.name % $1 AND similarity(P.name, $1) > 0.5)
+				OR (PA.alias % $1 AND similarity(PA.alias, $1) > 0.6)
+				OR (P.disambiguation % $1 AND similarity(P.disambiguation, $1) > 0.7)
+			)
+		ORDER BY
+			similarity(P.name, $1) DESC,
+			similarity(PA.alias, $1) DESC,
+			similarity(P.disambiguation, $1) DESC
+	) T LIMIT $2`
 	args := []interface{}{term, limit}
 	return qb.queryPerformers(query, args)
 }


### PR DESCRIPTION
~~This is a start, based on the current full text search for scenes.~~

~~In regards to performance, I'm unsure:
Should there be a `performer_search` table and functions updating the values, like `scene_search`?~~

Closes #124

This adds disambiguation and aliases to the performer search query with lower weights,
enabling searching for performers using those fields.
