### PR TITLE
Fix scenes fingerprints criterion

### DIFF
--- a/frontend/src/graphql/definitions/globalTypes.ts
+++ b/frontend/src/graphql/definitions/globalTypes.ts
@@ -275,6 +275,11 @@ export interface MultiIDCriterionInput {
   modifier: CriterionModifier;
 }
 
+export interface MultiStringCriterionInput {
+  value: string[];
+  modifier: CriterionModifier;
+}
+
 export interface NewUserInput {
   email: string;
   invite_key?: string | null;
@@ -411,7 +416,7 @@ export interface SceneFilterType {
   tags?: MultiIDCriterionInput | null;
   performers?: MultiIDCriterionInput | null;
   alias?: StringCriterionInput | null;
-  fingerprints?: MultiIDCriterionInput | null;
+  fingerprints?: MultiStringCriterionInput | null;
 }
 
 export interface SceneUpdateInput {

--- a/graphql/schema/types/filter.graphql
+++ b/graphql/schema/types/filter.graphql
@@ -13,6 +13,11 @@ input StringCriterionInput {
   modifier: CriterionModifier!
 }
 
+input MultiStringCriterionInput {
+  value: [String!]!
+  modifier: CriterionModifier!
+}
+
 input IntCriterionInput {
   value: Int!
   modifier: CriterionModifier!

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -172,5 +172,5 @@ input SceneFilterType {
   """Filter to include scenes with performer appearing as alias"""
   alias: StringCriterionInput
   """Filter to only include scenes with these fingerprints"""
-  fingerprints: MultiIDCriterionInput
+  fingerprints: MultiStringCriterionInput
 }

--- a/pkg/models/extension_criterion_input.go
+++ b/pkg/models/extension_criterion_input.go
@@ -1,0 +1,22 @@
+package models
+
+type MultiCriterionInput interface {
+	Count() int
+	GetModifier() CriterionModifier
+}
+
+func (i MultiIDCriterionInput) Count() int {
+	return len(i.Value)
+}
+
+func (i MultiIDCriterionInput) GetModifier() CriterionModifier {
+	return i.Modifier
+}
+
+func (i MultiStringCriterionInput) Count() int {
+	return len(i.Value)
+}
+
+func (i MultiStringCriterionInput) GetModifier() CriterionModifier {
+	return i.Modifier
+}

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -3019,6 +3019,11 @@ input StringCriterionInput {
   modifier: CriterionModifier!
 }
 
+input MultiStringCriterionInput {
+  value: [String!]!
+  modifier: CriterionModifier!
+}
+
 input IntCriterionInput {
   value: Int!
   modifier: CriterionModifier!
@@ -3598,7 +3603,7 @@ input SceneFilterType {
   """Filter to include scenes with performer appearing as alias"""
   alias: StringCriterionInput
   """Filter to only include scenes with these fingerprints"""
-  fingerprints: MultiIDCriterionInput
+  fingerprints: MultiStringCriterionInput
 }
 `, BuiltIn: false},
 	{Name: "graphql/schema/types/studio.graphql", Input: `type Studio {
@@ -16757,6 +16762,37 @@ func (ec *executionContext) unmarshalInputMultiIDCriterionInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputMultiStringCriterionInput(ctx context.Context, obj interface{}) (MultiStringCriterionInput, error) {
+	var it MultiStringCriterionInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "value":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			it.Value, err = ec.unmarshalNString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "modifier":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("modifier"))
+			it.Modifier, err = ec.unmarshalNCriterionModifier2githubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐCriterionModifier(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNewUserInput(ctx context.Context, obj interface{}) (NewUserInput, error) {
 	var it NewUserInput
 	asMap := map[string]interface{}{}
@@ -18077,7 +18113,7 @@ func (ec *executionContext) unmarshalInputSceneFilterType(ctx context.Context, o
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fingerprints"))
-			it.Fingerprints, err = ec.unmarshalOMultiIDCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐMultiIDCriterionInput(ctx, v)
+			it.Fingerprints, err = ec.unmarshalOMultiStringCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐMultiStringCriterionInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -24632,6 +24668,14 @@ func (ec *executionContext) unmarshalOMultiIDCriterionInput2ᚖgithubᚗcomᚋst
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputMultiIDCriterionInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOMultiStringCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐMultiStringCriterionInput(ctx context.Context, v interface{}) (*MultiStringCriterionInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMultiStringCriterionInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/pkg/models/generated_models.go
+++ b/pkg/models/generated_models.go
@@ -198,6 +198,11 @@ type MultiIDCriterionInput struct {
 	Modifier CriterionModifier `json:"modifier"`
 }
 
+type MultiStringCriterionInput struct {
+	Value    []string          `json:"value"`
+	Modifier CriterionModifier `json:"modifier"`
+}
+
 type NewUserInput struct {
 	Email     string  `json:"email"`
 	InviteKey *string `json:"invite_key"`
@@ -434,7 +439,7 @@ type SceneFilterType struct {
 	// Filter to include scenes with performer appearing as alias
 	Alias *StringCriterionInput `json:"alias"`
 	// Filter to only include scenes with these fingerprints
-	Fingerprints *MultiIDCriterionInput `json:"fingerprints"`
+	Fingerprints *MultiStringCriterionInput `json:"fingerprints"`
 }
 
 type SceneUpdateInput struct {


### PR DESCRIPTION
`/scenes?fingerprint={hash}` is currently broken:
`[GraphQL error]: Message: uuid: incorrect UUID length 16 in string "<hash>", Location: undefined, Path: queryScenes,scene_filter,fingerprints,value,0`

~~Not sure how to proceed from this point, yet.~~

I assume the correct fix is an interface that makes the two `Multi` types compatible with each other so they can be used in a single `getMultiCriterionClause` function, ~but that's where I got stuck.~