### PR TITLE
Scene form performer field fixes

### DIFF
--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -192,6 +192,12 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
     });
   };
 
+  const handleRemove = (index: number) => {
+    if (isChanging && isChanging > index) setChange(isChanging - 1);
+    else if (isChanging === index) setChange(undefined);
+    removePerformer(index);
+  };
+
   const handleChange = (result: PerformerResult, index: number) => {
     setChange(undefined);
     const alias = performerFields[index].alias || performerFields[index].name;
@@ -217,7 +223,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
 
       <Col xs={6}>
         <InputGroup className="flex-nowrap">
-          <Button variant="danger" onClick={() => removePerformer(index)}>
+          <Button variant="danger" onClick={() => handleRemove(index)}>
             Remove
           </Button>
           <>

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -205,6 +205,8 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
     });
   };
 
+  const currentPerformerIds = () => performerFields.map((p) => p.performerId);
+
   const performerList = performerFields.map((p, index) => (
     <Row className="performer-item d-flex g-0" key={p.performerId}>
       <Form.Control
@@ -235,6 +237,9 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
                 onClick={(res) =>
                   res.__typename === "Performer" && handleChange(res, index)
                 }
+                excludeIDs={currentPerformerIds().filter(
+                  (id) => id !== p.performerId
+                )}
                 searchType={SearchType.Performer}
               />
             ) : (
@@ -326,6 +331,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
                   onClick={(res) =>
                     res.__typename === "Performer" && addPerformer(res)
                   }
+                  excludeIDs={currentPerformerIds()}
                   searchType={SearchType.Performer}
                 />
               </div>

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -211,7 +211,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
     });
   };
 
-  const currentPerformerIds = () => performerFields.map((p) => p.performerId);
+  const currentPerformerIds = performerFields.map((p) => p.performerId);
 
   const performerList = performerFields.map((p, index) => (
     <Row className="performer-item d-flex g-0" key={p.performerId}>
@@ -243,7 +243,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
                 onClick={(res) =>
                   res.__typename === "Performer" && handleChange(res, index)
                 }
-                excludeIDs={currentPerformerIds().filter(
+                excludeIDs={currentPerformerIds.filter(
                   (id) => id !== p.performerId
                 )}
                 searchType={SearchType.Performer}
@@ -337,7 +337,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
                   onClick={(res) =>
                     res.__typename === "Performer" && addPerformer(res)
                   }
-                  excludeIDs={currentPerformerIds()}
+                  excludeIDs={currentPerformerIds}
                   searchType={SearchType.Performer}
                 />
               </div>


### PR DESCRIPTION
- Prevent adding duplicate performers to a scene.
- Handle performer removal while in change mode.
	- When clicking to change a performer, then removing it.
	- When clicking to change a performer, then removing any one of the performers above it.