### PR TITLE
Create edit votes for admin actions

### DIFF
--- a/frontend/src/constants/enums.ts
+++ b/frontend/src/constants/enums.ts
@@ -98,8 +98,8 @@ export const EditStatusTypes: EnumDictionary<VoteStatusEnum, string> = {
 
 export const VoteTypes: EnumDictionary<VoteTypeEnum, string> = {
   [VoteTypeEnum.ACCEPT]: "Yes",
-  [VoteTypeEnum.IMMEDIATE_ACCEPT]: "Approve",
-  [VoteTypeEnum.IMMEDIATE_REJECT]: "Reject",
+  [VoteTypeEnum.IMMEDIATE_ACCEPT]: "Admin Accept",
+  [VoteTypeEnum.IMMEDIATE_REJECT]: "Admin Reject",
   [VoteTypeEnum.ABSTAIN]: "Abstain",
   [VoteTypeEnum.REJECT]: "No",
 };

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -138,7 +138,7 @@ const StudioForm: FC<StudioProps> = ({
       <Form.Group className="mb-3">
         <div className="d-flex">
           <Button className="col-2" type="submit" disabled={!!file || saving}>
-            Save
+            Submit Edit
           </Button>
           <Button type="reset" variant="secondary" className="ms-auto me-2">
             Reset

--- a/frontend/src/pages/tags/tagForm/TagForm.tsx
+++ b/frontend/src/pages/tags/tagForm/TagForm.tsx
@@ -137,7 +137,7 @@ const TagForm: FC<TagProps> = ({ tag, callback, saving }) => {
       <Form.Group className="d-flex mb-3">
         <Button type="submit" disabled className="d-none" aria-hidden="true" />
         <Button type="submit" className="col-2" disabled={saving}>
-          Save
+          Submit Edit
         </Button>
         <Button type="reset" className="ms-auto me-2">
           Reset

--- a/pkg/api/edit_integration_test.go
+++ b/pkg/api/edit_integration_test.go
@@ -122,7 +122,7 @@ func (s *editTestRunner) testVotePermissionsPromotion() {
 		if err != nil {
 			return
 		}
-		s.ctx = context.WithValue(s.ctx, user.ContextUser, userDB.adminRoles)
+		s.ctx = context.WithValue(s.ctx, user.ContextRoles, userDB.adminRoles)
 		_, err = s.applyEdit(createdEdit.ID.String())
 		if err != nil {
 			return


### PR DESCRIPTION
- Cast `IMMEDIATE_ACCEPT` and `IMMEDIATE_REJECT` votes when an admin approves or rejects an edit, respectively.
- Fix inconsistent edit submit button labels.