### PR TITLE
Implement migration logging

### DIFF
--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -53,6 +53,8 @@ func (p *PostgresProvider) runMigrations(databasePath string) {
 		panic(err.Error())
 	}
 
+	m.Log = &migrateLogger{}
+
 	databaseSchemaVersion, _, _ := m.Version()
 	stepNumber := appSchemaVersion - databaseSchemaVersion
 	if stepNumber != 0 {
@@ -63,4 +65,18 @@ func (p *PostgresProvider) runMigrations(databasePath string) {
 	}
 
 	_, _ = m.Close()
+}
+
+type migrateLogger struct {
+	migrate.Logger
+}
+
+// Printf is like fmt.Printf
+func (*migrateLogger) Printf(format string, v ...interface{}) {
+	logger.Debugf("Migration: "+format, v...)
+}
+
+// Verbose should return true when verbose logging output is wanted
+func (*migrateLogger) Verbose() bool {
+	return true
 }


### PR DESCRIPTION
Enabled on debug logging level.
Example:
```
DEBU[0000] Migration: Start buffering 17/u edit_votes
DEBU[0000] Migration: Start buffering 18/u fingerprint_user
DEBU[0000] Migration: Start buffering 19/u scene_created_index
DEBU[0000] Migration: Start buffering 20/u edit_constraints
DEBU[0000] Migration: Read and execute 17/u edit_votes
DEBU[0000] Migration: Finished 17/u edit_votes (read 8.4711ms, ran 34.0342ms)
DEBU[0000] Migration: Read and execute 18/u fingerprint_user
DEBU[0050] Migration: Finished 18/u fingerprint_user (read 53.8315ms, ran 50.2988223s)
DEBU[0050] Migration: Read and execute 19/u scene_created_index
DEBU[0050] Migration: Finished 19/u scene_created_index (read 50.3605871s, ran 110.0424ms)
DEBU[0050] Migration: Read and execute 20/u edit_constraints
DEBU[0050] Migration: Finished 20/u edit_constraints (read 50.47837s, ran 25.8731ms)
DEBU[0050] Migration: Closing source and database
DEBU[0050] Edit cronjob initialized to run every 5m
stash-box version: WORKING_TREE (2021-11-24 19:52:54)
INFO[0050] stash-box is running on HTTP at http://127.0.0.1:9998/
```