### PR TITLE
Add option to regenerate API key

### DIFF
--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -1,15 +1,24 @@
-import { FC } from "react";
+import { ReactNode, FC } from "react";
 import { Modal, Button } from "react-bootstrap";
 
 interface ModalProps {
-  message: string;
   callback: (status: boolean) => void;
   cancelTerm?: string;
   acceptTerm?: string;
 }
 
-const ModalComponent: FC<ModalProps> = ({
+interface MessageProps {
+  message: string;
+  body?: never;
+}
+interface ElementProps {
+  body: ReactNode;
+  message?: never;
+}
+
+const ModalComponent: FC<ModalProps & (MessageProps | ElementProps)> = ({
   message,
+  body,
   callback,
   cancelTerm = "Cancel",
   acceptTerm = "Delete",
@@ -17,10 +26,14 @@ const ModalComponent: FC<ModalProps> = ({
   const handleCancel = () => callback(false);
   const handleAccept = () => callback(true);
 
+  const content = message || body;
+
   return (
     <Modal show onHide={handleCancel}>
-      <Modal.Header closeButton>Warning</Modal.Header>
-      <Modal.Body>{message}</Modal.Body>
+      <Modal.Header closeButton>
+        <b>Warning</b>
+      </Modal.Header>
+      <Modal.Body>{content}</Modal.Body>
       <Modal.Footer>
         <Button variant="danger" onClick={handleAccept}>
           {acceptTerm}

--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -9,16 +9,16 @@ interface ModalProps {
 
 interface MessageProps {
   message: string;
-  body?: never;
+  children?: never;
 }
 interface ElementProps {
-  body: ReactNode;
+  children: ReactNode;
   message?: never;
 }
 
 const ModalComponent: FC<ModalProps & (MessageProps | ElementProps)> = ({
   message,
-  body,
+  children,
   callback,
   cancelTerm = "Cancel",
   acceptTerm = "Delete",
@@ -26,7 +26,7 @@ const ModalComponent: FC<ModalProps & (MessageProps | ElementProps)> = ({
   const handleCancel = () => callback(false);
   const handleAccept = () => callback(true);
 
-  const content = message || body;
+  const content = message || children;
 
   return (
     <Modal show onHide={handleCancel}>

--- a/frontend/src/graphql/definitions/RegenerateAPIKey.ts
+++ b/frontend/src/graphql/definitions/RegenerateAPIKey.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+
+// ====================================================
+// GraphQL mutation operation: RegenerateAPIKey
+// ====================================================
+
+
+export interface RegenerateAPIKey {
+  /**
+   * Regenerates the api key for the given user, or the current user if id not provided
+   */
+  regenerateAPIKey: string;
+}
+
+export interface RegenerateAPIKeyVariables {
+  user_id?: string | null;
+}

--- a/frontend/src/graphql/mutations/RegenerateAPIKey.gql
+++ b/frontend/src/graphql/mutations/RegenerateAPIKey.gql
@@ -1,0 +1,3 @@
+mutation RegenerateAPIKey($user_id: ID) {
+  regenerateAPIKey(userID: $user_id)
+}

--- a/frontend/src/graphql/mutations/index.ts
+++ b/frontend/src/graphql/mutations/index.ts
@@ -48,6 +48,10 @@ import {
   ResetPassword,
   ResetPasswordVariables,
 } from "../definitions/ResetPassword";
+import {
+  RegenerateAPIKey,
+  RegenerateAPIKeyVariables,
+} from "../definitions/RegenerateAPIKey";
 import { GenerateInviteCode } from "../definitions/GenerateInviteCode";
 import { GrantInvite, GrantInviteVariables } from "../definitions/GrantInvite";
 import {
@@ -86,6 +90,7 @@ import ApplyEditMutation from "./ApplyEdit.gql";
 import CancelEditMutation from "./CancelEdit.gql";
 import ChangePasswordMutation from "./ChangePassword.gql";
 import ResetPasswordMutation from "./ResetPassword.gql";
+import RegenerateAPIKeyMutation from "./RegenerateAPIKey.gql";
 import GenerateInviteCodeMutation from "./GenerateInviteCode.gql";
 import GrantInviteMutation from "./GrantInvite.gql";
 import RescindInviteCodeMutation from "./RescindInviteCode.gql";
@@ -184,6 +189,10 @@ export const useChangePassword = (
 export const useResetPassword = (
   options?: MutationHookOptions<ResetPassword, ResetPasswordVariables>
 ) => useMutation(ResetPasswordMutation, options);
+
+export const useRegenerateAPIKey = (
+  options?: MutationHookOptions<RegenerateAPIKey, RegenerateAPIKeyVariables>
+) => useMutation(RegenerateAPIKeyMutation, options);
 
 export const useGenerateInviteCode = (
   options?: MutationHookOptions<GenerateInviteCode>

--- a/frontend/src/pages/users/User.tsx
+++ b/frontend/src/pages/users/User.tsx
@@ -111,21 +111,17 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
     setShowRegenerateAPIKey(false);
   };
   const regenerateAPIKeyModal = showRegenerateAPIKey && (
-    <Modal
-      body={
-        <>
-          <p>
-            Are you sure you want to regenerate the API key? The old key will be
-            removed and can no longer be used.
-          </p>
-          <p>
-            <i>This operation cannot be undone.</i>
-          </p>
-        </>
-      }
-      callback={handleRegenerateAPIKey}
-      acceptTerm="Confirm"
-    />
+    <Modal callback={handleRegenerateAPIKey} acceptTerm="Confirm">
+      <>
+        <p>
+          Are you sure you want to regenerate the API key? The old key will be
+          removed and can no longer be used.
+        </p>
+        <p>
+          <i>This operation cannot be undone.</i>
+        </p>
+      </>
+    </Modal>
   );
 
   const handleRescindCode = (status: boolean): void => {

--- a/frontend/src/pages/users/User.tsx
+++ b/frontend/src/pages/users/User.tsx
@@ -1,7 +1,12 @@
 import { FC, useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { Button, Col, Form, InputGroup, Row, Table } from "react-bootstrap";
-import { faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faMinus,
+  faPlus,
+  faSyncAlt,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import { sortBy } from "lodash-es";
 
 import {
@@ -9,6 +14,7 @@ import {
   VoteTypeEnum,
   useConfig,
   useDeleteUser,
+  useRegenerateAPIKey,
   useRescindInviteCode,
   useGenerateInviteCode,
   useGrantInvite,
@@ -28,7 +34,7 @@ import {
   ROUTE_USER_EDITS,
 } from "src/constants/route";
 import Modal from "src/components/modal";
-import { Icon } from "src/components/fragments";
+import { Icon, Tooltip } from "src/components/fragments";
 import { isAdmin, isPrivateUser, createHref } from "src/utils";
 import { EditStatusTypes, VoteTypes } from "src/constants";
 
@@ -66,9 +72,11 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
   const Auth = useContext(AuthContext);
   const { data: configData } = useConfig();
   const [showDelete, setShowDelete] = useState(false);
+  const [showRegenerateAPIKey, setShowRegenerateAPIKey] = useState(false);
   const [showRescindCode, setShowRescindCode] = useState<string | undefined>();
 
   const [deleteUser, { loading: deleting }] = useDeleteUser();
+  const [regenerateAPIKey] = useRegenerateAPIKey();
   const [rescindInviteCode] = useRescindInviteCode();
   const [generateInviteCode] = useGenerateInviteCode();
   const [grantInvite] = useGrantInvite();
@@ -90,6 +98,22 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
     <Modal
       message={`Are you sure you want to delete '${user.name}'? This operation cannot be undone.`}
       callback={handleDelete}
+    />
+  );
+
+  const handleRegenerateAPIKey = (status: boolean): void => {
+    if (status) {
+      const userID = user.id === Auth.user?.id ? null : user.id;
+      regenerateAPIKey({ variables: { user_id: userID } }).then(() => {
+        refetch();
+      });
+    }
+    setShowRegenerateAPIKey(false);
+  };
+  const regenerateAPIKeyModal = showRegenerateAPIKey && (
+    <Modal
+      message="Are you sure you want to regenerate the API key? This operation cannot be undone."
+      callback={handleRegenerateAPIKey}
     />
   );
 
@@ -152,6 +176,7 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
         <div className="d-flex">
           <h3>{user.name}</h3>
           {deleteModal}
+          {regenerateAPIKeyModal}
           {rescindCodeModal}
           <div className="ms-auto">
             <Link to={createHref(ROUTE_USER_EDITS, user)} className="ms-2">
@@ -202,6 +227,15 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
                   >
                     Copy to Clipboard
                   </Button>
+                  <Tooltip text="Regenerate API Key" placement="top-end">
+                    <Button
+                      variant="danger"
+                      disabled={showRegenerateAPIKey}
+                      onClick={() => setShowRegenerateAPIKey(true)}
+                    >
+                      <Icon icon={faSyncAlt} />
+                    </Button>
+                  </Tooltip>
                 </InputGroup>
               </Col>
             </Row>

--- a/frontend/src/pages/users/User.tsx
+++ b/frontend/src/pages/users/User.tsx
@@ -112,7 +112,17 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
   };
   const regenerateAPIKeyModal = showRegenerateAPIKey && (
     <Modal
-      message="Are you sure you want to regenerate the API key? This operation cannot be undone."
+      body={
+        <>
+          <p>
+            Are you sure you want to regenerate the API key? The old key will be
+            removed and can no longer be used.
+          </p>
+          <p>
+            <i>This operation cannot be undone.</i>
+          </p>
+        </>
+      }
       callback={handleRegenerateAPIKey}
       acceptTerm="Confirm"
     />

--- a/frontend/src/pages/users/User.tsx
+++ b/frontend/src/pages/users/User.tsx
@@ -114,6 +114,7 @@ const UserComponent: FC<Props> = ({ user, refetch }) => {
     <Modal
       message="Are you sure you want to regenerate the API key? This operation cannot be undone."
       callback={handleRegenerateAPIKey}
+      acceptTerm="Confirm"
     />
   );
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -67,6 +67,12 @@ func authenticateHandler() func(http.Handler) http.Handler {
 				userID, err = getSessionUserID(w, r)
 			}
 
+			var u *models.User
+			var roles []models.RoleEnum
+			if err == nil {
+				u, roles, err = getUserAndRoles(getRepo(ctx), userID)
+			}
+
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, err = w.Write([]byte(err.Error()))
@@ -76,12 +82,9 @@ func authenticateHandler() func(http.Handler) http.Handler {
 				return
 			}
 
-			u, roles, err := getUserAndRoles(getRepo(ctx), userID)
-
 			// ensure api key of the user matches the passed one
 			if apiKey != "" && u != nil && u.APIKey != apiKey {
 				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(err.Error()))
 				return
 			}
 


### PR DESCRIPTION
- Fix panic when using an invalid API key (like after regenerating it).
- Add UI option to regenerate your/a user's API key.
![i](https://user-images.githubusercontent.com/66393006/144654801-6ccb7437-ca79-475a-ad4b-a8aac609aaac.png)