### PR TITLE
Fix edit expiration

### DIFF
--- a/frontend/src/components/editCard/EditExpiration.tsx
+++ b/frontend/src/components/editCard/EditExpiration.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { addSeconds, formatDistance } from "date-fns";
 
 import { Tooltip } from "src/components/fragments";
-import { useConfig, OperationEnum, VoteStatusEnum } from "src/graphql";
+import { useConfig, VoteStatusEnum } from "src/graphql";
 import { Edits_queryEdits_edits as Edit } from "src/graphql/definitions/Edits";
 
 interface Props {
@@ -27,18 +27,16 @@ const ExpirationNotification: FC<Props> = ({ edit }) => {
 
   const expirationTime = addSeconds(
     new Date(edit.created as string),
-    data.getConfig.voting_period
+    edit.destructive
+      ? config.min_destructive_voting_period
+      : config.voting_period
   );
   const expirationDistance =
     expirationTime > new Date()
       ? formatDistance(expirationTime, new Date())
       : " a moment";
 
-  const threshold =
-    edit.operation === OperationEnum.MERGE ||
-    edit.operation === OperationEnum.DESTROY
-      ? 1
-      : 0;
+  const threshold = edit.destructive ? 1 : 0;
   const pass = edit.vote_count >= threshold;
 
   return (

--- a/frontend/src/components/editCard/VoteBar.tsx
+++ b/frontend/src/components/editCard/VoteBar.tsx
@@ -26,12 +26,22 @@ const VoteBar: FC<Props> = ({ edit }) => {
   const [vote, setVote] = useState<VoteTypeEnum | null>(userVote?.vote ?? null);
   const [submitVote, { loading: savingVote }] = useVote();
 
-  if (
-    edit.status !== VoteStatusEnum.PENDING ||
-    !canVote(auth.user) ||
-    auth.user?.id === edit.user?.id
-  )
+  if (edit.status !== VoteStatusEnum.PENDING || !canVote(auth.user))
     return <></>;
+
+  if (auth.user?.id === edit.user?.id)
+    return (
+      <div className={CLASSNAME}>
+        <div className={CLASSNAME_SAVE}>
+          <h6>
+            <span className="me-2">Current Vote:</span>
+            <span>{`${edit.vote_count > 0 ? "+" : ""}${
+              edit.vote_count === 0 ? "-" : edit.vote_count
+            }`}</span>
+          </h6>
+        </div>
+      </div>
+    );
 
   const handleSave = () => {
     if (!vote) return;

--- a/frontend/src/components/editCard/VoteBar.tsx
+++ b/frontend/src/components/editCard/VoteBar.tsx
@@ -29,19 +29,18 @@ const VoteBar: FC<Props> = ({ edit }) => {
   if (edit.status !== VoteStatusEnum.PENDING || !canVote(auth.user))
     return <></>;
 
-  if (auth.user?.id === edit.user?.id)
-    return (
-      <div className={CLASSNAME}>
-        <div className={CLASSNAME_SAVE}>
-          <h6>
-            <span className="me-2">Current Vote:</span>
-            <span>{`${edit.vote_count > 0 ? "+" : ""}${
-              edit.vote_count === 0 ? "-" : edit.vote_count
-            }`}</span>
-          </h6>
-        </div>
-      </div>
-    );
+  const currentVote = (
+    <h6>
+      <span className="me-2">Current Vote:</span>
+      <span>{`${edit.vote_count > 0 ? "+" : ""}${
+        edit.vote_count === 0 ? "-" : edit.vote_count
+      }`}</span>
+    </h6>
+  );
+
+  if (auth.user?.id === edit.user?.id) {
+    return <div>{currentVote}</div>;
+  }
 
   const handleSave = () => {
     if (!vote) return;
@@ -59,12 +58,7 @@ const VoteBar: FC<Props> = ({ edit }) => {
   return (
     <div className={CLASSNAME}>
       <div className={CLASSNAME_SAVE}>
-        <h6>
-          <span className="me-2">Current Vote:</span>
-          <span>{`${edit.vote_count > 0 ? "+" : ""}${
-            edit.vote_count === 0 ? "-" : edit.vote_count
-          }`}</span>
-        </h6>
+        {currentVote}
         {vote &&
           vote !== userVote?.vote &&
           (userVote || vote !== VoteTypeEnum.ABSTAIN) && (

--- a/frontend/src/components/list/SceneList.tsx
+++ b/frontend/src/components/list/SceneList.tsx
@@ -1,12 +1,16 @@
 import { FC } from "react";
-import { Col, Form, Row } from "react-bootstrap";
+import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import querystring from "query-string";
 import { useHistory } from "react-router-dom";
+import {
+  faSortAmountUp,
+  faSortAmountDown,
+} from "@fortawesome/free-solid-svg-icons";
 
-import { useScenes, SceneFilterType } from "src/graphql";
+import { useScenes, SceneFilterType, SortDirectionEnum } from "src/graphql";
 import { usePagination } from "src/hooks";
 import SceneCard from "src/components/sceneCard";
-import { ErrorMessage } from "src/components/fragments";
+import { ErrorMessage, Icon } from "src/components/fragments";
 import List from "./List";
 
 const PER_PAGE = 20;
@@ -27,6 +31,11 @@ const SceneList: FC<Props> = ({ perPage = PER_PAGE, filter }) => {
   const history = useHistory();
   const queries = querystring.parse(history.location.search);
   const sort = Array.isArray(queries.sort) ? queries.sort[0] : queries.sort;
+  const direction =
+    (Array.isArray(queries.dir) ? queries.dir[0] : queries.dir) ===
+    SortDirectionEnum.ASC
+      ? SortDirectionEnum.ASC
+      : SortDirectionEnum.DESC;
 
   const { page, setPage } = usePagination();
   const { loading, data } = useScenes({
@@ -34,6 +43,7 @@ const SceneList: FC<Props> = ({ perPage = PER_PAGE, filter }) => {
       page,
       per_page: perPage,
       sort,
+      direction,
     },
     sceneFilter: filter,
   });
@@ -50,17 +60,38 @@ const SceneList: FC<Props> = ({ perPage = PER_PAGE, filter }) => {
   };
 
   const filters = (
-    <Form.Select
-      className="w-auto"
-      onChange={(e) => handleQuery("sort", e.currentTarget.value)}
-      defaultValue={sort ?? "name"}
-    >
-      {sortOptions.map((s) => (
-        <option value={s.value} key={s.value}>
-          {s.label}
-        </option>
-      ))}
-    </Form.Select>
+    <InputGroup className="scene-sort w-auto">
+      <Form.Select
+        className="w-auto"
+        onChange={(e) => handleQuery("sort", e.currentTarget.value)}
+        defaultValue={sort ?? "name"}
+      >
+        {sortOptions.map((s) => (
+          <option value={s.value} key={s.value}>
+            {s.label}
+          </option>
+        ))}
+      </Form.Select>
+      <Button
+        variant="secondary"
+        onClick={() =>
+          handleQuery(
+            "dir",
+            direction === SortDirectionEnum.DESC
+              ? SortDirectionEnum.ASC
+              : undefined
+          )
+        }
+      >
+        <Icon
+          icon={
+            direction === SortDirectionEnum.DESC
+              ? faSortAmountDown
+              : faSortAmountUp
+          }
+        />
+      </Button>
+    </InputGroup>
   );
 
   const scenes = (data?.queryScenes.scenes ?? []).map((scene) => (

--- a/frontend/src/components/list/SceneList.tsx
+++ b/frontend/src/components/list/SceneList.tsx
@@ -51,7 +51,7 @@ const SceneList: FC<Props> = ({ perPage = PER_PAGE, filter }) => {
 
   const filters = (
     <Form.Select
-      className="w-25"
+      className="w-auto"
       onChange={(e) => handleQuery("sort", e.currentTarget.value)}
       defaultValue={sort ?? "name"}
     >

--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -1263,6 +1263,7 @@ export interface ApplyEdit_applyEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: ApplyEdit_applyEdit_comments[];
   votes: ApplyEdit_applyEdit_votes[];
   user: ApplyEdit_applyEdit_user | null;

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -1263,6 +1263,7 @@ export interface Edit_findEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: Edit_findEdit_comments[];
   votes: Edit_findEdit_votes[];
   user: Edit_findEdit_user | null;

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -1263,6 +1263,7 @@ export interface EditFragment {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: EditFragment_comments[];
   votes: EditFragment_votes[];
   user: EditFragment_user | null;

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -1263,6 +1263,7 @@ export interface Edits_queryEdits_edits {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: Edits_queryEdits_edits_comments[];
   votes: Edits_queryEdits_edits_votes[];
   user: Edits_queryEdits_edits_user | null;

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -1263,6 +1263,7 @@ export interface PerformerEdit_performerEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: PerformerEdit_performerEdit_comments[];
   votes: PerformerEdit_performerEdit_votes[];
   user: PerformerEdit_performerEdit_user | null;

--- a/frontend/src/graphql/definitions/SceneEdit.ts
+++ b/frontend/src/graphql/definitions/SceneEdit.ts
@@ -1263,6 +1263,7 @@ export interface SceneEdit_sceneEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: SceneEdit_sceneEdit_comments[];
   votes: SceneEdit_sceneEdit_votes[];
   user: SceneEdit_sceneEdit_user | null;

--- a/frontend/src/graphql/definitions/StudioEdit.ts
+++ b/frontend/src/graphql/definitions/StudioEdit.ts
@@ -1263,6 +1263,7 @@ export interface StudioEdit_studioEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: StudioEdit_studioEdit_comments[];
   votes: StudioEdit_studioEdit_votes[];
   user: StudioEdit_studioEdit_user | null;

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -1263,6 +1263,7 @@ export interface TagEdit_tagEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: TagEdit_tagEdit_comments[];
   votes: TagEdit_tagEdit_votes[];
   user: TagEdit_tagEdit_user | null;

--- a/frontend/src/graphql/definitions/Vote.ts
+++ b/frontend/src/graphql/definitions/Vote.ts
@@ -1263,6 +1263,7 @@ export interface Vote_editVote {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  destructive: boolean;
   comments: Vote_editVote_comments[];
   votes: Vote_editVote_votes[];
   user: Vote_editVote_user | null;

--- a/frontend/src/graphql/fragments/EditFragment.gql
+++ b/frontend/src/graphql/fragments/EditFragment.gql
@@ -13,6 +13,7 @@ fragment EditFragment on Edit {
   created
   updated
   vote_count
+  destructive
   comments {
     ...CommentFragment
   }

--- a/graphql/schema/types/edit.graphql
+++ b/graphql/schema/types/edit.graphql
@@ -66,6 +66,8 @@ type Edit {
     votes: [EditVote!]!
     """ = Accepted - Rejected"""
     vote_count: Int!
+    """Is the edit considered destructive."""
+    destructive: Boolean!
     status: VoteStatusEnum!
     applied: Boolean!
     created: Time!

--- a/pkg/api/resolver_model_edit.go
+++ b/pkg/api/resolver_model_edit.go
@@ -311,3 +311,7 @@ func (r *editResolver) Options(ctx context.Context, obj *models.Edit) (*models.P
 	}
 	return nil, nil
 }
+
+func (r *editResolver) Destructive(ctx context.Context, obj *models.Edit) (bool, error) {
+	return obj.IsDestructive(), nil
+}

--- a/pkg/manager/cron/cron.go
+++ b/pkg/manager/cron/cron.go
@@ -35,7 +35,7 @@ func (c EditCron) processEdits() {
 	for _, e := range edits {
 		if err := c.rfp.Repo().WithTxn(func() error {
 			voteThreshold := 0
-			if e.Operation == models.OperationEnumDestroy.String() || e.Operation == models.OperationEnumMerge.String() {
+			if e.IsDestructive() {
 				// Require at least +1 votes to pass destructive edits
 				voteThreshold = 1
 			}

--- a/pkg/manager/edit/edit.go
+++ b/pkg/manager/edit/edit.go
@@ -245,7 +245,7 @@ func ResolveVotingThreshold(fac models.Repo, edit *models.Edit) (models.VoteStat
 	}
 
 	// For destructive edits we check if they've been open for a minimum period before applying
-	if edit.Operation == models.OperationEnumDestroy.String() || edit.Operation == models.OperationEnumMerge.String() {
+	if edit.IsDestructive() {
 		if time.Since(edit.CreatedAt.Timestamp).Seconds() <= float64(config.GetMinDestructiveVotingPeriod()) {
 			return models.VoteStatusEnumPending, nil
 		}

--- a/pkg/models/model_edit.go
+++ b/pkg/models/model_edit.go
@@ -161,6 +161,13 @@ func (e *Edit) GetSceneData() (*SceneEditData, error) {
 	return &data, nil
 }
 
+func (e *Edit) IsDestructive() bool {
+	if e.Operation == OperationEnumDestroy.String() || e.Operation == OperationEnumMerge.String() {
+		return true
+	}
+	return false
+}
+
 type Edits []*Edit
 
 func (p Edits) Each(fn func(interface{})) {


### PR DESCRIPTION
- I noticed the UI did not display the correct expiration time for destructive edits.
Making it a field makes it easy to update the conditions that label an edit as destructive.
(I was considering labelling performer renames as destructive when I noticed the issue)

- `ScenesList` sort order selector was wider than needed.