### PR TITLE
Refactor edit diffing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@types/react-router-dom": "^5.1.8",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "@vitejs/plugin-react": "1.0.5",
+    "@vitejs/plugin-react": "^1.1.1",
     "apollo": "^2.33.9",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-typescript": "^16.0.0",

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -94,7 +94,7 @@ const Login: FC = () => {
               </Link>
             </div>
           </Col>
-          <Col xs={3} className="d-flex justify-content-end pr-0">
+          <Col xs={3} className="d-flex justify-content-end">
             <div>
               <Button type="submit" className="login-button" disabled={loading}>
                 Login

--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -3,16 +3,16 @@ import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
 
 import {
   Edits_queryEdits_edits_details as Details,
-  Edits_queryEdits_edits_details_PerformerEdit as PerformerDetails,
-  Edits_queryEdits_edits_details_StudioEdit as StudioDetails,
-  Edits_queryEdits_edits_details_TagEdit as TagDetails,
   Edits_queryEdits_edits_old_details as OldDetails,
-  Edits_queryEdits_edits_old_details_PerformerEdit as OldPerformerDetails,
-  Edits_queryEdits_edits_old_details_StudioEdit as OldStudioDetails,
-  Edits_queryEdits_edits_old_details_TagEdit as OldTagDetails,
   Edits_queryEdits_edits_options as Options,
 } from "src/graphql/definitions/Edits";
-import { FingerprintAlgorithm, PerformerFragment } from "src/graphql";
+import {
+  FingerprintAlgorithm,
+  PerformerFragment,
+  GenderEnum,
+  EthnicityEnum,
+  BreastTypeEnum,
+} from "src/graphql";
 import {
   formatDuration,
   getCountryByISO,
@@ -37,9 +37,17 @@ import LinkedChangeRow from "../linkedChangeRow";
 import ListChangeRow from "../listChangeRow";
 import { renderPerformer, renderTag, renderFingerprint } from "./renderEntity";
 
+export interface TagDetails {
+  name: string | null;
+  description?: string | null;
+  category: { id: string; name: string } | null;
+  added_aliases?: string[] | null;
+  removed_aliases?: string[] | null;
+}
+
 const renderTagDetails = (
   tagDetails: TagDetails,
-  oldTagDetails: OldTagDetails | undefined,
+  oldTagDetails: TagDetails | undefined,
   showDiff: boolean
 ) => (
   <>
@@ -82,9 +90,47 @@ const renderTagDetails = (
   </>
 );
 
-const renderPerformerDetails = (
+type BodyMod = {
+  location: string;
+  description: string | null;
+};
+
+type Image = {
+  id: string;
+  url: string;
+};
+
+export interface PerformerDetails {
+  name: string | null;
+  gender?: GenderEnum | null;
+  disambiguation?: string | null;
+  birthdate?: string | null;
+  birthdate_accuracy?: string | null;
+  career_start_year?: number | null;
+  career_end_year?: number | null;
+  height?: number | null;
+  band_size?: number | null;
+  cup_size?: string | null;
+  waist_size?: number | null;
+  hip_size?: number | null;
+  breast_type?: BreastTypeEnum | null;
+  country?: string | null;
+  ethnicity?: EthnicityEnum | null;
+  eye_color?: string | null;
+  hair_color?: string | null;
+  added_tattoos?: BodyMod[] | null;
+  removed_tattoos?: BodyMod[] | null;
+  added_piercings?: BodyMod[] | null;
+  removed_piercings?: BodyMod[] | null;
+  added_aliases?: string[] | null;
+  removed_aliases?: string[] | null;
+  added_images?: Image[] | null;
+  removed_images?: Image[] | null;
+}
+
+export const renderPerformerDetails = (
   performerDetails: PerformerDetails,
-  oldPerformerDetails: OldPerformerDetails | undefined,
+  oldPerformerDetails: PerformerDetails | undefined,
   showDiff: boolean,
   setModifyAliases = false
 ) => (
@@ -209,27 +255,27 @@ const renderPerformerDetails = (
     />
     <ChangeRow
       name="Tattoos"
-      newValue={(performerDetails?.added_tattoos ?? [])
+      newValue={(performerDetails.added_tattoos ?? [])
         .map(formatBodyModification)
         .join("\n")}
-      oldValue={(performerDetails?.removed_tattoos ?? [])
+      oldValue={(performerDetails.removed_tattoos ?? [])
         .map(formatBodyModification)
         .join("\n")}
       showDiff={showDiff}
     />
     <ChangeRow
       name="Piercings"
-      newValue={(performerDetails?.added_piercings ?? [])
+      newValue={(performerDetails.added_piercings ?? [])
         .map(formatBodyModification)
         .join("\n")}
-      oldValue={(performerDetails?.removed_piercings ?? [])
+      oldValue={(performerDetails.removed_piercings ?? [])
         .map(formatBodyModification)
         .join("\n")}
       showDiff={showDiff}
     />
     <ImageChangeRow
-      newImages={performerDetails?.added_images}
-      oldImages={performerDetails?.removed_images}
+      newImages={performerDetails.added_images}
+      oldImages={performerDetails.removed_images}
       showDiff={showDiff}
     />
   </>
@@ -243,6 +289,11 @@ type ScenePerformance = {
   >;
 };
 
+interface URL {
+  url: string;
+  type: string;
+}
+
 export interface SceneDetails {
   title: string | null;
   date: string | null;
@@ -255,30 +306,10 @@ export interface SceneDetails {
   } | null;
   added_performers?: ScenePerformance[] | null;
   removed_performers?: ScenePerformance[] | null;
-  added_images?:
-    | {
-        id: string;
-        url: string;
-      }[]
-    | null;
-  removed_images?:
-    | {
-        id: string;
-        url: string;
-      }[]
-    | null;
-  added_urls?:
-    | {
-        type: string;
-        url: string;
-      }[]
-    | null;
-  removed_urls?:
-    | {
-        type: string;
-        url: string;
-      }[]
-    | null;
+  added_images?: Image[] | null;
+  removed_images?: Image[] | null;
+  added_urls?: URL[] | null;
+  removed_urls?: URL[] | null;
   added_tags?:
     | {
         id: string;
@@ -394,9 +425,21 @@ export const renderSceneDetails = (
   </>
 );
 
-const renderStudioDetails = (
+export interface StudioDetails {
+  name: string | null;
+  parent: {
+    id: string;
+    name: string;
+  } | null;
+  added_images?: Image[] | null;
+  removed_images?: Image[] | null;
+  added_urls?: URL[] | null;
+  removed_urls?: URL[] | null;
+}
+
+export const renderStudioDetails = (
   studioDetails: StudioDetails,
-  oldStudioDetails: OldStudioDetails | undefined,
+  oldStudioDetails: StudioDetails | undefined,
   showDiff: boolean
 ) => (
   <>
@@ -424,8 +467,8 @@ const renderStudioDetails = (
       showDiff={showDiff}
     />
     <ImageChangeRow
-      newImages={studioDetails?.added_images}
-      oldImages={studioDetails?.removed_images}
+      newImages={studioDetails.added_images}
+      oldImages={studioDetails.removed_images}
       showDiff={showDiff}
     />
   </>

--- a/frontend/src/components/studioSelect/StudioSelect.tsx
+++ b/frontend/src/components/studioSelect/StudioSelect.tsx
@@ -90,12 +90,15 @@ const StudioSelect: FC<StudioSelectProps> = ({
       <Controller
         name="studio"
         control={control}
-        defaultValue={initialStudio?.id ?? null}
+        defaultValue={defaultValue}
+        rules={{ validate: () => true }}
         render={({ field: { onChange } }) => (
           <Async
             classNamePrefix="react-select"
             className={`react-select ${CLASSNAME_SELECT}`}
-            onChange={(s) => onChange({ id: s?.value, name: s?.label })}
+            onChange={(s) =>
+              onChange(s ? { id: s.value, name: s.label } : undefined)
+            }
             defaultValue={defaultValue}
             loadOptions={debouncedLoad}
             placeholder="Search for studio"

--- a/frontend/src/graphql/definitions/ActivateNewUser.ts
+++ b/frontend/src/graphql/definitions/ActivateNewUser.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { ActivateNewUserInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ActivateNewUser
 // ====================================================
-
 
 export interface ActivateNewUser_activateNewUser {
   __typename: "User";

--- a/frontend/src/graphql/definitions/AddImage.ts
+++ b/frontend/src/graphql/definitions/AddImage.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { ImageCreateInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AddImage
 // ====================================================
-
 
 export interface AddImage_imageCreate {
   __typename: "Image";

--- a/frontend/src/graphql/definitions/AddScene.ts
+++ b/frontend/src/graphql/definitions/AddScene.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { SceneCreateInput, GenderEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AddScene
 // ====================================================
-
 
 export interface AddScene_sceneCreate_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/AddStudio.ts
+++ b/frontend/src/graphql/definitions/AddStudio.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { StudioCreateInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AddStudio
 // ====================================================
-
 
 export interface AddStudio_studioCreate_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/AddTagCategory.ts
+++ b/frontend/src/graphql/definitions/AddTagCategory.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagCategoryCreateInput, TagGroupEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AddTagCategory
 // ====================================================
-
 
 export interface AddTagCategory_tagCategoryCreate {
   __typename: "TagCategory";

--- a/frontend/src/graphql/definitions/AddUser.ts
+++ b/frontend/src/graphql/definitions/AddUser.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { UserCreateInput, RoleEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AddUser
 // ====================================================
-
 
 export interface AddUser_userCreate {
   __typename: "User";

--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { ApplyEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ApplyEdit
 // ====================================================
-
 
 export interface ApplyEdit_applyEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/CancelEdit.ts
+++ b/frontend/src/graphql/definitions/CancelEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { CancelEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CancelEdit
 // ====================================================
-
 
 export interface CancelEdit_cancelEdit_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/Categories.ts
+++ b/frontend/src/graphql/definitions/Categories.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, TagGroupEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Categories
 // ====================================================
-
 
 export interface Categories_queryTagCategories_tag_categories {
   __typename: "TagCategory";

--- a/frontend/src/graphql/definitions/Category.ts
+++ b/frontend/src/graphql/definitions/Category.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagGroupEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Category
 // ====================================================
-
 
 export interface Category_findTagCategory {
   __typename: "TagCategory";
@@ -21,7 +19,7 @@ export interface Category_findTagCategory {
 
 export interface Category {
   /**
-   * Find a tag cateogry by ID
+   * Find a tag category by ID
    */
   findTagCategory: Category_findTagCategory | null;
 }

--- a/frontend/src/graphql/definitions/ChangePassword.ts
+++ b/frontend/src/graphql/definitions/ChangePassword.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { UserChangePasswordInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ChangePassword
 // ====================================================
-
 
 export interface ChangePassword {
   /**

--- a/frontend/src/graphql/definitions/CommentFragment.ts
+++ b/frontend/src/graphql/definitions/CommentFragment.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL fragment: CommentFragment
 // ====================================================
-
 
 export interface CommentFragment_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/Config.ts
+++ b/frontend/src/graphql/definitions/Config.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL query operation: Config
 // ====================================================
-
 
 export interface Config_getConfig {
   __typename: "StashBoxConfig";

--- a/frontend/src/graphql/definitions/DeleteScene.ts
+++ b/frontend/src/graphql/definitions/DeleteScene.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { SceneDestroyInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: DeleteScene
 // ====================================================
-
 
 export interface DeleteScene {
   sceneDestroy: boolean;

--- a/frontend/src/graphql/definitions/DeleteStudio.ts
+++ b/frontend/src/graphql/definitions/DeleteStudio.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { StudioDestroyInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: DeleteStudio
 // ====================================================
-
 
 export interface DeleteStudio {
   studioDestroy: boolean;

--- a/frontend/src/graphql/definitions/DeleteTagCategory.ts
+++ b/frontend/src/graphql/definitions/DeleteTagCategory.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagCategoryDestroyInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: DeleteTagCategory
 // ====================================================
-
 
 export interface DeleteTagCategory {
   tagCategoryDestroy: boolean;

--- a/frontend/src/graphql/definitions/DeleteUser.ts
+++ b/frontend/src/graphql/definitions/DeleteUser.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { UserDestroyInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: DeleteUser
 // ====================================================
-
 
 export interface DeleteUser {
   userDestroy: boolean;

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Edit
 // ====================================================
-
 
 export interface Edit_findEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/EditComment.ts
+++ b/frontend/src/graphql/definitions/EditComment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { EditCommentInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: EditComment
 // ====================================================
-
 
 export interface EditComment_editComment_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: EditFragment
 // ====================================================
-
 
 export interface EditFragment_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, EditFilterType, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Edits
 // ====================================================
-
 
 export interface Edits_queryEdits_edits_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/FullPerformer.ts
+++ b/frontend/src/graphql/definitions/FullPerformer.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: FullPerformer
 // ====================================================
-
 
 export interface FullPerformer_findPerformer_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/GenerateInviteCode.ts
+++ b/frontend/src/graphql/definitions/GenerateInviteCode.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL mutation operation: GenerateInviteCode
 // ====================================================
-
 
 export interface GenerateInviteCode {
   /**

--- a/frontend/src/graphql/definitions/GrantInvite.ts
+++ b/frontend/src/graphql/definitions/GrantInvite.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GrantInviteInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: GrantInvite
 // ====================================================
-
 
 export interface GrantInvite {
   /**

--- a/frontend/src/graphql/definitions/Me.ts
+++ b/frontend/src/graphql/definitions/Me.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { RoleEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Me
 // ====================================================
-
 
 export interface Me_me {
   __typename: "User";

--- a/frontend/src/graphql/definitions/NewUser.ts
+++ b/frontend/src/graphql/definitions/NewUser.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { NewUserInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: NewUser
 // ====================================================
-
 
 export interface NewUser {
   /**

--- a/frontend/src/graphql/definitions/PendingEditsCount.ts
+++ b/frontend/src/graphql/definitions/PendingEditsCount.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TargetTypeEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: PendingEditsCount
 // ====================================================
-
 
 export interface PendingEditsCount_queryEdits {
   __typename: "QueryEditsResultType";

--- a/frontend/src/graphql/definitions/Performer.ts
+++ b/frontend/src/graphql/definitions/Performer.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Performer
 // ====================================================
-
 
 export interface Performer_findPerformer_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { PerformerEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PerformerEdit
 // ====================================================
-
 
 export interface PerformerEdit_performerEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/PerformerFragment.ts
+++ b/frontend/src/graphql/definitions/PerformerFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: PerformerFragment
 // ====================================================
-
 
 export interface PerformerFragment_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/Performers.ts
+++ b/frontend/src/graphql/definitions/Performers.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, PerformerFilterType, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Performers
 // ====================================================
-
 
 export interface Performers_queryPerformers_performers_birthdate {
   __typename: "FuzzyDate";
@@ -39,16 +37,16 @@ export interface Performers_queryPerformers_performers_piercings {
 
 export interface Performers_queryPerformers_performers_urls {
   __typename: "URL";
-  type: string;
   url: string;
+  type: string;
 }
 
 export interface Performers_queryPerformers_performers_images {
   __typename: "Image";
   id: string;
   url: string;
-  height: number;
   width: number;
+  height: number;
 }
 
 export interface Performers_queryPerformers_performers {

--- a/frontend/src/graphql/definitions/PublicUser.ts
+++ b/frontend/src/graphql/definitions/PublicUser.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL query operation: PublicUser
 // ====================================================
-
 
 export interface PublicUser_findUser_vote_count {
   __typename: "UserVoteCount";

--- a/frontend/src/graphql/definitions/QuerySceneFragment.ts
+++ b/frontend/src/graphql/definitions/QuerySceneFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: QuerySceneFragment
 // ====================================================
-
 
 export interface QuerySceneFragment_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/RegenerateAPIKey.ts
+++ b/frontend/src/graphql/definitions/RegenerateAPIKey.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL mutation operation: RegenerateAPIKey
 // ====================================================
-
 
 export interface RegenerateAPIKey {
   /**

--- a/frontend/src/graphql/definitions/RescindInviteCode.ts
+++ b/frontend/src/graphql/definitions/RescindInviteCode.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL mutation operation: RescindInviteCode
 // ====================================================
-
 
 export interface RescindInviteCode {
   /**

--- a/frontend/src/graphql/definitions/ResetPassword.ts
+++ b/frontend/src/graphql/definitions/ResetPassword.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { ResetPasswordInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ResetPassword
 // ====================================================
-
 
 export interface ResetPassword {
   /**

--- a/frontend/src/graphql/definitions/RevokeInvite.ts
+++ b/frontend/src/graphql/definitions/RevokeInvite.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { RevokeInviteInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: RevokeInvite
 // ====================================================
-
 
 export interface RevokeInvite {
   /**

--- a/frontend/src/graphql/definitions/Scene.ts
+++ b/frontend/src/graphql/definitions/Scene.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Scene
 // ====================================================
-
 
 export interface Scene_findScene_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/SceneEdit.ts
+++ b/frontend/src/graphql/definitions/SceneEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { SceneEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: SceneEdit
 // ====================================================
-
 
 export interface SceneEdit_sceneEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/SceneFragment.ts
+++ b/frontend/src/graphql/definitions/SceneFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: SceneFragment
 // ====================================================
-
 
 export interface SceneFragment_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/ScenePerformerFragment.ts
+++ b/frontend/src/graphql/definitions/ScenePerformerFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: ScenePerformerFragment
 // ====================================================
-
 
 export interface ScenePerformerFragment {
   __typename: "Performer";

--- a/frontend/src/graphql/definitions/Scenes.ts
+++ b/frontend/src/graphql/definitions/Scenes.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, SceneFilterType, GenderEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Scenes
 // ====================================================
-
 
 export interface Scenes_queryScenes_scenes_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/ScenesWithoutCount.ts
+++ b/frontend/src/graphql/definitions/ScenesWithoutCount.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, SceneFilterType, GenderEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: ScenesWithoutCount
 // ====================================================
-
 
 export interface ScenesWithoutCount_queryScenes_scenes_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/SearchAll.ts
+++ b/frontend/src/graphql/definitions/SearchAll.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchAll
 // ====================================================
-
 
 export interface SearchAll_searchPerformer_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/SearchPerformerFragment.ts
+++ b/frontend/src/graphql/definitions/SearchPerformerFragment.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: SearchPerformerFragment
 // ====================================================
-
 
 export interface SearchPerformerFragment_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/SearchPerformers.ts
+++ b/frontend/src/graphql/definitions/SearchPerformers.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { GenderEnum, DateAccuracyEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchPerformers
 // ====================================================
-
 
 export interface SearchPerformers_searchPerformer_birthdate {
   __typename: "FuzzyDate";

--- a/frontend/src/graphql/definitions/Studio.ts
+++ b/frontend/src/graphql/definitions/Studio.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL query operation: Studio
 // ====================================================
-
 
 export interface Studio_findStudio_child_studios {
   __typename: "Studio";

--- a/frontend/src/graphql/definitions/StudioEdit.ts
+++ b/frontend/src/graphql/definitions/StudioEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { StudioEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: StudioEdit
 // ====================================================
-
 
 export interface StudioEdit_studioEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/StudioFragment.ts
+++ b/frontend/src/graphql/definitions/StudioFragment.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL fragment: StudioFragment
 // ====================================================
-
 
 export interface StudioFragment_child_studios {
   __typename: "Studio";

--- a/frontend/src/graphql/definitions/Studios.ts
+++ b/frontend/src/graphql/definitions/Studios.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, StudioFilterType } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Studios
 // ====================================================
-
 
 export interface Studios_queryStudios_studios_parent {
   __typename: "Studio";
@@ -27,8 +25,8 @@ export interface Studios_queryStudios_studios_images {
   __typename: "Image";
   id: string;
   url: string;
-  height: number;
   width: number;
+  height: number;
 }
 
 export interface Studios_queryStudios_studios {

--- a/frontend/src/graphql/definitions/Tag.ts
+++ b/frontend/src/graphql/definitions/Tag.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagGroupEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Tag
 // ====================================================
-
 
 export interface Tag_findTag_category {
   __typename: "TagCategory";

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagEditInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: TagEdit
 // ====================================================
-
 
 export interface TagEdit_tagEdit_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/TagFragment.ts
+++ b/frontend/src/graphql/definitions/TagFragment.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL fragment: TagFragment
 // ====================================================
-
 
 export interface TagFragment_category {
   __typename: "TagCategory";

--- a/frontend/src/graphql/definitions/Tags.ts
+++ b/frontend/src/graphql/definitions/Tags.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { QuerySpec, TagFilterType } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Tags
 // ====================================================
-
 
 export interface Tags_queryTags_tags {
   __typename: "Tag";

--- a/frontend/src/graphql/definitions/URLFragment.ts
+++ b/frontend/src/graphql/definitions/URLFragment.ts
@@ -4,13 +4,11 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL fragment: ImageFragment
+// GraphQL fragment: URLFragment
 // ====================================================
 
-export interface ImageFragment {
-  __typename: "Image";
-  id: string;
+export interface URLFragment {
+  __typename: "URL";
   url: string;
-  width: number;
-  height: number;
+  type: string;
 }

--- a/frontend/src/graphql/definitions/UpdateScene.ts
+++ b/frontend/src/graphql/definitions/UpdateScene.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { SceneUpdateInput, GenderEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateScene
 // ====================================================
-
 
 export interface UpdateScene_sceneUpdate_urls {
   __typename: "URL";

--- a/frontend/src/graphql/definitions/UpdateStudio.ts
+++ b/frontend/src/graphql/definitions/UpdateStudio.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { StudioUpdateInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateStudio
 // ====================================================
-
 
 export interface UpdateStudio_studioUpdate_child_studios {
   __typename: "Studio";

--- a/frontend/src/graphql/definitions/UpdateTagCategory.ts
+++ b/frontend/src/graphql/definitions/UpdateTagCategory.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { TagCategoryUpdateInput, TagGroupEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateTagCategory
 // ====================================================
-
 
 export interface UpdateTagCategory_tagCategoryUpdate {
   __typename: "TagCategory";

--- a/frontend/src/graphql/definitions/UpdateUser.ts
+++ b/frontend/src/graphql/definitions/UpdateUser.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { UserUpdateInput, RoleEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateUser
 // ====================================================
-
 
 export interface UpdateUser_userUpdate {
   __typename: "User";

--- a/frontend/src/graphql/definitions/User.ts
+++ b/frontend/src/graphql/definitions/User.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { RoleEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: User
 // ====================================================
-
 
 export interface User_findUser_invited_by {
   __typename: "User";

--- a/frontend/src/graphql/definitions/Users.ts
+++ b/frontend/src/graphql/definitions/Users.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { UserFilterType, QuerySpec, RoleEnum } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Users
 // ====================================================
-
 
 export interface Users_queryUsers_users_invited_by {
   __typename: "User";

--- a/frontend/src/graphql/definitions/Version.ts
+++ b/frontend/src/graphql/definitions/Version.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 // ====================================================
 // GraphQL query operation: Version
 // ====================================================
-
 
 export interface Version_version {
   __typename: "Version";

--- a/frontend/src/graphql/definitions/Vote.ts
+++ b/frontend/src/graphql/definitions/Vote.ts
@@ -3,13 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 import { EditVoteInput, TargetTypeEnum, OperationEnum, VoteStatusEnum, VoteTypeEnum, GenderEnum, DateAccuracyEnum, HairColorEnum, EyeColorEnum, EthnicityEnum, BreastTypeEnum, FingerprintAlgorithm } from "./globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: Vote
 // ====================================================
-
 
 export interface Vote_editVote_comments_user {
   __typename: "User";

--- a/frontend/src/graphql/definitions/globalTypes.ts
+++ b/frontend/src/graphql/definitions/globalTypes.ts
@@ -3,11 +3,9 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-
 //==============================================================
 // START Enums and Input Objects
 //==============================================================
-
 
 export enum BreastTypeEnum {
   FAKE = "FAKE",
@@ -561,4 +559,3 @@ export interface UserUpdateInput {
 //==============================================================
 // END Enums and Input Objects
 //==============================================================
-

--- a/frontend/src/graphql/fragments/EditFragment.gql
+++ b/frontend/src/graphql/fragments/EditFragment.gql
@@ -4,6 +4,7 @@
 #import "../fragments/SceneFragment.gql"
 #import "../fragments/TagFragment.gql"
 #import "../fragments/CommentFragment.gql"
+#import "../fragments/URLFragment.gql"
 fragment EditFragment on Edit {
   id
   target_type
@@ -67,12 +68,10 @@ fragment EditFragment on Edit {
       removed_aliases
       gender
       added_urls {
-        url
-        type
+        ...URLFragment
       }
       removed_urls {
-        url
-        type
+        ...URLFragment
       }
       birthdate
       birthdate_accuracy
@@ -114,12 +113,10 @@ fragment EditFragment on Edit {
     ... on StudioEdit {
       name
       added_urls {
-        url
-        type
+        ...URLFragment
       }
       removed_urls {
-        url
-        type
+        ...URLFragment
       }
       parent {
         ...StudioFragment
@@ -135,12 +132,10 @@ fragment EditFragment on Edit {
       title
       details
       added_urls {
-        url
-        type
+        ...URLFragment
       }
       removed_urls {
-        url
-        type
+        ...URLFragment
       }
       date
       studio {
@@ -212,12 +207,10 @@ fragment EditFragment on Edit {
       title
       details
       added_urls {
-        url
-        type
+        ...URLFragment
       }
       removed_urls {
-        url
-        type
+        ...URLFragment
       }
       date
       studio {

--- a/frontend/src/graphql/fragments/PerformerFragment.gql
+++ b/frontend/src/graphql/fragments/PerformerFragment.gql
@@ -1,4 +1,5 @@
 #import "../fragments/ImageFragment.gql"
+#import "../fragments/URLFragment.gql"
 fragment PerformerFragment on Performer {
   id
   name
@@ -34,8 +35,7 @@ fragment PerformerFragment on Performer {
     description
   }
   urls {
-      url
-      type
+    ...URLFragment
   }
   images {
     ... ImageFragment

--- a/frontend/src/graphql/fragments/QuerySceneFragment.gql
+++ b/frontend/src/graphql/fragments/QuerySceneFragment.gql
@@ -1,3 +1,4 @@
+#import "../fragments/URLFragment.gql"
 #import "../fragments/ImageFragment.gql"
 #import "../fragments/ScenePerformerFragment.gql"
 fragment QuerySceneFragment on Scene {
@@ -6,8 +7,7 @@ fragment QuerySceneFragment on Scene {
   title
   duration
   urls {
-    url
-    type
+    ...URLFragment
   }
   images {
     ...ImageFragment

--- a/frontend/src/graphql/fragments/SceneFragment.gql
+++ b/frontend/src/graphql/fragments/SceneFragment.gql
@@ -1,5 +1,6 @@
 #import "../fragments/ImageFragment.gql"
 #import "../fragments/ScenePerformerFragment.gql"
+#import "../fragments/URLFragment.gql"
 fragment SceneFragment on Scene {
   id
   date
@@ -9,8 +10,7 @@ fragment SceneFragment on Scene {
   director
   duration
   urls {
-    url
-    type
+    ...URLFragment
   }
   images {
     ...ImageFragment

--- a/frontend/src/graphql/fragments/SearchPerformerFragment.gql
+++ b/frontend/src/graphql/fragments/SearchPerformerFragment.gql
@@ -1,4 +1,5 @@
 #import "../fragments/ImageFragment.gql"
+#import "../fragments/URLFragment.gql"
 fragment SearchPerformerFragment on Performer {
   id
   name
@@ -15,10 +16,9 @@ fragment SearchPerformerFragment on Performer {
     accuracy
   }
   urls {
-    url
-    type
+    ...URLFragment
   }
   images {
-    ... ImageFragment
+    ...ImageFragment
   }
 }

--- a/frontend/src/graphql/fragments/StudioFragment.gql
+++ b/frontend/src/graphql/fragments/StudioFragment.gql
@@ -1,3 +1,4 @@
+#import "../fragments/URLFragment.gql"
 fragment StudioFragment on Studio {
     id
     name
@@ -10,8 +11,7 @@ fragment StudioFragment on Studio {
       name
     }
     urls {
-        url
-        type
+      ...URLFragment
     }
     images {
         id

--- a/frontend/src/graphql/fragments/URLFragment.gql
+++ b/frontend/src/graphql/fragments/URLFragment.gql
@@ -1,0 +1,4 @@
+fragment URLFragment on URL {
+  url
+  type
+}

--- a/frontend/src/graphql/queries/Performers.gql
+++ b/frontend/src/graphql/queries/Performers.gql
@@ -1,3 +1,5 @@
+#import "../fragments/URLFragment.gql"
+#import "../fragments/ImageFragment.gql"
 query Performers($filter: QuerySpec, $performerFilter: PerformerFilterType) {
   queryPerformers(filter: $filter, performer_filter: $performerFilter) {
     count
@@ -36,14 +38,10 @@ query Performers($filter: QuerySpec, $performerFilter: PerformerFilterType) {
         description
       }
       urls {
-          type
-          url
+        ...URLFragment
       }
       images {
-          id
-          url
-          height
-          width
+        ...ImageFragment
       }
     }
   }

--- a/frontend/src/graphql/queries/SearchAll.gql
+++ b/frontend/src/graphql/queries/SearchAll.gql
@@ -1,5 +1,6 @@
 #import "../fragments/ImageFragment.gql"
 #import "../fragments/SearchPerformerFragment.gql"
+#import "../fragments/URLFragment.gql"
 query SearchAll($term: String!, $limit: Int = 5) {
     searchPerformer(term: $term, limit: $limit) {
       ...SearchPerformerFragment
@@ -10,8 +11,7 @@ query SearchAll($term: String!, $limit: Int = 5) {
         title
         duration
         urls {
-            url
-            type
+          ...URLFragment
         }
         images {
           ...ImageFragment

--- a/frontend/src/graphql/queries/Studios.gql
+++ b/frontend/src/graphql/queries/Studios.gql
@@ -1,3 +1,5 @@
+#import "../fragments/URLFragment.gql"
+#import "../fragments/ImageFragment.gql"
 query Studios($filter: QuerySpec, $studioFilter: StudioFilterType) {
   queryStudios(filter: $filter, studio_filter: $studioFilter) {
       count
@@ -9,14 +11,10 @@ query Studios($filter: QuerySpec, $studioFilter: StudioFilterType) {
             name
         }
         urls {
-            url
-            type
+          ...URLFragment
         }
         images {
-            id
-            url
-            height
-            width
+          ...ImageFragment
         }
       }
   }

--- a/frontend/src/pages/activateUser/ActivateUser.tsx
+++ b/frontend/src/pages/activateUser/ActivateUser.tsx
@@ -109,7 +109,7 @@ const ActivateNewUserPage: FC = () => {
           </div>
         </label>
         <div className="row">
-          <div className="col-3 offset-9 d-flex justify-content-end pr-0">
+          <div className="col-3 offset-9 d-flex justify-content-end">
             <div>
               <button type="submit" className="register-button btn btn-primary">
                 Create Account

--- a/frontend/src/pages/forgotPassword/ForgotPassword.tsx
+++ b/frontend/src/pages/forgotPassword/ForgotPassword.tsx
@@ -81,7 +81,7 @@ const ForgotPassword: FC = () => {
           <div className="invalid-feedback">{errors?.email?.message}</div>
         </label>
         <div className="row">
-          <div className="col-3 offset-9 d-flex justify-content-end pr-0">
+          <div className="col-3 offset-9 d-flex justify-content-end">
             <div>
               <button
                 type="submit"

--- a/frontend/src/pages/performers/PerformerEdit.tsx
+++ b/frontend/src/pages/performers/PerformerEdit.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { FullPerformer_findPerformer as Performer } from "src/graphql/definitions/FullPerformer";
@@ -17,11 +17,14 @@ interface Props {
 
 const PerformerModify: FC<Props> = ({ performer }) => {
   const history = useHistory();
+  const [submissionError, setSubmissionError] = useState("");
   const [submitPerformerEdit, { loading: saving }] = usePerformerEdit({
     onCompleted: (editData) => {
+      if (submissionError) setSubmissionError("");
       if (editData.performerEdit.id)
         history.push(editHref(editData.performerEdit));
     },
+    onError: (error) => setSubmissionError(error.message),
   });
 
   const doUpdate = (
@@ -61,6 +64,11 @@ const PerformerModify: FC<Props> = ({ performer }) => {
         changeType="modify"
         saving={saving}
       />
+      {submissionError && (
+        <div className="text-danger text-end col-9">
+          Error: {submissionError}
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useForm, Controller } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -19,14 +19,14 @@ import {
   DateAccuracyEnum,
   PerformerEditDetailsInput,
 } from "src/graphql";
-import { getBraSize, formatFuzzyDate } from "src/utils";
+import { getBraSize, parseBraSize, formatFuzzyDate } from "src/utils";
 import { Performer_findPerformer as Performer } from "src/graphql/definitions/Performer";
 import { Image } from "src/utils/transforms";
 
+import { renderPerformerDetails } from "src/components/editCard/ModifyEdit";
 import { Help } from "src/components/fragments";
 import { BodyModification, EditNote } from "src/components/form";
 import MultiSelect from "src/components/multiSelect";
-import ChangeRow from "src/components/changeRow";
 import EditImages from "src/components/editImages";
 import DiffPerformer from "./diff";
 
@@ -226,7 +226,6 @@ const PerformerForm: FC<PerformerProps> = ({
   callback,
   initialAliases = [],
   initialImages = [],
-  changeType,
   saving,
 }) => {
   const images = uniqBy([...performer.images, ...initialImages], (i) => i.id);
@@ -241,6 +240,7 @@ const PerformerForm: FC<PerformerProps> = ({
     control,
     handleSubmit,
     watch,
+    setValue,
     formState: { errors },
   } = useForm<PerformerFormData>({
     resolver: yupResolver(schema),
@@ -258,11 +258,19 @@ const PerformerForm: FC<PerformerProps> = ({
   const [file, setFile] = useState<File | undefined>();
 
   const fieldData = watch();
-  const changes = useMemo(
-    () => DiffPerformer(performer, schema.cast(fieldData)),
+  const [oldChanges, newChanges] = useMemo(
+    () => DiffPerformer(schema.cast(fieldData), performer),
     [fieldData, performer]
   );
   const history = useHistory();
+
+  const showBreastType =
+    fieldData.gender !== GenderEnum.MALE &&
+    fieldData.gender !== GenderEnum.TRANSGENDER_MALE;
+  // Update breast type based on gender
+  useEffect(() => {
+    if (!showBreastType) setValue("boobJob", BreastTypeEnum.NA);
+  }, [showBreastType, setValue]);
 
   const enumOptions = (enums: OptionEnum[]) =>
     enums.map((obj) => (
@@ -301,15 +309,8 @@ const PerformerForm: FC<PerformerProps> = ({
       hip: data.hipSize ?? null,
     };
     if (data.braSize != null) {
-      const band = /^\d+/.exec(data.braSize)?.[0];
-      const bandSize = band ? Number.parseInt(band, 10) : null;
-      const cup = bandSize
-        ? data.braSize.replace(bandSize.toString(), "")
-        : null;
-      const braSize = cup
-        ? /^[a-zA-Z]+/.exec(cup)?.[0]?.toUpperCase() ?? null
-        : null;
-      performerData.measurements.cup_size = braSize;
+      const [cupSize, bandSize] = parseBraSize(data.braSize);
+      performerData.measurements.cup_size = cupSize;
       performerData.measurements.band_size = bandSize ?? 0;
     }
 
@@ -544,53 +545,52 @@ const PerformerForm: FC<PerformerProps> = ({
               )}
           </Row>
 
-          {fieldData.gender !== GenderEnum.MALE &&
-            fieldData.gender !== GenderEnum.TRANSGENDER_MALE && (
-              <Row>
-                <Form.Group controlId="braSize" className="col-4 mb-3">
-                  <Form.Label>Bra size</Form.Label>
-                  <Form.Control
-                    className={cx({ "is-invalid": errors.braSize })}
-                    defaultValue={getBraSize(performer.measurements)}
-                    {...register("braSize", {
-                      pattern: /\d{2,3}[a-zA-Z]{1,4}/i,
-                    })}
-                  />
-                  <Form.Control.Feedback type="invalid">
-                    {errors?.braSize?.message}
-                  </Form.Control.Feedback>
-                  <Form.Text>US Bra Size</Form.Text>
-                </Form.Group>
+          {showBreastType && (
+            <Row>
+              <Form.Group controlId="braSize" className="col-4 mb-3">
+                <Form.Label>Bra size</Form.Label>
+                <Form.Control
+                  className={cx({ "is-invalid": errors.braSize })}
+                  defaultValue={getBraSize(performer.measurements)}
+                  {...register("braSize", {
+                    pattern: /\d{2,3}[a-zA-Z]{1,4}/i,
+                  })}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {errors?.braSize?.message}
+                </Form.Control.Feedback>
+                <Form.Text>US Bra Size</Form.Text>
+              </Form.Group>
 
-                <Form.Group controlId="waistSize" className="col-4 mb-3">
-                  <Form.Label>Waist size</Form.Label>
-                  <Form.Control
-                    className={cx({ "is-invalid": errors.waistSize })}
-                    type="number"
-                    defaultValue={performer.measurements.waist ?? ""}
-                    {...register("waistSize")}
-                  />
-                  <Form.Control.Feedback type="invalid">
-                    {errors?.waistSize?.message}
-                  </Form.Control.Feedback>
-                  <Form.Text>Waist circumference in inches</Form.Text>
-                </Form.Group>
+              <Form.Group controlId="waistSize" className="col-4 mb-3">
+                <Form.Label>Waist size</Form.Label>
+                <Form.Control
+                  className={cx({ "is-invalid": errors.waistSize })}
+                  type="number"
+                  defaultValue={performer.measurements.waist ?? ""}
+                  {...register("waistSize")}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {errors?.waistSize?.message}
+                </Form.Control.Feedback>
+                <Form.Text>Waist circumference in inches</Form.Text>
+              </Form.Group>
 
-                <Form.Group controlId="hipSize" className="col-4 mb-3">
-                  <Form.Label>Hip size</Form.Label>
-                  <Form.Control
-                    className={cx({ "is-invalid": errors.hipSize })}
-                    type="number"
-                    defaultValue={performer.measurements.hip ?? ""}
-                    {...register("hipSize")}
-                  />
-                  <Form.Control.Feedback type="invalid">
-                    {errors?.hipSize?.message}
-                  </Form.Control.Feedback>
-                  <Form.Text>Hip circumference in inches</Form.Text>
-                </Form.Group>
-              </Row>
-            )}
+              <Form.Group controlId="hipSize" className="col-4 mb-3">
+                <Form.Label>Hip size</Form.Label>
+                <Form.Control
+                  className={cx({ "is-invalid": errors.hipSize })}
+                  type="number"
+                  defaultValue={performer.measurements.hip ?? ""}
+                  {...register("hipSize")}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {errors?.hipSize?.message}
+                </Form.Control.Feedback>
+                <Form.Text>Hip circumference in inches</Form.Text>
+              </Form.Group>
+            </Row>
+          )}
 
           <Row>
             <Form.Group controlId="country" className="col-6 mb-3">
@@ -767,17 +767,8 @@ const PerformerForm: FC<PerformerProps> = ({
           </div>
         </Tab>
 
-        <Tab eventKey="confirm" title="Confirm" className="mt-2 col-xl-9">
-          {changes.length > 0 && (
-            <Row>
-              <h6 className="col-5 offset-2">Remove</h6>
-              <h6 className="col-5">Add</h6>
-            </Row>
-          )}
-          {changes.length === 0 && <h6>No changes.</h6>}
-          {changes.map((c) => (
-            <ChangeRow {...c} key={c.name} />
-          ))}
+        <Tab eventKey="confirm" title="Confirm" className="mt-3 col-xl-9">
+          {renderPerformerDetails(newChanges, oldChanges, true, updateAliases)}
           <Row className="my-4">
             <Col md={{ span: 8, offset: 4 }}>
               <EditNote register={register} error={errors.note} />
@@ -797,12 +788,7 @@ const PerformerForm: FC<PerformerProps> = ({
               className="d-none"
               aria-hidden="true"
             />
-            <Button
-              type="submit"
-              disabled={
-                (changes.length === 0 && changeType !== "merge") || saving
-              }
-            >
+            <Button type="submit" disabled={!!file || saving}>
               Submit Edit
             </Button>
           </div>

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -4,7 +4,6 @@ import { useForm, Controller } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Select from "react-select";
 import { Button, Col, Form, Row, Tabs, Tab } from "react-bootstrap";
-import * as yup from "yup";
 import Countries from "i18n-iso-countries";
 import english from "i18n-iso-countries/langs/en.json";
 import cx from "classnames";
@@ -29,6 +28,7 @@ import { BodyModification, EditNote } from "src/components/form";
 import MultiSelect from "src/components/multiSelect";
 import EditImages from "src/components/editImages";
 import DiffPerformer from "./diff";
+import { PerformerSchema, PerformerFormData } from "./schema";
 
 Countries.registerLocale(english);
 const CountryList = Countries.getNames("en");
@@ -99,114 +99,6 @@ const getEnumValue = (enumArray: OptionEnum[], val: string) => {
   return val;
 };
 
-const nullCheck = (input: string | null) =>
-  input === "" || input === "null" ? null : input;
-const zeroCheck = (input: number | null) =>
-  input === 0 || Number.isNaN(input) ? null : input;
-
-const schema = yup.object({
-  id: yup.string(),
-  name: yup.string().required("Name is required"),
-  gender: yup
-    .string()
-    .transform(nullCheck)
-    .nullable()
-    .oneOf([null, ...Object.keys(GenderEnum)], "Invalid gender"),
-  disambiguation: yup.string().trim().transform(nullCheck).nullable(),
-  birthdate: yup
-    .string()
-    .defined()
-    .transform(nullCheck)
-    .matches(/^\d{4}$|^\d{4}-\d{2}$|^\d{4}-\d{2}-\d{2}$/, {
-      excludeEmptyString: true,
-      message: "Invalid date, must be YYYY, YYYY-MM, or YYYY-MM-DD",
-    })
-    .nullable(),
-  career_start_year: yup
-    .number()
-    .transform(zeroCheck)
-    .nullable()
-    .min(1950, "Invalid year")
-    .max(new Date().getFullYear(), "Invalid year"),
-  career_end_year: yup
-    .number()
-    .transform(zeroCheck)
-    .min(1950, "Invalid year")
-    .max(new Date().getFullYear(), "Invalid year")
-    .nullable(),
-  height: yup
-    .number()
-    .transform(zeroCheck)
-    .min(100, "Invalid height, Height must be in centimeters.")
-    .max(230, "Invalid height")
-    .nullable(),
-  braSize: yup
-    .string()
-    .transform(nullCheck)
-    .matches(
-      /\d{2,3}[a-zA-Z]{1,4}/,
-      "Invalid cup size. Only american sizes are accepted."
-    )
-    .nullable(),
-  waistSize: yup
-    .number()
-    .transform(zeroCheck)
-    .min(15, "Invalid waist size")
-    .max(50, "Invalid waist size")
-    .nullable(),
-  hipSize: yup.number().transform(zeroCheck).nullable(),
-  boobJob: yup
-    .string()
-    .transform(nullCheck)
-    .nullable()
-    .oneOf([...Object.keys(BreastTypeEnum), null], "Invalid breast type"),
-  country: yup.string().trim().transform(nullCheck).nullable().defined(),
-  ethnicity: yup
-    .string()
-    .transform(nullCheck)
-    .nullable()
-    .oneOf([...Object.keys(EthnicityEnum), null], "Invalid ethnicity"),
-  eye_color: yup
-    .string()
-    .transform(nullCheck)
-    .nullable()
-    .oneOf([null, ...Object.keys(EyeColorEnum)], "Invalid eye color"),
-  hair_color: yup
-    .string()
-    .transform(nullCheck)
-    .nullable()
-    .oneOf([null, ...Object.keys(HairColorEnum)], "Invalid hair color"),
-  tattoos: yup.array().of(
-    yup.object({
-      location: yup.string().trim().required("Location is required"),
-      description: yup.string().trim().transform(nullCheck).nullable(),
-    })
-  ),
-  piercings: yup.array().of(
-    yup.object({
-      location: yup.string().trim().required("Location is required"),
-      description: yup.string().trim().transform(nullCheck).nullable(),
-    })
-  ),
-  aliases: yup
-    .array()
-    .of(yup.string().trim().transform(nullCheck).required())
-    .required(),
-  images: yup
-    .array()
-    .of(
-      yup.object({
-        id: yup.string().required(),
-        url: yup.string().required(),
-      })
-    )
-    .required(),
-  note: yup.string().required("Edit note is required"),
-});
-
-export type PerformerFormData = yup.Asserts<typeof schema>;
-export type CastedPerformerFormData = yup.TypeOf<typeof schema>;
-
 interface PerformerProps {
   performer: Performer;
   callback: (
@@ -243,7 +135,7 @@ const PerformerForm: FC<PerformerProps> = ({
     setValue,
     formState: { errors },
   } = useForm<PerformerFormData>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(PerformerSchema),
     mode: "onBlur",
     defaultValues: {
       tattoos,
@@ -259,7 +151,7 @@ const PerformerForm: FC<PerformerProps> = ({
 
   const fieldData = watch();
   const [oldChanges, newChanges] = useMemo(
-    () => DiffPerformer(schema.cast(fieldData), performer),
+    () => DiffPerformer(PerformerSchema.cast(fieldData), performer),
     [fieldData, performer]
   );
   const history = useHistory();

--- a/frontend/src/pages/performers/performerForm/diff.ts
+++ b/frontend/src/pages/performers/performerForm/diff.ts
@@ -12,7 +12,7 @@ import {
   parseBraSize,
 } from "src/utils";
 
-import { CastedPerformerFormData } from "./PerformerForm";
+import { CastedPerformerFormData } from "./schema";
 
 const diffBodyMods = (
   newMods:

--- a/frontend/src/pages/performers/performerForm/schema.ts
+++ b/frontend/src/pages/performers/performerForm/schema.ts
@@ -1,0 +1,117 @@
+import * as yup from "yup";
+
+import {
+  GenderEnum,
+  HairColorEnum,
+  EyeColorEnum,
+  BreastTypeEnum,
+  EthnicityEnum,
+} from "src/graphql";
+
+const nullCheck = (input: string | null) =>
+  input === "" || input === "null" ? null : input;
+const zeroCheck = (input: number | null) =>
+  input === 0 || Number.isNaN(input) ? null : input;
+
+export const PerformerSchema = yup.object({
+  id: yup.string(),
+  name: yup.string().required("Name is required"),
+  gender: yup
+    .string()
+    .transform(nullCheck)
+    .nullable()
+    .oneOf([null, ...Object.keys(GenderEnum)], "Invalid gender"),
+  disambiguation: yup.string().trim().transform(nullCheck).nullable(),
+  birthdate: yup
+    .string()
+    .defined()
+    .transform(nullCheck)
+    .matches(/^\d{4}$|^\d{4}-\d{2}$|^\d{4}-\d{2}-\d{2}$/, {
+      excludeEmptyString: true,
+      message: "Invalid date, must be YYYY, YYYY-MM, or YYYY-MM-DD",
+    })
+    .nullable(),
+  career_start_year: yup
+    .number()
+    .transform(zeroCheck)
+    .nullable()
+    .min(1950, "Invalid year")
+    .max(new Date().getFullYear(), "Invalid year"),
+  career_end_year: yup
+    .number()
+    .transform(zeroCheck)
+    .min(1950, "Invalid year")
+    .max(new Date().getFullYear(), "Invalid year")
+    .nullable(),
+  height: yup
+    .number()
+    .transform(zeroCheck)
+    .min(100, "Invalid height, Height must be in centimeters.")
+    .max(230, "Invalid height")
+    .nullable(),
+  braSize: yup
+    .string()
+    .transform(nullCheck)
+    .matches(
+      /\d{2,3}[a-zA-Z]{1,4}/,
+      "Invalid cup size. Only american sizes are accepted."
+    )
+    .nullable(),
+  waistSize: yup
+    .number()
+    .transform(zeroCheck)
+    .min(15, "Invalid waist size")
+    .max(50, "Invalid waist size")
+    .nullable(),
+  hipSize: yup.number().transform(zeroCheck).nullable(),
+  boobJob: yup
+    .string()
+    .transform(nullCheck)
+    .nullable()
+    .oneOf([...Object.keys(BreastTypeEnum), null], "Invalid breast type"),
+  country: yup.string().trim().transform(nullCheck).nullable().defined(),
+  ethnicity: yup
+    .string()
+    .transform(nullCheck)
+    .nullable()
+    .oneOf([...Object.keys(EthnicityEnum), null], "Invalid ethnicity"),
+  eye_color: yup
+    .string()
+    .transform(nullCheck)
+    .nullable()
+    .oneOf([null, ...Object.keys(EyeColorEnum)], "Invalid eye color"),
+  hair_color: yup
+    .string()
+    .transform(nullCheck)
+    .nullable()
+    .oneOf([null, ...Object.keys(HairColorEnum)], "Invalid hair color"),
+  tattoos: yup.array().of(
+    yup.object({
+      location: yup.string().trim().required("Location is required"),
+      description: yup.string().trim().transform(nullCheck).nullable(),
+    })
+  ),
+  piercings: yup.array().of(
+    yup.object({
+      location: yup.string().trim().required("Location is required"),
+      description: yup.string().trim().transform(nullCheck).nullable(),
+    })
+  ),
+  aliases: yup
+    .array()
+    .of(yup.string().trim().transform(nullCheck).required())
+    .required(),
+  images: yup
+    .array()
+    .of(
+      yup.object({
+        id: yup.string().required(),
+        url: yup.string().required(),
+      })
+    )
+    .required(),
+  note: yup.string().required("Edit note is required"),
+});
+
+export type PerformerFormData = yup.Asserts<typeof PerformerSchema>;
+export type CastedPerformerFormData = yup.TypeOf<typeof PerformerSchema>;

--- a/frontend/src/pages/registerUser/Register.tsx
+++ b/frontend/src/pages/registerUser/Register.tsx
@@ -101,7 +101,7 @@ const Register: FC = () => {
           </div>
         </label>
         <div className="row">
-          <div className="col-3 offset-9 d-flex justify-content-end pr-0">
+          <div className="col-3 offset-9 d-flex justify-content-end">
             <div>
               <button type="submit" className="register-button btn btn-primary">
                 Register

--- a/frontend/src/pages/resetPassword/ResetPassword.tsx
+++ b/frontend/src/pages/resetPassword/ResetPassword.tsx
@@ -87,7 +87,7 @@ const ResetPassword: FC = () => {
           <div className="invalid-feedback">{errors?.password?.message}</div>
         </label>
         <div className="row">
-          <div className="col-3 offset-9 d-flex justify-content-end pr-0">
+          <div className="col-3 offset-9 d-flex justify-content-end">
             <div>
               <button
                 type="submit"

--- a/frontend/src/pages/scenes/SceneEdit.tsx
+++ b/frontend/src/pages/scenes/SceneEdit.tsx
@@ -44,7 +44,12 @@ const SceneEdit: FC<Props> = ({ scene }) => {
 
   return (
     <div>
-      <h3>Edit “{scene.title}”</h3>
+      <h3>
+        Edit scene{" "}
+        <i>
+          <b>{scene.title}</b>
+        </i>
+      </h3>
       <hr />
       <SceneForm scene={scene} callback={doUpdate} saving={saving} />
       {submissionError && (

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -48,7 +48,7 @@ const schema = yup.object({
   director: yup.string().trim().transform(nullCheck).nullable(),
   studio: yup
     .object({
-      id: yup.string().required("asdasd"),
+      id: yup.string().required(),
       name: yup.string().required(),
     })
     .nullable()

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -2,13 +2,12 @@ import { FC, useState, useMemo } from "react";
 import { useHistory } from "react-router-dom";
 import { useForm, useFieldArray } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
 import cx from "classnames";
 import { Button, Col, Form, InputGroup, Row, Tab, Tabs } from "react-bootstrap";
 
 import { Scene_findScene as Scene } from "src/graphql/definitions/Scene";
 import { Tags_queryTags_tags as Tag } from "src/graphql/definitions/Tags";
-import { GenderEnum, SceneEditDetailsInput } from "src/graphql";
+import { SceneEditDetailsInput } from "src/graphql";
 import { getUrlByType, formatDuration, parseDuration } from "src/utils";
 
 import { renderSceneDetails } from "src/components/editCard/ModifyEdit";
@@ -22,79 +21,10 @@ import StudioSelect from "src/components/studioSelect";
 import EditImages from "src/components/editImages";
 import { EditNote } from "src/components/form";
 import DiffScene from "./diff";
-
-const nullCheck = (input: string | null) =>
-  input === "" || input === "null" ? null : input;
-
-const schema = yup.object({
-  title: yup.string().required("Title is required"),
-  details: yup.string().trim(),
-  date: yup
-    .string()
-    .transform(nullCheck)
-    .matches(/^\d{4}-\d{2}-\d{2}$/, {
-      excludeEmptyString: true,
-      message: "Invalid date",
-    })
-    .nullable()
-    .required("Release date is required"),
-  duration: yup
-    .string()
-    .matches(/^((\d+:)?([0-5]?\d):)?([0-5]?\d)$/, {
-      excludeEmptyString: true,
-      message: "Invalid duration, format should be HH:MM:SS",
-    })
-    .nullable(),
-  director: yup.string().trim().transform(nullCheck).nullable(),
-  studio: yup
-    .object({
-      id: yup.string().required(),
-      name: yup.string().required(),
-    })
-    .nullable()
-    .required("Studio is required"),
-  studioURL: yup.string().url("Invalid URL").transform(nullCheck).nullable(),
-  performers: yup
-    .array()
-    .of(
-      yup
-        .object({
-          performerId: yup.string().required(),
-          name: yup.string().required(),
-          disambiguation: yup.string().nullable(),
-          alias: yup.string().trim().transform(nullCheck).nullable(),
-          gender: yup.string().oneOf(Object.keys(GenderEnum)).nullable(),
-          deleted: yup.bool().required(),
-        })
-        .required()
-    )
-    .ensure(),
-  tags: yup
-    .array()
-    .of(
-      yup.object({
-        id: yup.string().required(),
-        name: yup.string().required(),
-      })
-    )
-    .ensure(),
-  images: yup
-    .array()
-    .of(
-      yup.object({
-        id: yup.string().required(),
-        url: yup.string().required(),
-      })
-    )
-    .required(),
-  note: yup.string().required("Edit note is required"),
-});
+import { SceneSchema, SceneFormData } from "./schema";
 
 const CLASS_NAME = "SceneForm";
 const CLASS_NAME_PERFORMER_CHANGE = `${CLASS_NAME}-performer-change`;
-
-type SceneFormData = yup.Asserts<typeof schema>;
-export type CastedSceneFormData = yup.TypeOf<typeof schema>;
 
 interface SceneProps {
   scene: Scene;
@@ -111,7 +41,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
     watch,
     formState: { errors },
   } = useForm<SceneFormData>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(SceneSchema),
     mode: "onBlur",
     defaultValues: {
       title: scene?.title ?? undefined,
@@ -151,7 +81,7 @@ const SceneForm: FC<SceneProps> = ({ scene, callback, saving }) => {
 
   const fieldData = watch();
   const [oldSceneChanges, newSceneChanges] = useMemo(
-    () => DiffScene(schema.cast(fieldData), scene),
+    () => DiffScene(SceneSchema.cast(fieldData), scene),
     [fieldData, scene]
   );
 

--- a/frontend/src/pages/scenes/sceneForm/diff.ts
+++ b/frontend/src/pages/scenes/sceneForm/diff.ts
@@ -10,7 +10,7 @@ import {
   diffURLs,
 } from "src/utils";
 
-import { CastedSceneFormData } from "./SceneForm";
+import { CastedSceneFormData } from "./schema";
 
 const selectSceneDetails = (
   data: CastedSceneFormData,

--- a/frontend/src/pages/scenes/sceneForm/diff.ts
+++ b/frontend/src/pages/scenes/sceneForm/diff.ts
@@ -1,30 +1,21 @@
-import { SceneDetails as SceneDet } from "src/components/editCard/ModifyEdit";
+import { SceneDetails } from "src/components/editCard/ModifyEdit";
 
 import { SceneFragment } from "src/graphql";
-import { genderEnum, parseDuration } from "src/utils";
+import {
+  genderEnum,
+  parseDuration,
+  diffArray,
+  diffValue,
+  diffImages,
+  diffURLs,
+} from "src/utils";
 
 import { CastedSceneFormData } from "./SceneForm";
-
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const diffArray = <T extends unknown>(
-  a: T[],
-  b: T[],
-  getKey: (t: T) => string
-) => [
-  a.filter((x) => !b.some((val) => getKey(val) === getKey(x))),
-  b.filter((x) => !a.some((val) => getKey(val) === getKey(x))),
-];
-
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const diffValue = <T extends unknown>(
-  a: T | undefined | null,
-  b: T | undefined | null
-): T | null => (a && a !== b ? a : null);
 
 const selectSceneDetails = (
   data: CastedSceneFormData,
   original: SceneFragment
-): [SceneDet, SceneDet] => {
+): [SceneDetails, SceneDetails] => {
   const [addedPerformers, removedPerformers] = diffArray(
     (data.performers ?? []).flatMap((p) =>
       p.performerId && p.name
@@ -61,22 +52,8 @@ const selectSceneDetails = (
     (t) => t.id
   );
 
-  const [addedImages, removedImages] = diffArray(
-    (data.images ?? []).flatMap((i) =>
-      i.id && i.url
-        ? [
-            {
-              id: i.id,
-              url: i.url,
-            },
-          ]
-        : []
-    ),
-    original.images,
-    (i) => i.id
-  );
-
-  const [addedUrls, removedUrls] = diffArray(
+  const [addedImages, removedImages] = diffImages(data.images, original.images);
+  const [addedUrls, removedUrls] = diffURLs(
     data.studioURL
       ? [
           {
@@ -85,11 +62,7 @@ const selectSceneDetails = (
           },
         ]
       : [],
-    original.urls.map((u) => ({
-      url: u.url,
-      type: u.type,
-    })),
-    (u) => `${u.url}${u.type}`
+    original.urls
   );
 
   return [

--- a/frontend/src/pages/scenes/sceneForm/schema.ts
+++ b/frontend/src/pages/scenes/sceneForm/schema.ts
@@ -1,0 +1,72 @@
+import * as yup from "yup";
+import { GenderEnum } from "src/graphql";
+
+const nullCheck = (input: string | null) =>
+  input === "" || input === "null" ? null : input;
+
+export const SceneSchema = yup.object({
+  title: yup.string().required("Title is required"),
+  details: yup.string().trim(),
+  date: yup
+    .string()
+    .transform(nullCheck)
+    .matches(/^\d{4}-\d{2}-\d{2}$/, {
+      excludeEmptyString: true,
+      message: "Invalid date",
+    })
+    .nullable()
+    .required("Release date is required"),
+  duration: yup
+    .string()
+    .matches(/^((\d+:)?([0-5]?\d):)?([0-5]?\d)$/, {
+      excludeEmptyString: true,
+      message: "Invalid duration, format should be HH:MM:SS",
+    })
+    .nullable(),
+  director: yup.string().trim().transform(nullCheck).nullable(),
+  studio: yup
+    .object({
+      id: yup.string().required(),
+      name: yup.string().required(),
+    })
+    .nullable()
+    .required("Studio is required"),
+  studioURL: yup.string().url("Invalid URL").transform(nullCheck).nullable(),
+  performers: yup
+    .array()
+    .of(
+      yup
+        .object({
+          performerId: yup.string().required(),
+          name: yup.string().required(),
+          disambiguation: yup.string().nullable(),
+          alias: yup.string().trim().transform(nullCheck).nullable(),
+          gender: yup.string().oneOf(Object.keys(GenderEnum)).nullable(),
+          deleted: yup.bool().required(),
+        })
+        .required()
+    )
+    .ensure(),
+  tags: yup
+    .array()
+    .of(
+      yup.object({
+        id: yup.string().required(),
+        name: yup.string().required(),
+      })
+    )
+    .ensure(),
+  images: yup
+    .array()
+    .of(
+      yup.object({
+        id: yup.string().required(),
+        url: yup.string().required(),
+      })
+    )
+    .required(),
+  note: yup.string().required("Edit note is required"),
+});
+
+export type SceneFormData = yup.Asserts<typeof SceneSchema>;
+export type CastedSceneFormData = yup.TypeOf<typeof SceneSchema>;

--- a/frontend/src/pages/studios/StudioEdit.tsx
+++ b/frontend/src/pages/studios/StudioEdit.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { Studio_findStudio as Studio } from "src/graphql/definitions/Studio";
@@ -17,11 +17,14 @@ interface Props {
 
 const StudioEdit: FC<Props> = ({ studio }) => {
   const history = useHistory();
+  const [submissionError, setSubmissionError] = useState("");
   const [insertStudioEdit, { loading: saving }] = useStudioEdit({
     onCompleted: (data) => {
+      if (submissionError) setSubmissionError("");
       if (data.studioEdit.id)
         history.push(createHref(ROUTE_EDIT, data.studioEdit));
     },
+    onError: (error) => setSubmissionError(error.message),
   });
 
   const doUpdate = (insertData: StudioEditDetailsInput, editNote: string) => {
@@ -52,6 +55,11 @@ const StudioEdit: FC<Props> = ({ studio }) => {
         showNetworkSelect={studio.child_studios.length === 0}
         saving={saving}
       />
+      {submissionError && (
+        <div className="text-danger text-end col-9">
+          Error: {submissionError}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -3,7 +3,6 @@ import { useHistory } from "react-router-dom";
 import { Button, Row, Col, Form, Tab, Tabs } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
 import cx from "classnames";
 
 import { Studio_findStudio as Studio } from "src/graphql/definitions/Studio";
@@ -14,35 +13,8 @@ import { getUrlByType } from "src/utils";
 import { EditNote } from "src/components/form";
 import { renderStudioDetails } from "src/components/editCard/ModifyEdit";
 
+import { StudioSchema, StudioFormData } from "./schema";
 import DiffStudio from "./diff";
-
-const nullCheck = (input: string | null) =>
-  input === "" || input === "null" ? null : input;
-
-const schema = yup.object({
-  name: yup.string().required("Name is required"),
-  url: yup.string().url("Invalid URL").transform(nullCheck).nullable(),
-  images: yup
-    .array()
-    .of(
-      yup.object({
-        id: yup.string().required(),
-        url: yup.string().required(),
-      })
-    )
-    .required(),
-  studio: yup
-    .object({
-      id: yup.string().required(),
-      name: yup.string().required(),
-    })
-    .optional()
-    .default(undefined),
-  note: yup.string().required("Edit note is required"),
-});
-
-type StudioFormData = yup.Asserts<typeof schema>;
-export type CastedStudioFormData = yup.TypeOf<typeof schema>;
 
 interface StudioProps {
   studio: Studio;
@@ -65,7 +37,7 @@ const StudioForm: FC<StudioProps> = ({
     watch,
     formState: { errors },
   } = useForm<StudioFormData>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(StudioSchema),
     defaultValues: {
       name: studio.name,
       images: studio.images,
@@ -81,7 +53,7 @@ const StudioForm: FC<StudioProps> = ({
   const [file, setFile] = useState<File | undefined>();
   const fieldData = watch();
   const [oldStudioChanges, newStudioChanges] = useMemo(
-    () => DiffStudio(schema.cast(fieldData), studio),
+    () => DiffStudio(StudioSchema.cast(fieldData), studio),
     [fieldData, studio]
   );
 

--- a/frontend/src/pages/studios/studioForm/diff.ts
+++ b/frontend/src/pages/studios/studioForm/diff.ts
@@ -1,0 +1,55 @@
+import { StudioDetails } from "src/components/editCard/ModifyEdit";
+import { StudioFragment } from "src/graphql";
+import { CastedStudioFormData } from "./StudioForm";
+import { diffValue, diffImages, diffURLs } from "src/utils";
+
+const selectStudioDetails = (
+  data: CastedStudioFormData,
+  original: StudioFragment
+): [StudioDetails, StudioDetails] => {
+  const [addedImages, removedImages] = diffImages(data.images, original.images);
+  const [addedUrls, removedUrls] = diffURLs(
+    data.url
+      ? [
+          {
+            url: data.url,
+            type: "HOME",
+          },
+        ]
+      : [],
+    original.urls
+  );
+
+  return [
+    {
+      name: diffValue(original.name, data.name),
+      parent:
+        original.parent?.id !== data.studio?.id &&
+        original.parent?.id &&
+        original.parent.name
+          ? {
+              id: original.parent.id,
+              name: original.parent.name,
+            }
+          : null,
+    },
+    {
+      name: diffValue(data.name, original.name),
+      parent:
+        data.studio?.id !== original.parent?.id &&
+        data.studio?.id &&
+        data.studio?.name
+          ? {
+              id: data.studio.id,
+              name: data.studio.name,
+            }
+          : null,
+      added_urls: addedUrls,
+      removed_urls: removedUrls,
+      added_images: addedImages,
+      removed_images: removedImages,
+    },
+  ];
+};
+
+export default selectStudioDetails;

--- a/frontend/src/pages/studios/studioForm/diff.ts
+++ b/frontend/src/pages/studios/studioForm/diff.ts
@@ -1,6 +1,6 @@
 import { StudioDetails } from "src/components/editCard/ModifyEdit";
 import { StudioFragment } from "src/graphql";
-import { CastedStudioFormData } from "./StudioForm";
+import { CastedStudioFormData } from "./schema";
 import { diffValue, diffImages, diffURLs } from "src/utils";
 
 const selectStudioDetails = (

--- a/frontend/src/pages/studios/studioForm/schema.ts
+++ b/frontend/src/pages/studios/studioForm/schema.ts
@@ -1,0 +1,29 @@
+import * as yup from "yup";
+
+const nullCheck = (input: string | null) =>
+  input === "" || input === "null" ? null : input;
+
+export const StudioSchema = yup.object({
+  name: yup.string().required("Name is required"),
+  url: yup.string().url("Invalid URL").transform(nullCheck).nullable(),
+  images: yup
+    .array()
+    .of(
+      yup.object({
+        id: yup.string().required(),
+        url: yup.string().required(),
+      })
+    )
+    .required(),
+  studio: yup
+    .object({
+      id: yup.string().required(),
+      name: yup.string().required(),
+    })
+    .optional()
+    .default(undefined),
+  note: yup.string().required("Edit note is required"),
+});
+
+export type StudioFormData = yup.Asserts<typeof StudioSchema>;
+export type CastedStudioFormData = yup.TypeOf<typeof StudioSchema>;

--- a/frontend/src/pages/tags/TagEdit.tsx
+++ b/frontend/src/pages/tags/TagEdit.tsx
@@ -44,9 +44,7 @@ const TagEdit: FC<Props> = ({ tag }) => {
       <hr />
       <TagForm tag={tag} callback={doUpdate} saving={saving} />
       {submissionError && (
-        <div className="text-danger text-end col-9">
-          Error: {submissionError}
-        </div>
+        <div className="text-danger col-9">Error: {submissionError}</div>
       )}
     </div>
   );

--- a/frontend/src/pages/tags/TagEdit.tsx
+++ b/frontend/src/pages/tags/TagEdit.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { useTagEdit, OperationEnum, TagEditDetailsInput } from "src/graphql";
@@ -14,10 +14,13 @@ interface Props {
 
 const TagEdit: FC<Props> = ({ tag }) => {
   const history = useHistory();
+  const [submissionError, setSubmissionError] = useState("");
   const [insertTagEdit, { loading: saving }] = useTagEdit({
     onCompleted: (data) => {
+      if (submissionError) setSubmissionError("");
       if (data.tagEdit.id) history.push(createHref(ROUTE_EDIT, data.tagEdit));
     },
+    onError: (error) => setSubmissionError(error.message),
   });
 
   const doUpdate = (insertData: TagEditDetailsInput, editNote: string) => {
@@ -40,6 +43,11 @@ const TagEdit: FC<Props> = ({ tag }) => {
       <h3>Edit tag</h3>
       <hr />
       <TagForm tag={tag} callback={doUpdate} saving={saving} />
+      {submissionError && (
+        <div className="text-danger text-end col-9">
+          Error: {submissionError}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/tags/TagMerge.tsx
+++ b/frontend/src/pages/tags/TagMerge.tsx
@@ -15,11 +15,14 @@ interface Props {
 
 const TagMerge: FC<Props> = ({ tag }) => {
   const history = useHistory();
+  const [submissionError, setSubmissionError] = useState("");
   const [mergeSources, setMergeSources] = useState<string[]>([]);
   const [insertTagEdit, { loading: saving }] = useTagEdit({
     onCompleted: (data) => {
+      if (submissionError) setSubmissionError("");
       if (data.tagEdit.id) history.push(editHref(data.tagEdit));
     },
+    onError: (error) => setSubmissionError(error.message),
   });
 
   const doUpdate = (insertData: TagEditDetailsInput, editNote: string) => {
@@ -59,6 +62,9 @@ const TagMerge: FC<Props> = ({ tag }) => {
         Modify <em>{tag.name}</em>
       </h5>
       <Row className="g-0">
+        {submissionError && (
+          <div className="text-danger mb-2">Error: {submissionError}</div>
+        )}
         <TagForm tag={tag} callback={doUpdate} saving={saving} />
       </Row>
     </div>

--- a/frontend/src/utils/data.ts
+++ b/frontend/src/utils/data.ts
@@ -1,0 +1,2 @@
+export const filterData = <T>(data?: (T | null | undefined)[] | null) =>
+  data ? (data.filter((item) => item) as T[]) : [];

--- a/frontend/src/utils/diff.ts
+++ b/frontend/src/utils/diff.ts
@@ -1,0 +1,58 @@
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+export const diffArray = <T extends unknown>(
+  a: T[],
+  b: T[],
+  getKey: (t: T) => string
+) => [
+  a.filter((x) => !b.some((val) => getKey(val) === getKey(x))),
+  b.filter((x) => !a.some((val) => getKey(val) === getKey(x))),
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+export const diffValue = <T extends unknown>(
+  a: T | undefined | null,
+  b: T | undefined | null
+): T | null => (a && a !== b ? a : null);
+
+export const diffImages = (
+  newImages: { id: string | undefined; url: string | undefined }[] | undefined,
+  oldImages: { id: string; url: string }[]
+) =>
+  diffArray(
+    (newImages ?? []).flatMap((i) =>
+      i.id && i.url
+        ? [
+            {
+              id: i.id,
+              url: i.url,
+            },
+          ]
+        : []
+    ),
+    oldImages,
+    (i) => i.id
+  );
+
+export const diffURLs = (
+  newURLs:
+    | {
+        url: string | undefined;
+        type: string;
+      }[]
+    | undefined,
+  originalURLs: {
+    url: string;
+    type: string;
+  }[]
+) =>
+  diffArray(
+    (newURLs ?? []).map((u) => ({
+      url: u.url ?? "",
+      type: u.type ?? "",
+    })),
+    originalURLs.map((u) => ({
+      url: u.url,
+      type: u.type,
+    })),
+    (u) => `${u.url}${u.type}`
+  );

--- a/frontend/src/utils/enum.ts
+++ b/frontend/src/utils/enum.ts
@@ -1,4 +1,9 @@
-import { FingerprintAlgorithm, GenderEnum } from "src/graphql";
+import {
+  BreastTypeEnum,
+  FingerprintAlgorithm,
+  EthnicityEnum,
+  GenderEnum,
+} from "src/graphql";
 
 export const genderEnum = (
   gender: string | undefined | null
@@ -15,6 +20,31 @@ export const genderEnum = (
     ? GenderEnum.INTERSEX
     : null;
 
+export const ethnicityEnum = (
+  ethnicity: string | undefined | null
+): EthnicityEnum | null => {
+  switch (ethnicity) {
+    case "ASIAN":
+      return EthnicityEnum.ASIAN;
+    case "BLACK":
+      return EthnicityEnum.BLACK;
+    case "CAUCASIAN":
+      return EthnicityEnum.CAUCASIAN;
+    case "INDIAN":
+      return EthnicityEnum.INDIAN;
+    case "LATIN":
+      return EthnicityEnum.LATIN;
+    case "MIDDLE_EASTERN":
+      return EthnicityEnum.MIDDLE_EASTERN;
+    case "MIXED":
+      return EthnicityEnum.MIXED;
+    case "OTHER":
+      return EthnicityEnum.OTHER;
+    default:
+      return null;
+  }
+};
+
 export const fingerprintAlgorithm = (
   algorithm: string | undefined | null
 ): FingerprintAlgorithm | null =>
@@ -25,3 +55,18 @@ export const fingerprintAlgorithm = (
     : algorithm === "PHASH"
     ? FingerprintAlgorithm.PHASH
     : null;
+
+export const breastType = (
+  type: string | undefined | null
+): BreastTypeEnum | null => {
+  switch (type) {
+    case "FAKE":
+      return BreastTypeEnum.FAKE;
+    case "NA":
+      return BreastTypeEnum.NA;
+    case "NATURAL":
+      return BreastTypeEnum.NATURAL;
+    default:
+      return null;
+  }
+};

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -8,3 +8,5 @@ export * from "./route";
 export * from "./markdown";
 export * from "./enum";
 export * from "./user";
+export * from "./diff";
+export * from "./data";

--- a/frontend/src/utils/transforms.ts
+++ b/frontend/src/utils/transforms.ts
@@ -120,3 +120,14 @@ export const parseDuration = (
     Number.parseInt(hours, 10) * 3600;
   return duration > 0 ? duration : null;
 };
+
+export const parseBraSize = (braSize = ""): [string | null, number | null] => {
+  const band = /^\d+/.exec(braSize)?.[0];
+  const bandSize = band ? Number.parseInt(band, 10) : null;
+  const cup = bandSize ? braSize.replace(bandSize.toString(), "") : null;
+  const cupSize = cup
+    ? /^[a-zA-Z]+/.exec(cup)?.[0]?.toUpperCase() ?? null
+    : null;
+
+  return [cupSize, bandSize];
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@apollo/client@^3.1.3", "@apollo/client@^3.4.17":
-  version "3.4.17"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.17.tgz#4972e19a49809e16d17c5adc67f45623a6dac135"
-  integrity sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.6.tgz#911929df073280689efd98e5603047b79e0c39a2"
+  integrity sha512-XHoouuEJ4L37mtfftcHHO1caCRrKKAofAwqRoq28UQIPMJk+e7n3X9OtRRNXKk/9tmhNkwelSary+EilfPwI7A==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"
@@ -16,9 +16,9 @@
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
+    ts-invariant "^0.9.4"
     tslib "^2.3.0"
-    zen-observable-ts "~1.1.0"
+    zen-observable-ts "^1.2.0"
 
 "@apollo/federation@0.27.0":
   version "0.27.0"
@@ -61,14 +61,7 @@
   dependencies:
     "@apollographql/graphql-language-service-types" "^2.0.0"
 
-"@babel/code-frame@^7.0.0":
-  version "7.15.8"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.15.8.tgz#45990c47adadb00c03677baa89221f7cc23d2503"
-  integrity sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==
-  dependencies:
-    "@babel/highlight" "^7.14.5"
-
-"@babel/code-frame@^7.16.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
   integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
@@ -76,9 +69,9 @@
     "@babel/highlight" "^7.16.0"
 
 "@babel/compat-data@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.0.tgz#ea269d7f78deb3a7826c39a4048eecda541ebdaa"
-  integrity sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
+  integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
 "@babel/core@^7.15.5":
   version "7.16.0"
@@ -118,13 +111,13 @@
     "@babel/types" "^7.16.0"
 
 "@babel/helper-compilation-targets@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz#01d615762e796c17952c29e3ede9d6de07d235a8"
-  integrity sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz#5b480cd13f68363df6ec4dc8ac8e2da11363cbf0"
+  integrity sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==
   dependencies:
     "@babel/compat-data" "^7.16.0"
     "@babel/helper-validator-option" "^7.14.5"
-    browserslist "^4.16.6"
+    browserslist "^4.17.5"
     semver "^6.3.0"
 
 "@babel/helper-function-name@^7.16.0":
@@ -214,7 +207,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.15.7":
+"@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
@@ -225,22 +218,13 @@
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helpers@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.0.tgz#875519c979c232f41adfbd43a3b0398c2e388183"
-  integrity sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.3.tgz#27fc64f40b996e7074dc73128c3e5c3e7f55c43c"
+  integrity sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==
   dependencies:
     "@babel/template" "^7.16.0"
-    "@babel/traverse" "^7.16.0"
+    "@babel/traverse" "^7.16.3"
     "@babel/types" "^7.16.0"
-
-"@babel/highlight@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.16.0":
   version "7.16.0"
@@ -251,15 +235,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.3":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.3.tgz#271bafcb811080905a119222edbc17909c82261d"
-  integrity sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==
-
-"@babel/parser@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.0.tgz#cf147d7ada0a3655e79bf4b08ee846f00a00a295"
-  integrity sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A==
+"@babel/parser@^7.1.3", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
+  integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
 "@babel/plugin-syntax-jsx@^7.16.0":
   version "7.16.0"
@@ -301,28 +280,14 @@
     "@babel/types" "^7.16.0"
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz#403139af262b9a6e8f9ba04a6fdcebf8de692bf1"
-  integrity sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz#1e25de4fa994c57c18e5fdda6cc810dac70f5590"
+  integrity sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==
   dependencies:
-    core-js-pure "^3.16.0"
+    core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.13.16", "@babel/runtime@^7.14.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
-  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.16.3":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.16", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.7":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -338,17 +303,17 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/traverse@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.0.tgz#965df6c6bfc0a958c1e739284d3c9fa4a6e3c45b"
-  integrity sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==
+"@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.3.tgz#f63e8a938cc1b780f66d9ed3c54f532ca2d14787"
+  integrity sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
   dependencies:
     "@babel/code-frame" "^7.16.0"
     "@babel/generator" "^7.16.0"
     "@babel/helper-function-name" "^7.16.0"
     "@babel/helper-hoist-variables" "^7.16.0"
     "@babel/helper-split-export-declaration" "^7.16.0"
-    "@babel/parser" "^7.16.0"
+    "@babel/parser" "^7.16.3"
     "@babel/types" "^7.16.0"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -366,13 +331,13 @@
   resolved "https://registry.yarnpkg.com/@cush/relative/-/relative-1.0.0.tgz#8cd1769bf9bde3bb27dac356b1bc94af40f6cc16"
   integrity sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==
 
-"@emotion/cache@^11.4.0", "@emotion/cache@^11.5.0":
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.5.0.tgz#a5eb78cbef8163939ee345e3ddf0af217b845e62"
-  integrity sha512-mAZ5QRpLriBtaj/k2qyrXwck6yeoz1V5lMt/jfj6igWU35yYlNKs2LziXVgvH81gnJZ+9QQNGelSsnuoAy6uIw==
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.6.0":
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.6.0.tgz#65fbdbbe4382f1991d8b20853c38e63ecccec9a1"
+  integrity sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==
   dependencies:
     "@emotion/memoize" "^0.7.4"
-    "@emotion/sheet" "^1.0.3"
+    "@emotion/sheet" "^1.1.0"
     "@emotion/utils" "^1.0.0"
     "@emotion/weak-memoize" "^0.2.5"
     stylis "^4.0.10"
@@ -388,14 +353,14 @@
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/react@^11.1.1":
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.5.0.tgz#19b5771bbfbda5e8517e948a2d9064810f0022bd"
-  integrity sha512-MYq/bzp3rYbee4EMBORCn4duPQfgpiEB5XzrZEBnUZAL80Qdfr7CEv/T80jwaTl/dnZmt9SnTa8NkTrwFNpLlw==
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.0.tgz#b179da970ac0e8415de3ac165deadf8d9c4bf89f"
+  integrity sha512-WL93hf9+/2s3cA1JVJlz8+Uy6p6QWukqQFOm2OZO5ki51hfucHMOmbSjiyC3t2Y4RI8XUmBoepoc/24ny/VBbA==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@emotion/cache" "^11.5.0"
+    "@emotion/cache" "^11.6.0"
     "@emotion/serialize" "^1.0.2"
-    "@emotion/sheet" "^1.0.3"
+    "@emotion/sheet" "^1.1.0"
     "@emotion/utils" "^1.0.0"
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
@@ -411,10 +376,10 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.3.tgz#00c326cd7985c5ccb8fe2c1b592886579dcfab8f"
-  integrity sha512-YoX5GyQ4db7LpbmXHMuc8kebtBGP6nZfRC5Z13OKJMixBEwdZrJ914D6yJv/P+ZH/YY3F5s89NYX2hlZAf3SRQ==
+"@emotion/sheet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
+  integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
 
 "@emotion/unitless@^0.7.5":
   version "0.7.5"
@@ -441,14 +406,14 @@
     ts-node "^8"
     tslib "^1"
 
-"@eslint/eslintrc@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.4.tgz#dfe0ff7ba270848d10c5add0715e04964c034b31"
-  integrity sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==
+"@eslint/eslintrc@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
+  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.0.0"
+    espree "^9.2.0"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
@@ -483,28 +448,28 @@
     prop-types "^15.7.2"
 
 "@graphql-typed-document-node/core@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@hookform/resolvers@2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.8.3.tgz#d362360f6057bcca7318ad22d49e5f0c47290e27"
   integrity sha512-9G6/vCUNvg3O4MeAK4l749syOz/2r1DF/Pq3Njuk3sI4ObHoRyV0nxio5NrNLGC+7N1Ixu9vJ/loNhaUNXTX6A==
 
-"@humanwhocodes/config-array@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.6.0.tgz#b5621fdb3b32309d2d16575456cbc277fa8f021a"
-  integrity sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
+  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
   dependencies:
-    "@humanwhocodes/object-schema" "^1.2.0"
+    "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
 
-"@humanwhocodes/object-schema@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
-  integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -538,7 +503,7 @@
     supports-color "^5.4.0"
     tslib "^1"
 
-"@oclif/command@1.8.0", "@oclif/command@^1.5.10", "@oclif/command@^1.5.12", "@oclif/command@^1.5.13", "@oclif/command@^1.5.20", "@oclif/command@^1.6.0":
+"@oclif/command@1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
   integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
@@ -550,7 +515,19 @@
     debug "^4.1.1"
     semver "^7.3.2"
 
-"@oclif/config@1.17.0", "@oclif/config@^1.12.8", "@oclif/config@^1.13.0", "@oclif/config@^1.15.1":
+"@oclif/command@^1.5.10", "@oclif/command@^1.5.12", "@oclif/command@^1.5.13", "@oclif/command@^1.5.20", "@oclif/command@^1.6.0", "@oclif/command@^1.8.9":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.9.tgz#9a3cf897b1b83ef9e116657577324987c2d7f063"
+  integrity sha512-lrtLau+rCXlVyE4LWaDyhs5cFOYcI8+PRCshlKoRUuI6bC3wd+gQ6j5SxXtnR9XxOR6eDXnGZg7/0LB3GGGTpw==
+  dependencies:
+    "@oclif/config" "^1.18.2"
+    "@oclif/errors" "^1.3.5"
+    "@oclif/parser" "^3.8.6"
+    "@oclif/plugin-help" "^3.2.13"
+    debug "^4.1.1"
+    semver "^7.3.2"
+
+"@oclif/config@1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.17.0.tgz#ba8639118633102a7e481760c50054623d09fcab"
   integrity sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
@@ -562,7 +539,19 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/errors@1.3.5", "@oclif/errors@^1.2.1", "@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3":
+"@oclif/config@^1.12.8", "@oclif/config@^1.13.0", "@oclif/config@^1.15.1", "@oclif/config@^1.18.2":
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.2.tgz#5bfe74a9ba6a8ca3dceb314a81bd9ce2e15ebbfe"
+  integrity sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==
+  dependencies:
+    "@oclif/errors" "^1.3.3"
+    "@oclif/parser" "^3.8.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-wsl "^2.1.1"
+    tslib "^2.0.0"
+
+"@oclif/errors@1.3.5", "@oclif/errors@^1.2.1", "@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3", "@oclif/errors@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
   integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==
@@ -578,15 +567,15 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.3":
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.5.tgz#c5161766a1efca7343e1f25d769efbefe09f639b"
-  integrity sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
+"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.3", "@oclif/parser@^3.8.6":
+  version "3.8.6"
+  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.6.tgz#d5a108af9c708a051cc6b1d27d47359d75f41236"
+  integrity sha512-tXb0NKgSgNxmf6baN6naK+CCwOueaFk93FG9u202U7mTBHUKsioOUlw1SG/iPi9aJM3WE4pHLXmty59pci0OEw==
   dependencies:
     "@oclif/errors" "^1.2.2"
     "@oclif/linewrap" "^1.0.0"
-    chalk "^2.4.2"
-    tslib "^1.9.3"
+    chalk "^4.1.0"
+    tslib "^2.0.0"
 
 "@oclif/plugin-autocomplete@0.3.0":
   version "0.3.0"
@@ -617,21 +606,21 @@
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
 
-"@oclif/plugin-help@^3":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.2.4.tgz#100e0e09d806e20595096609f2220d009ee096e2"
-  integrity sha512-kMSfFbv11S7CKFlbWTKDdAe/gC7P2zCFZEDq6BAHjJdA0htHT8FvBhnyoppR0O2jOTjX80wHjU+ItPpjanfuag==
+"@oclif/plugin-help@^3", "@oclif/plugin-help@^3.2.13":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.2.14.tgz#7149eb322d36abc6cbf09f205bad128141e7eba4"
+  integrity sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==
   dependencies:
-    "@oclif/command" "^1.5.20"
-    "@oclif/config" "^1.15.1"
-    "@oclif/errors" "^1.2.2"
-    chalk "^4.1.0"
+    "@oclif/command" "^1.8.9"
+    "@oclif/config" "^1.18.2"
+    "@oclif/errors" "^1.3.5"
+    chalk "^4.1.2"
     indent-string "^4.0.0"
     lodash "^4.17.21"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     widest-line "^3.1.0"
-    wrap-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 "@oclif/plugin-not-found@1.2.4":
   version "1.2.4"
@@ -678,15 +667,15 @@
     lodash.template "^4.4.0"
     semver "^5.6.0"
 
-"@oclif/screen@^1.0.3":
+"@oclif/screen@^1.0.3", "@oclif/screen@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
 "@popperjs/core@^2.10.1":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.0.tgz#6734f8ebc106a0860dff7f92bf90df193f0935d7"
+  integrity sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==
 
 "@react-aria/ssr@^3.0.1":
   version "3.1.0"
@@ -708,9 +697,9 @@
     dequal "^2.0.2"
 
 "@restart/hooks@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.1.tgz#716b1fd7a67650a6d4ed441b5d704b4f73ca2612"
-  integrity sha512-87UMGZcFwbj0Gr+8eEBAzL6H8xF5pMwq/S3LWeFK9cg4+lTqLFMsiVQFT4ncMJzqgpdD7T6ktF8PsEHeN2O+MQ==
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.4.tgz#1d68576371687e9af64c3ca233cffaffc921ff76"
+  integrity sha512-+7PS1Sh6Fv7WM6vbsi0eUDDfO/Ql2+ADOSwvQ2Sf4Xz66QExmI9FEPVsekxGpaFHqzciNUIEgIigv2ix6/gE4w==
   dependencies:
     dequal "^2.0.2"
 
@@ -809,9 +798,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*", "@types/lodash@^4.14.175":
-  version "4.14.176"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
-  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
+  version "4.14.177"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
+  integrity sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==
 
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.10"
@@ -844,9 +833,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+  version "16.11.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.12.tgz#ac7fb693ac587ee182c3780c26eb65546a1a3c10"
+  integrity sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -901,28 +890,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.33"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.33.tgz#e01ae3de7613dac1094569880bb3792732203ad5"
-  integrity sha512-pLWntxXpDPaU+RTAuSGWGSEL2FRTNyRQOjSWDke/rxRg14ncsZvx8AKWMWZqvc1UOaJIAoObdZhAWvRaHFi5rw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.14.8", "@types/react@>=16.9.11":
-  version "17.0.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
-  integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.35":
-  version "17.0.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
-  integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==
+"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11", "@types/react@^17.0.35":
+  version "17.0.37"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
+  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -943,18 +914,13 @@
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
-
 "@typescript-eslint/eslint-plugin@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.4.0.tgz#05e711a2e7b68342661fde61bccbd1531c19521a"
-  integrity sha512-9/yPSBlwzsetCsGEn9j24D8vGQgJkOTr4oMLas/w886ZtzKIs1iyoqFrwsX2fqYEeUwsdBpC21gcjRGo57u0eg==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.6.0.tgz#efd8668b3d6627c46ce722c2afe813928fe120a0"
+  integrity sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "5.4.0"
-    "@typescript-eslint/scope-manager" "5.4.0"
+    "@typescript-eslint/experimental-utils" "5.6.0"
+    "@typescript-eslint/scope-manager" "5.6.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -962,60 +928,60 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.4.0.tgz#238a7418d2da3b24874ba35385eb21cc61d2a65e"
-  integrity sha512-Nz2JDIQUdmIGd6p33A+naQmwfkU5KVTLb/5lTk+tLVTDacZKoGQisj8UCxk7onJcrgjIvr8xWqkYI+DbI3TfXg==
+"@typescript-eslint/experimental-utils@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz#f3a5960f2004abdcac7bb81412bafc1560841c23"
+  integrity sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.4.0"
-    "@typescript-eslint/types" "5.4.0"
-    "@typescript-eslint/typescript-estree" "5.4.0"
+    "@typescript-eslint/scope-manager" "5.6.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/typescript-estree" "5.6.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.4.0.tgz#3aa83ce349d66e39b84151f6d5464928044ca9e3"
-  integrity sha512-JoB41EmxiYpaEsRwpZEYAJ9XQURPFer8hpkIW9GiaspVLX8oqbqNM8P4EP8HOZg96yaALiLEVWllA2E8vwsIKw==
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.6.0.tgz#11677324659641400d653253c03dcfbed468d199"
+  integrity sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.4.0"
-    "@typescript-eslint/types" "5.4.0"
-    "@typescript-eslint/typescript-estree" "5.4.0"
+    "@typescript-eslint/scope-manager" "5.6.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/typescript-estree" "5.6.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.4.0.tgz#aaab08415f4a9cf32b870c7750ae8ba4607126a1"
-  integrity sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==
+"@typescript-eslint/scope-manager@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz#9dd7f007dc8f3a34cdff6f79f5eaab27ae05157e"
+  integrity sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==
   dependencies:
-    "@typescript-eslint/types" "5.4.0"
-    "@typescript-eslint/visitor-keys" "5.4.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/visitor-keys" "5.6.0"
 
-"@typescript-eslint/types@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
-  integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
+"@typescript-eslint/types@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.6.0.tgz#745cb1b59daadcc1f32f7be95f0f68accf38afdd"
+  integrity sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==
 
-"@typescript-eslint/typescript-estree@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.4.0.tgz#fe524fb308973c68ebeb7428f3b64499a6ba5fc0"
-  integrity sha512-nhlNoBdhKuwiLMx6GrybPT3SFILm5Gij2YBdPEPFlYNFAXUJWX6QRgvi/lwVoadaQEFsizohs6aFRMqsXI2ewA==
+"@typescript-eslint/typescript-estree@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz#dfbb19c9307fdd81bd9c650c67e8397821d7faf0"
+  integrity sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==
   dependencies:
-    "@typescript-eslint/types" "5.4.0"
-    "@typescript-eslint/visitor-keys" "5.4.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/visitor-keys" "5.6.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
-  integrity sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==
+"@typescript-eslint/visitor-keys@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz#3e36509e103fe9713d8f035ac977235fd63cb6e6"
+  integrity sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==
   dependencies:
-    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/types" "5.6.0"
     eslint-visitor-keys "^3.0.0"
 
 "@vitejs/plugin-react@1.0.5":
@@ -1065,10 +1031,10 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
-  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+acorn@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -1081,9 +1047,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.6.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1512,9 +1478,9 @@ axobject-query@^2.2.0:
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 bail@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.1.tgz#d676736373a374058a935aec81b94c12ba815771"
-  integrity sha512-d5FoTAr2S5DSUPKl85WNm2yUwsINN8eidIdIwsOge2t33DaOfOdSmmsI11jMN3GmALCXaw+Y6HMVHDzePshFAA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1556,13 +1522,13 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.16.6:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.5.tgz#c827bbe172a4c22b123f5e337533ceebadfdd559"
-  integrity sha512-I3ekeB92mmpctWBoLXe0d5wPS2cBuRvvW0JyyJHMrk9/HmP2ZjrTboNAZ8iuGqaEIlKguljbQY32OkOJIRrgoA==
+browserslist@^4.17.5:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
+  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
   dependencies:
-    caniuse-lite "^1.0.30001271"
-    electron-to-chromium "^1.3.878"
+    caniuse-lite "^1.0.30001280"
+    electron-to-chromium "^1.3.896"
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
@@ -1631,10 +1597,10 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001271:
-  version "1.0.30001272"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz#8e9790ff995e9eb6e1f4c45cd07ddaa87cddbb14"
-  integrity sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==
+caniuse-lite@^1.0.30001280:
+  version "1.0.30001285"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz#fe1e52229187e11d6670590790d669b9e03315b7"
+  integrity sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -1658,7 +1624,7 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1686,7 +1652,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1712,20 +1678,10 @@ change-case@^4.0.0:
     snake-case "^3.0.4"
     tslib "^2.0.3"
 
-character-entities-legacy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
-  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
-
 character-entities@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.1.tgz#98724833e1e27990dee0bd0f2b8a859c3476aac7"
   integrity sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ==
-
-character-reference-invalid@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
-  integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.2"
@@ -1782,7 +1738,7 @@ cli-truncate@^0.2.1:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
 
-cli-ux@5.6.3, cli-ux@^5.2.1:
+cli-ux@5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.3.tgz#eecdb2e0261171f2b28f2be6b18c490291c3a287"
   integrity sha512-/oDU4v8BiDjX2OKcSunGH0iGDiEtj2rZaGyqNuv9IT4CgcSMyVWAMfn0+rEHaOc4n9ka78B0wo1+N1QX89f7mw==
@@ -1841,6 +1797,38 @@ cli-ux@^4.9.0:
     treeify "^1.1.0"
     tslib "^1.9.3"
 
+cli-ux@^5.2.1:
+  version "5.6.6"
+  resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.6.6.tgz#1424f5a9fbddcd796ad985b867a3de7f5a452090"
+  integrity sha512-4wUB34zoFklcZV0z5YiOM5IqVMMt9c3TK3QYRK3dqyk3XoRC0ybiWDWHfsMDjkKrzsVTw95rXn9NrzSHbae4pg==
+  dependencies:
+    "@oclif/command" "^1.8.9"
+    "@oclif/errors" "^1.3.5"
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^1.0.4"
+    ansi-escapes "^4.3.0"
+    ansi-styles "^4.2.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.0"
+    clean-stack "^3.0.0"
+    cli-progress "^3.4.0"
+    extract-stack "^2.0.0"
+    fs-extra "^8.1"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.13.1"
+    lodash "^4.17.21"
+    natural-orderby "^2.0.1"
+    object-treeify "^1.1.4"
+    password-prompt "^1.1.2"
+    semver "^7.3.2"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    supports-color "^8.1.0"
+    supports-hyperlinks "^2.1.0"
+    tslib "^2.0.0"
+
 clone-regexp@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
@@ -1895,9 +1883,9 @@ comma-separated-tokens@^2.0.0:
   integrity sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==
 
 common-tags@^1.5.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.1.tgz#ebf4973edf7d476a9c19646f5f04a45f95796029"
-  integrity sha512-uOZd85rJqrdEIE/JjhW5YAeatX8iqjjvVzIyfx7JL7G5r9Tep6YpYT9gEJWhWpVyDQEyzukWd6p2qULpJ8tmBw==
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1930,20 +1918,15 @@ convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-core-js-pure@^3.10.2:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.1.tgz#edffc1fc7634000a55ba05e95b3f0fe9587a5aa4"
-  integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
-
-core-js-pure@^3.16.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.0.tgz#db6fdadfdd4dc280ec93b64c3c2e8460e6f10094"
-  integrity sha512-UEQk8AxyCYvNAs6baNoPqDADv7BX0AmBLGxVsrAifPPx/C8EAzV4Q+2ZUJqVzfI2TQQEZITnwUkWcHpgc/IubQ==
+core-js-pure@^3.10.2, core-js-pure@^3.19.0:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.3.tgz#c69b2b36b58927317824994b532ec3f0f7e49607"
+  integrity sha512-N3JruInmCyt7EJj5mAq3csCgGYgiSqu7p7TQp2KOztr180/OAIxyIvL1FCjzgmQk/t3Yniua50Fsak7FShI9lA==
 
 core-js@^3.0.1, core-js@^3.6.5:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
-  integrity sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.3.tgz#6df8142a996337503019ff3235a7022d7cdf4559"
+  integrity sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==
 
 cosmiconfig@^5.0.6:
   version "5.2.1"
@@ -1992,9 +1975,9 @@ cssesc@^3.0.0:
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 csstype@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
-  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 damerau-levenshtein@^1.0.7:
   version "1.0.7"
@@ -2007,9 +1990,9 @@ date-fns@^1.27.2:
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-fns@^2.25.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"
-  integrity sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
 
 debug@^2.6.9:
   version "2.6.9"
@@ -2026,9 +2009,9 @@ debug@^3.2.7:
     ms "^2.1.1"
 
 debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -2044,6 +2027,13 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.1.tgz#57b2bd9112659cacbc449d3577d7dadb8e1f3d1b"
+  integrity sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==
+  dependencies:
+    character-entities "^2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -2134,10 +2124,10 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
-electron-to-chromium@^1.3.878:
-  version "1.3.885"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.885.tgz#c8cec32fbc61364127849ae00f2395a1bae7c454"
-  integrity sha512-JXKFJcVWrdHa09n4CNZYfYaK6EW5aAew7/wr3L1OnsD1L+JHL+RCtd7QgIsxUbFPeTwPlvnpqNNTOLkoefmtXg==
+electron-to-chromium@^1.3.896:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.12.tgz#5f73d1278c6205fc41d7a0ebd75563046b77c5d8"
+  integrity sha512-zjfhG9Us/hIy8AlQ5OzfbR/C4aBv1Dg/ak4GX35CELYlJ4tDAtoEcQivXvyBdqdNQ+R6PhlgQqV8UNPJmhkJog==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -2217,113 +2207,113 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-esbuild-android-arm64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.10.tgz#3545c71bf01e8b36535681078cdb0191c8654452"
-  integrity sha512-1sCdVAq64yMp2Uhlu+97/enFxpmrj31QHtThz7K+/QGjbHa7JZdBdBsZCzWJuntKHZ+EU178tHYkvjaI9z5sGg==
+esbuild-android-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz#3fc3ff0bab76fe35dd237476b5d2b32bb20a3d44"
+  integrity sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==
 
-esbuild-darwin-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.10.tgz#143e34d7f5d3860cc681c64c860f531e60496b5b"
-  integrity sha512-XlL+BYZ2h9cz3opHfFgSHGA+iy/mljBFIRU9q++f9SiBXEZTb4gTW/IENAD1l9oKH0FdO9rUpyAfV+lM4uAxrg==
+esbuild-darwin-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
+  integrity sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==
 
-esbuild-darwin-arm64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.10.tgz#456a044b789d5d256af8d264314da5217ca9fcd1"
-  integrity sha512-RZMMqMTyActMrXKkW71IQO8B0tyQm0Bm+ZJQWNaHJchL5LlqazJi7rriwSocP+sKLszHhsyTEBBh6qPdw5g5yQ==
+esbuild-darwin-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz#1b07f893b632114f805e188ddfca41b2b778229a"
+  integrity sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==
 
-esbuild-freebsd-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.10.tgz#dcd829a4a95226716faae8a2f378f08688f921b6"
-  integrity sha512-pf4BEN9reF3jvZEZdxljVgOv5JS4kuYFCI78xk+2HWustbLvTP0b9XXfWI/OD0ZLWbyLYZYIA+VbVe4tdAklig==
+esbuild-freebsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
+  integrity sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==
 
-esbuild-freebsd-arm64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.10.tgz#116c254b3eb1b9d1dd6f12e0271967de4512ca09"
-  integrity sha512-j9PUcuNWmlxr4/ry4dK/s6zKh42Jhh/N5qnAAj7tx3gMbkIHW0JBoVSbbgp97p88X9xgKbXx4lG2sJDhDWmsYQ==
+esbuild-freebsd-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz#2e1a6c696bfdcd20a99578b76350b41db1934e52"
+  integrity sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==
 
-esbuild-linux-32@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.10.tgz#131971622c38e5aa014303a494a1b5c3cc90f2be"
-  integrity sha512-imtdHG5ru0xUUXuc2ofdtyw0fWlHYXV7JjF7oZHgmn0b+B4o4Nr6ZON3xxoo1IP8wIekW+7b9exIf/MYq0QV7w==
+esbuild-linux-32@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
+  integrity sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==
 
-esbuild-linux-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.10.tgz#48826c388abd5dde3fc098a8ef38d8b548674f93"
-  integrity sha512-O7fzQIH2e7GC98dvoTH0rad5BVLm9yU3cRWfEmryCEIFTwbNEWCEWOfsePuoGOHRtSwoVY1hPc21CJE4/9rWxQ==
+esbuild-linux-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz#9cb8e4bcd7574e67946e4ee5f1f1e12386bb6dd3"
+  integrity sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==
 
-esbuild-linux-arm64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.10.tgz#0be9ffc92e30641869c7fbca0ec5d30fa8cbddd6"
-  integrity sha512-bkGxN67S2n0PF4zhh87/92kBTsH2xXLuH6T5omReKhpXdJZF5SVDSk5XU/nngARzE+e6QK6isK060Dr5uobzNw==
+esbuild-linux-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
+  integrity sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==
 
-esbuild-linux-arm@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.10.tgz#8c15bcaa41a022c834f049a71a7d1fbade507532"
-  integrity sha512-R2Jij4A0K8BcmBehvQeUteQEcf24Y2YZ6mizlNFuJOBPxe3vZNmkZ4mCE7Pf1tbcqA65qZx8J3WSHeGJl9EsJA==
+esbuild-linux-arm@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz#8a00e99e6a0c6c9a6b7f334841364d8a2b4aecfe"
+  integrity sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==
 
-esbuild-linux-mips64le@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.10.tgz#5bb33a2bc82e9c78ed724f345a8359610ddc9695"
-  integrity sha512-UDNO5snJYOLWrA2uOUxM/PVbzzh2TR7Zf2i8zCCuFlYgvAb/81XO+Tasp3YAElDpp4VGqqcpBXLtofa9nrnJGA==
+esbuild-linux-mips64le@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
+  integrity sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==
 
-esbuild-linux-ppc64le@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.10.tgz#18703cd0d52447d97486735b8e79fba7d81eac65"
-  integrity sha512-xu6J9rMWu1TcEGuEmoc8gsTrJCEPsf+QtxK4IiUZNde9r4Q4nlRVah4JVZP3hJapZgZJcxsse0XiKXh1UFdOeA==
+esbuild-linux-ppc64le@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz#f7e6bba40b9a11eb9dcae5b01550ea04670edad2"
+  integrity sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==
 
-esbuild-netbsd-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.10.tgz#3ecb06158aadb5b7396a5b7632069181b1591c56"
-  integrity sha512-d+Gr0ScMC2J83Bfx/ZvJHK0UAEMncctwgjRth9d4zppYGLk/xMfFKxv5z1ib8yZpQThafq8aPm8AqmFIJrEesw==
+esbuild-netbsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz#a2fedc549c2b629d580a732d840712b08d440038"
+  integrity sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==
 
-esbuild-openbsd-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.10.tgz#3a6950b1d955de921ac52f7af0b4865e89d6e4f1"
-  integrity sha512-OuCYc+bNKumBvxflga+nFzZvxsgmWQW+z4rMGIjM5XIW0nNbGgRc5p/0PSDv0rTdxAmwCpV69fezal0xjrDaaA==
+esbuild-openbsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
+  integrity sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==
 
-esbuild-sunos-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.10.tgz#ad407f721a8b5727fca31958b5eab1b0232e2d73"
-  integrity sha512-gUkgivZK11bD56wDoLsnYrsOHD/zHzzLSdqKcIl3wRMulfHpRBpoX8gL0dbWr+8N9c+1HDdbNdvxSRmZ4RCVwg==
+esbuild-sunos-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz#d0b6454a88375ee8d3964daeff55c85c91c7cef4"
+  integrity sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==
 
-esbuild-windows-32@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.10.tgz#ddaaa0b6e172df6512edc7a91bd2456615cfa914"
-  integrity sha512-C1xJ54E56dGWRaYcTnRy7amVZ9n1/D/D2/qVw7e5EtS7p+Fv/yZxxgqyb1hMGKXgtFYX4jMpU5eWBF/AsYrn+A==
+esbuild-windows-32@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
+  integrity sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==
 
-esbuild-windows-64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.10.tgz#93d861abf36bf71b6e61f5cbd2e42762ce5cb83a"
-  integrity sha512-6+EXEXopEs3SvPFAHcps2Krp/FvqXXsOQV33cInmyilb0ZBEQew4MIoZtMIyB3YXoV6//dl3i6YbPrFZaWEinQ==
+esbuild-windows-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz#1f79cb9b1e1bb02fb25cd414cb90d4ea2892c294"
+  integrity sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==
 
-esbuild-windows-arm64@0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.10.tgz#85a2d338aaa8b0cd1d8ecbe9150def9a608e8947"
-  integrity sha512-xTqM/XKhORo6u9S5I0dNJWEdWoemFjogLUTVLkQMVyUV3ZuMChahVA+bCqKHdyX55pCFxD/8v2fm3/sfFMWN+g==
+esbuild-windows-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
+  integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
 
-esbuild@^0.13.2:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.10.tgz#e3d24d59f1d8b2130d746ca858efcb80e1d99b26"
-  integrity sha512-0NfCsnAh5XatHIx6Cu93wpR2v6opPoOMxONYhaAoZKzGYqAE+INcDeX2wqMdcndvPQdWCuuCmvlnsh0zmbHcSQ==
+esbuild@^0.13.12:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.15.tgz#db56a88166ee373f87dbb2d8798ff449e0450cdf"
+  integrity sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==
   optionalDependencies:
-    esbuild-android-arm64 "0.13.10"
-    esbuild-darwin-64 "0.13.10"
-    esbuild-darwin-arm64 "0.13.10"
-    esbuild-freebsd-64 "0.13.10"
-    esbuild-freebsd-arm64 "0.13.10"
-    esbuild-linux-32 "0.13.10"
-    esbuild-linux-64 "0.13.10"
-    esbuild-linux-arm "0.13.10"
-    esbuild-linux-arm64 "0.13.10"
-    esbuild-linux-mips64le "0.13.10"
-    esbuild-linux-ppc64le "0.13.10"
-    esbuild-netbsd-64 "0.13.10"
-    esbuild-openbsd-64 "0.13.10"
-    esbuild-sunos-64 "0.13.10"
-    esbuild-windows-32 "0.13.10"
-    esbuild-windows-64 "0.13.10"
-    esbuild-windows-arm64 "0.13.10"
+    esbuild-android-arm64 "0.13.15"
+    esbuild-darwin-64 "0.13.15"
+    esbuild-darwin-arm64 "0.13.15"
+    esbuild-freebsd-64 "0.13.15"
+    esbuild-freebsd-arm64 "0.13.15"
+    esbuild-linux-32 "0.13.15"
+    esbuild-linux-64 "0.13.15"
+    esbuild-linux-arm "0.13.15"
+    esbuild-linux-arm64 "0.13.15"
+    esbuild-linux-mips64le "0.13.15"
+    esbuild-linux-ppc64le "0.13.15"
+    esbuild-netbsd-64 "0.13.15"
+    esbuild-openbsd-64 "0.13.15"
+    esbuild-sunos-64 "0.13.15"
+    esbuild-windows-32 "0.13.15"
+    esbuild-windows-64 "0.13.15"
+    esbuild-windows-arm64 "0.13.15"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2356,9 +2346,9 @@ eslint-config-airbnb-base@^15.0.0:
     semver "^6.3.0"
 
 eslint-config-airbnb-typescript@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-16.0.0.tgz#75007e27d5a7fb75530721f48197817c1d2ad4d1"
-  integrity sha512-qDOyD0YYZo5Us1YvOnWig2Ly/+IlQKmMZpnqKnJgVtHdK8SkjaSyVBHKbD41dEaQxk8vRVGBC94PuR2ceSwbLQ==
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-16.1.0.tgz#f75a6b4f3bb679eef34c3c930359c2ca9bc3f09c"
+  integrity sha512-W5Cq20KpEx5ZLC54bnVrC37zq2+WD956Kp/Ma3nYFRjT1v9KM63v+DPkrrmmrVqrlDKaD0ivm/qeYmyHV6qKlw==
   dependencies:
     eslint-config-airbnb-base "^15.0.0"
 
@@ -2427,9 +2417,9 @@ eslint-plugin-react-hooks@^4.3.0:
   integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
 
 eslint-plugin-react@^7.27.0:
-  version "7.27.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz#f952c76517a3915b81c7788b220b2b4c96703124"
-  integrity sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz#469202442506616f77a854d91babaae1ec174b45"
+  integrity sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flatmap "^1.2.5"
@@ -2454,10 +2444,10 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
-  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
+eslint-scope@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
+  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -2474,18 +2464,18 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
 eslint@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.2.0.tgz#44d3fb506d0f866a506d97a0fc0e90ee6d06a815"
-  integrity sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.4.1.tgz#d6531bbf3e598dffd7c0c7d35ec52a0b30fdfa2d"
+  integrity sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==
   dependencies:
-    "@eslint/eslintrc" "^1.0.4"
-    "@humanwhocodes/config-array" "^0.6.0"
+    "@eslint/eslintrc" "^1.0.5"
+    "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -2493,10 +2483,10 @@ eslint@^8.2.0:
     doctrine "^3.0.0"
     enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^6.0.0"
+    eslint-scope "^7.1.0"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.0.0"
-    espree "^9.0.0"
+    eslint-visitor-keys "^3.1.0"
+    espree "^9.2.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -2523,14 +2513,14 @@ eslint@^8.2.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
-  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
+espree@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.2.0.tgz#c50814e01611c2d0f8bd4daa83c369eabba80dbc"
+  integrity sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==
   dependencies:
-    acorn "^8.5.0"
+    acorn "^8.6.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.0.0"
+    eslint-visitor-keys "^3.1.0"
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
@@ -2709,9 +2699,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
-  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
+  integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -2992,24 +2982,17 @@ graphql-tag@2.12.4:
   dependencies:
     tslib "^2.1.0"
 
-graphql-tag@^2.10.1, graphql-tag@^2.12.6:
+graphql-tag@^2.10.1, graphql-tag@^2.12.3, graphql-tag@^2.12.6, graphql-tag@^2.2.2:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
 
-graphql-tag@^2.12.3, graphql-tag@^2.2.2:
-  version "2.12.5"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
-  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
-  dependencies:
-    tslib "^2.1.0"
-
 "graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@^15.3.0, graphql@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
-  integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -3134,9 +3117,9 @@ hyperlinker@^1.0.0:
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
 i18n-iso-countries@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-7.0.0.tgz#b842d6bd947093a38af0f3587fe3632175dd249e"
-  integrity sha512-Q7NEui+oCW4LK2OkUTOV9qCARLViWpwTJfNPOPKG2KpPw5WAxrK8bAPSPFdsu/0GyjK/NPexQFgCGiqwkHl6yg==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-7.1.0.tgz#123513a36c31fcb0f69127d5634304e810b0ff1a"
+  integrity sha512-XJ3c46J8zs8EXzaHN7NnVf079yupl8PHSr6zbMufhkLFopEXbM9u79i6H11w6HUdkiPkARcO2+YpSmIfUJyttw==
   dependencies:
     diacritics "1.3.0"
 
@@ -3145,12 +3128,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4, ignore@^5.1.8:
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
-  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
-
-ignore@^5.1.9:
+ignore@^5.1.4, ignore@^5.1.8, ignore@^5.1.9:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
@@ -3245,19 +3223,6 @@ is-absolute-url@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-4.0.1.tgz#16e4d487d4fded05cfe0685e53ec86804a5e94dc"
   integrity sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==
 
-is-alphabetical@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.0.tgz#ef6e2caea57c63450fffc7abb6cbdafc5eb96e96"
-  integrity sha512-5OV8Toyq3oh4eq6sbWTYzlGdnMT/DPI5I0zxUBxjiigQsZycpkKF3kskkao3JyYGuYDHvhgJF+DrjMQp9SX86w==
-
-is-alphanumerical@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.0.tgz#0fbfeb6a72d21d91143b3d182bf6cf5909ee66f6"
-  integrity sha512-t+2GlJ+hO9yagJ+jU3+HSh80VKvz/3cG2cxbGGm4S0hjKuhWQXgPVUVOZz3tqZzMjhmphZ+1TIJTlRZRoe6GCQ==
-  dependencies:
-    is-alphabetical "^2.0.0"
-    is-decimal "^2.0.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3309,11 +3274,6 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-decimal@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.0.tgz#db1140337809fd043a056ae40a9bd1cdc563034c"
-  integrity sha512-QfrfjQV0LjoWQ1K1XSoEZkTAzSa14RKVMa5zg3SdAfzEmQzRM4+tbSFWb78creCeA9rNBzaZal92opi1TwPWZw==
-
 is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
@@ -3352,11 +3312,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-hexadecimal@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.0.tgz#8e1ec9f48fe3eabd90161109856a23e0907a65d5"
-  integrity sha512-vGOtYkiaxwIiR0+Ng/zNId+ZZehGfINwTzdrDqc6iubbnQWhnPuYymOzOKUDqa2cSl59yHnEh2h6MvRLQsyNug==
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -3624,9 +3579,9 @@ levn@^0.4.1:
     type-check "~0.4.0"
 
 lines-and-columns@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
-  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -3826,9 +3781,9 @@ map-obj@^4.0.0:
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
 markdown-table@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.1.tgz#88c48957aaf2a8014ccb2ba026776a1d736fe3dc"
-  integrity sha512-CBbaYXKSGnE1uLRpKA1SWgIRb2PQrpkllNWpZtZe6VojOJ4ysqiq7/2glYcmKsOYN09QgH/HEBX5hIshAeiK6A==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.2.tgz#9b59eb2c1b22fe71954a65ff512887065a7bb57c"
+  integrity sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==
 
 matcher@^3.0.0:
   version "3.0.0"
@@ -3861,12 +3816,13 @@ mdast-util-find-and-replace@^2.0.0:
     unist-util-visit-parents "^4.0.0"
 
 mdast-util-from-markdown@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.0.4.tgz#b1fefae59cf4a6368779e01b7e830281ee277532"
-  integrity sha512-BlL42o885QO+6o43ceoc6KBdp/bi9oYyamj0hUbeu730yhP1WDC7m2XYSBfmQkOb0TdoHSAJ3de3SMqse69u+g==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
+  integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==
   dependencies:
     "@types/mdast" "^3.0.0"
     "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
     mdast-util-to-string "^3.1.0"
     micromark "^3.0.0"
     micromark-util-decode-numeric-character-reference "^1.0.0"
@@ -3874,7 +3830,6 @@ mdast-util-from-markdown@^1.0.0:
     micromark-util-normalize-identifier "^1.0.0"
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.0"
-    parse-entities "^3.0.0"
     unist-util-stringify-position "^3.0.0"
     uvu "^0.5.0"
 
@@ -3949,9 +3904,9 @@ mdast-util-to-hast@^11.0.0:
     unist-util-visit "^4.0.0"
 
 mdast-util-to-markdown@^1.0.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.3.tgz#2b3af92bf0e29080927eb59a8a10cd0a7398e093"
-  integrity sha512-040jJYtjOUdbvYAXCfPrpLJRdvMOmR33KRqlhT4r+fEbVM+jao1RMbA8RmGeRmw8RAj3vQ+HvhIaJPijvnOwCg==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.6.tgz#9d0d1fcb22838e4af83fb04841cbde92525972f3"
+  integrity sha512-doJZmTEGagHypWvJ8ltinmwUsT9ZaNgNIQW6Gl7jNdsI1QZkTHTimYW561Niy2s8AEPAqEgV0dIh2UOVlSXUJA==
   dependencies:
     "@types/mdast" "^3.0.0"
     "@types/unist" "^2.0.0"
@@ -4005,10 +3960,11 @@ merge2@^1.3.0:
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.0.4.tgz#fee459d29c5912a32f059c3a9836d4318ac85f30"
-  integrity sha512-HAtoZisp1M/sQFuw2zoUKGo1pMKod7GSvdM6B2oBU0U2CEN5/C6Tmydmi1rmvEieEhGQsjMyiiSoYgxISNxGFA==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz#edff4c72e5993d93724a3c206970f5a15b0585ad"
+  integrity sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==
   dependencies:
+    decode-named-character-reference "^1.0.0"
     micromark-factory-destination "^1.0.0"
     micromark-factory-label "^1.0.0"
     micromark-factory-space "^1.0.0"
@@ -4023,7 +3979,6 @@ micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
     micromark-util-subtokenize "^1.0.0"
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.1"
-    parse-entities "^3.0.0"
     uvu "^0.5.0"
 
 micromark-extension-gfm-autolink-literal@^1.0.0:
@@ -4063,9 +4018,9 @@ micromark-extension-gfm-strikethrough@^1.0.0:
     uvu "^0.5.0"
 
 micromark-extension-gfm-table@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.3.tgz#4761e35e3d21bde691aa06313406e1124a319239"
-  integrity sha512-JIfE1DGi64zzOx39/pGg6cZbiaUAF/MXbBLZnVl4aFz6Mja7GYMZjksfTGm9NzbgZkiZvbD77NLPuwGIRcFMjg==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.4.tgz#37fdcd11c3ef8d1928a037207597f1f7951d3381"
+  integrity sha512-IK2yzl7ycXeFFvZ8qiH4j5am529ihjOFD7NMo8Nhyq+VGwgWe4+qeI925RRrJuEzX3KyQ+1vzY8BIIvqlgOJhw==
   dependencies:
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.0.0"
@@ -4193,14 +4148,14 @@ micromark-util-decode-numeric-character-reference@^1.0.0:
     micromark-util-symbol "^1.0.0"
 
 micromark-util-decode-string@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz#fa779dcef7f2dc2c9e4b759abd85e553674eea4f"
-  integrity sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz#942252ab7a76dec2dbf089cc32505ee2bc3acf02"
+  integrity sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==
   dependencies:
+    decode-named-character-reference "^1.0.0"
     micromark-util-character "^1.0.0"
     micromark-util-decode-numeric-character-reference "^1.0.0"
     micromark-util-symbol "^1.0.0"
-    parse-entities "^3.0.0"
 
 micromark-util-encode@^1.0.0:
   version "1.0.0"
@@ -4246,22 +4201,23 @@ micromark-util-subtokenize@^1.0.0:
     uvu "^0.5.0"
 
 micromark-util-symbol@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.0.tgz#91cdbcc9b2a827c0129a177d36241bcd3ccaa34d"
-  integrity sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
+  integrity sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==
 
 micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.0.1.tgz#8bb8a092d93d326bd29fe29602799f2d0d922fd4"
-  integrity sha512-UT0ylWEEy80RFYzK9pEaugTqaxoD/j0Y9WhHpSyitxd99zjoQz7JJ+iKuhPAgOW2MiPSUAx+c09dcqokeyaROA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.0.2.tgz#f4220fdb319205812f99c40f8c87a9be83eded20"
+  integrity sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==
 
 micromark@^3.0.0:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.0.7.tgz#036dfc974ddf8e6e773b197839c5671d92d0928c"
-  integrity sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.0.10.tgz#1eac156f0399d42736458a14b0ca2d86190b457c"
+  integrity sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==
   dependencies:
     "@types/debug" "^4.0.0"
     debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
     micromark-core-commonmark "^1.0.1"
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.0.0"
@@ -4275,7 +4231,6 @@ micromark@^3.0.0:
     micromark-util-subtokenize "^1.0.0"
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.1"
-    parse-entities "^3.0.0"
     uvu "^0.5.0"
 
 micromatch@^4.0.4:
@@ -4470,9 +4425,9 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-inspect@^1.11.0, object-inspect@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
-  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.1.tgz#d4bd7d7de54b9a75599f59a00bd698c1f1c6549b"
+  integrity sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -4642,19 +4597,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-entities@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-3.1.0.tgz#82b04f2c26f2b3604e4df1972beb231f20d207e2"
-  integrity sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    character-entities "^2.0.0"
-    character-entities-legacy "^3.0.0"
-    character-reference-invalid "^2.0.0"
-    is-alphanumerical "^2.0.0"
-    is-decimal "^2.0.0"
-    is-hexadecimal "^2.0.0"
-
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -4796,7 +4738,7 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-scss@^4.0.1:
+postcss-scss@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.2.tgz#39ddcc0ab32f155d5ab328ee91353d67a52d537b"
   integrity sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==
@@ -4810,18 +4752,18 @@ postcss-selector-parser@^6.0.6:
     util-deprecate "^1.0.2"
 
 postcss-value-parser@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
-  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.3.11, postcss@^8.3.8:
-  version "8.3.11"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
-  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+postcss@^8.3.11:
+  version "8.4.4"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.4.tgz#d53d4ec6a75fd62557a66bb41978bf47ff0c2869"
+  integrity sha512-joU6fBsN6EIer28Lj6GDFoC/5yOZzLCfn0zHAn/MYXI7aPt4m4hK5KC5ovEZXy+lnCjmYIbQWngvju2ddyEr8Q==
   dependencies:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
-    source-map-js "^0.6.2"
+    source-map-js "^1.0.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4861,9 +4803,9 @@ property-expr@^2.0.4:
   integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
 
 property-information@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.0.1.tgz#7c668d9f2b9cb63bc3e105d8b8dfee7221a17800"
-  integrity sha512-F4WUUAF7fMeF4/JUFHNBWDaKDXi2jbvqBW/y6o5wsf3j19wTZ7S60TmtB5HoBhtgw7NKQRMWuz5vk2PR0CygUg==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.1.1.tgz#5ca85510a3019726cb9afed4197b7b8ac5926a22"
+  integrity sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==
 
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
@@ -4876,9 +4818,9 @@ punycode@^2.1.0:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@^6.9.4:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
   dependencies:
     side-channel "^1.0.4"
 
@@ -4913,9 +4855,9 @@ quick-lru@^4.0.1:
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 react-bootstrap@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.0.2.tgz#ec3492513066038bcf612ab8fcab46f88d254ab9"
-  integrity sha512-QuMqJ+WJmd6dUyOys6OF3nr6T/FjUVAoEMbSjsFrwVufJtvMox0SU1Dvz/cDID+Dl6Rz2RLcJzyqkdl+DEK2Gg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.0.3.tgz#a53ee96aa5e1c205d46e73ae78c374a43017df74"
+  integrity sha512-gIRzQf170SGKS09azr8Cl9+8FxBf3J9jyFf/8sWNWXtRcgbRzTog9bFCS4ua5Wv1U/A7W7hRlnrKxzy+wl+5Rw==
   dependencies:
     "@babel/runtime" "^7.14.0"
     "@restart/context" "^2.1.4"
@@ -4987,9 +4929,9 @@ react-lifecycles-compat@^3.0.4:
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-markdown@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-7.1.0.tgz#0ba62a4459daab6600ede83495a9228dae9d8f8e"
-  integrity sha512-hL8cLLkTydyoKlZWZOjlU6TvMYIw9qKLh1CCzVfnhKt/R/SnKVAqiyugetXY61CkjhBqJl2C5FdU3OwHYo7SrQ==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-7.1.1.tgz#cb4d2c2fa3bc1292c889b068a5bf064ae4be1c60"
+  integrity sha512-bXS7indkcPlCLB6wRFFzX8Xdghr62TBxUF2587o+CUkaZlNaoILb2qNt+5pYmTZuCOC+OeEcdJ+06mu5whtCVQ==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/unist" "^2.0.0"
@@ -5205,9 +5147,9 @@ remark-gfm@^3.0.1:
     unified "^10.0.0"
 
 remark-parse@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.0.tgz#65e2b2b34d8581d36b97f12a2926bb2126961cb4"
-  integrity sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
   dependencies:
     "@types/mdast" "^3.0.0"
     mdast-util-from-markdown "^1.0.0"
@@ -5301,10 +5243,10 @@ rollup-plugin-analyzer@^4.0.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz#96b757ed64a098b59d72f085319e68cdd86d5798"
   integrity sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==
 
-rollup@^2.57.0:
-  version "2.58.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.3.tgz#71a08138d9515fb65043b6a18618b2ed9ac8d239"
-  integrity sha512-ei27MSw1KhRur4p87Q0/Va2NAYqMXOX++FNEumMBcdreIRLURKy+cE2wcDJKBn0nfmhP2ZGrJkP1XPO+G8FJQw==
+rollup@^2.59.0:
+  version "2.60.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.60.2.tgz#3f45ace36a9b10b4297181831ea0719922513463"
+  integrity sha512-1Bgjpq61sPjgoZzuiDSGvbI1tD91giZABgjCQBKM5aYLnzjq52GoDuWVwT/cm/MCxCMPU8gqQvkj8doQ5C8Oqw==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -5340,9 +5282,9 @@ safe-buffer@~5.1.1:
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 sass@~1.43.4:
-  version "1.43.4"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.43.4.tgz#68c7d6a1b004bef49af0d9caf750e9b252105d1f"
-  integrity sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==
+  version "1.43.5"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.43.5.tgz#25a9d91dd098793ef7229d7b04dd3daae2fc4a65"
+  integrity sha512-WuNm+eAryMgQluL7Mbq9M4EruyGGMyal7Lu58FfnRMVWxgUzIvI7aSn60iNt3kn5yZBMR7G84fAGDcwqOF5JOg==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
@@ -5443,9 +5385,9 @@ side-channel@^1.0.4:
     object-inspect "^1.9.0"
 
 signal-exit@^3.0.2, signal-exit@^3.0.3:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
-  integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5474,15 +5416,15 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
 
 source-map-support@^0.5.17:
-  version "0.5.20"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
-  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -5524,9 +5466,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
-  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
+  integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
 specificity@^0.4.1:
   version "0.4.1"
@@ -5677,11 +5619,11 @@ stylelint-config-prettier@^9.0.3:
   integrity sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==
 
 stylelint-config-recommended-scss@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.0.tgz#0b1d8117c84f616283abf309272af97df32ba79d"
-  integrity sha512-nQonGHxkv+n61WiU03bcHBHlA9XPMg7mGyD48ZmwrcnNroCEbH2nZhfn6Y1xcxfIHpD2wnwtAUPAwFaNQQpivw==
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz#193f483861c76a36ece24c52eb6baca4838f4a48"
+  integrity sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==
   dependencies:
-    postcss-scss "^4.0.1"
+    postcss-scss "^4.0.2"
     stylelint-config-recommended "^6.0.0"
     stylelint-scss "^4.0.0"
 
@@ -5829,10 +5771,21 @@ symbol-observable@^4.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
-table@6.7.3, table@^6.7.3:
+table@6.7.3:
   version "6.7.3"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.3.tgz#255388439715a738391bd2ee4cbca89a4d05a9b7"
   integrity sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+
+table@^6.7.3:
+  version "6.7.5"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.7.5.tgz#f04478c351ef3d8c7904f0e8be90a1b62417d238"
+  integrity sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==
   dependencies:
     ajv "^8.0.1"
     lodash.truncate "^4.4.2"
@@ -5846,9 +5799,9 @@ text-table@^0.2.0:
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
 tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
@@ -5904,10 +5857,10 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-invariant@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
-  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -5923,9 +5876,9 @@ ts-node@^8:
     yn "3.1.1"
 
 tsconfig-paths@^3.11.0, tsconfig-paths@^3.9.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
-  integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
+  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
@@ -6036,9 +5989,9 @@ uncontrollable@^7.2.1:
     react-lifecycles-compat "^3.0.4"
 
 unified@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.0.tgz#4e65eb38fc2448b1c5ee573a472340f52b9346fe"
-  integrity sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.1.tgz#345e349e3ab353ab612878338eb9d57b4dea1d46"
+  integrity sha512-v4ky1+6BN9X3pQrOdkFIPWAaeDsHPE1svRDxq7YpTc2plkIqFMwukfqM+l0ewpP9EfwARlt9pPFAeWYhHm8X9w==
   dependencies:
     "@types/unist" "^2.0.0"
     bail "^2.0.0"
@@ -6216,14 +6169,14 @@ vite-tsconfig-paths@^3.3.17:
     tsconfig-paths "^3.9.0"
 
 vite@^2.6.14:
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.6.14.tgz#35c09a15e4df823410819a2a239ab11efb186271"
-  integrity sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.7.1.tgz#be50ad13214290ecbebbe5ad389ed423cb5f137e"
+  integrity sha512-TDXXhcu5lyQ6uosK4ZWaOyB4VzOiizk0biitRzDzaEtgSUi8rVYPc4k1xgOjLSf0OuceDJmojFKXHOX9DB1WuQ==
   dependencies:
-    esbuild "^0.13.2"
-    postcss "^8.3.8"
+    esbuild "^0.13.12"
+    postcss "^8.3.11"
     resolve "^1.20.0"
-    rollup "^2.57.0"
+    rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -6337,6 +6290,15 @@ wrap-ansi@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -6407,12 +6369,11 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable-ts@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
   dependencies:
-    "@types/zen-observable" "0.8.3"
     zen-observable "0.8.15"
 
 zen-observable@0.8.15, zen-observable@^0.8.0:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -73,7 +73,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
   integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
-"@babel/core@^7.15.5":
+"@babel/core@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.0.tgz#c4ff44046f5fe310525cc9eb4ef5147f0c5374d4"
   integrity sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
@@ -247,28 +247,28 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-jsx-development@^7.14.5":
+"@babel/plugin-transform-react-jsx-development@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.0.tgz#1cb52874678d23ab11d0d16488d54730807303ef"
   integrity sha512-qq65iSqBRq0Hr3wq57YG2AmW0H6wgTnIzpffTphrUWUgLCOK+zf1f7G0vuOiXrp7dU1qq+fQBoqZ3wCDAkhFzw==
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.16.0"
 
-"@babel/plugin-transform-react-jsx-self@^7.14.9":
+"@babel/plugin-transform-react-jsx-self@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.16.0.tgz#09202158abbc716a08330f392bfb98d6b9acfa0c"
   integrity sha512-97yCFY+2GvniqOThOSjPor8xUoDiQ0STVWAQMl3pjhJoFVe5DuXDLZCRSZxu9clx+oRCbTiXGgKEG/Yoyo6Y+w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-jsx-source@^7.14.5":
+"@babel/plugin-transform-react-jsx-source@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.16.0.tgz#d40c959d7803aae38224594585748693e84c0a22"
   integrity sha512-8yvbGGrHOeb/oyPc9tzNoe9/lmIjz3HLa9Nc5dMGDyNpGjfFrk8D2KdEq9NRkftZzeoQEW6yPQ29TMZtrLiUUA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-jsx@^7.14.9", "@babel/plugin-transform-react-jsx@^7.16.0":
+"@babel/plugin-transform-react-jsx@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz#55b797d4960c3de04e07ad1c0476e2bc6a4889f1"
   integrity sha512-rqDgIbukZ44pqq7NIRPGPGNklshPkvlmvqjdx3OZcGPk4zGIenYkxDTvl3LsSL8gqcc3ZzGmXPE6hR/u/voNOw==
@@ -984,18 +984,18 @@
     "@typescript-eslint/types" "5.6.0"
     eslint-visitor-keys "^3.0.0"
 
-"@vitejs/plugin-react@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.0.5.tgz#8da501137078c8cb791cf2611f23de7b96ad5494"
-  integrity sha512-n92p2fMlo0FZED+y5WYt+tM1mnQsVxcjZ8HuTJhv9gU/nW2zHwEoCemU78Az0KvF+bgafv2AdU4VEnP24bppvw==
+"@vitejs/plugin-react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.1.1.tgz#5a242c64fa0a588e5b203938e5bd6d05fa25edf2"
+  integrity sha512-IJSRD4culdwQ6cRK0D1mstV1vdvYSb2HK1JQ1FDo6Hr7j5ppWJEwBC2v/Gy0h/A1lMmi4AnXACY/d10EgbQNEA==
   dependencies:
-    "@babel/core" "^7.15.5"
-    "@babel/plugin-transform-react-jsx" "^7.14.9"
-    "@babel/plugin-transform-react-jsx-development" "^7.14.5"
-    "@babel/plugin-transform-react-jsx-self" "^7.14.9"
-    "@babel/plugin-transform-react-jsx-source" "^7.14.5"
+    "@babel/core" "^7.16.0"
+    "@babel/plugin-transform-react-jsx" "^7.16.0"
+    "@babel/plugin-transform-react-jsx-development" "^7.16.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.16.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.16.0"
     "@rollup/pluginutils" "^4.1.1"
-    react-refresh "^0.10.0"
+    react-refresh "^0.11.0"
     resolve "^1.20.0"
 
 "@wry/context@^0.6.0":
@@ -4948,10 +4948,10 @@ react-markdown@^7.1.0:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-refresh@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
-  integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
+react-refresh@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
+  integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 react-responsive-carousel@^3.2.20:
   version "3.2.22"

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -21,7 +21,7 @@ type Query {
   findTag(id: ID, name: String): Tag @hasRole(role: READ)
   queryTags(tag_filter: TagFilterType, filter: QuerySpec): QueryTagsResultType! @hasRole(role: READ)
 
-  """Find a tag cateogry by ID"""
+  """Find a tag category by ID"""
   findTagCategory(id: ID!): TagCategory @hasRole(role: READ)
   queryTagCategories(filter: QuerySpec): QueryTagCategoriesResultType! @hasRole(role: READ)
 
@@ -36,7 +36,6 @@ type Query {
   """Finds scenes that match a list of hashes"""
   findScenesByFingerprints(fingerprints: [String!]!): [Scene!]! @hasRole(role: READ)
   findScenesByFullFingerprints(fingerprints: [FingerprintQueryInput!]!): [Scene!]! @hasRole(role: READ)
-
   queryScenes(scene_filter: SceneFilterType, filter: QuerySpec): QueryScenesResultType! @hasRole(role: READ)
 
   #### Edits ####

--- a/pkg/api/integration_test.go
+++ b/pkg/api/integration_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gofrs/uuid"
 	"github.com/stashapp/stash-box/pkg/api"
 	dbtest "github.com/stashapp/stash-box/pkg/database/databasetest"
 	"github.com/stashapp/stash-box/pkg/dataloader"
@@ -19,6 +18,7 @@ import (
 	"github.com/99designs/gqlgen/client"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/gofrs/uuid"
 )
 
 // we need to create some users to test the api with, otherwise all calls

--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -1,7 +1,6 @@
 package edit
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -100,7 +99,7 @@ func (m *PerformerEditProcessor) modifyEdit(input models.PerformerEditInput, inp
 	}
 
 	if reflect.DeepEqual(performerEdit.Old, performerEdit.New) {
-		return errors.New("edit contains no changes")
+		return ErrNoChanges
 	}
 
 	return m.edit.SetData(performerEdit)
@@ -111,7 +110,7 @@ func (m *PerformerEditProcessor) mergeEdit(input models.PerformerEditInput, inpu
 
 	// get the existing performer
 	if input.Edit.ID == nil {
-		return errors.New("Merge performer ID is required")
+		return ErrMergeIDMissing
 	}
 	performerID := *input.Edit.ID
 	performer, err := pqb.Find(performerID)
@@ -135,13 +134,13 @@ func (m *PerformerEditProcessor) mergeEdit(input models.PerformerEditInput, inpu
 			return fmt.Errorf("performer with id %v not found", sourceID)
 		}
 		if performerID == sourceID {
-			return errors.New("merge target cannot be used as source")
+			return ErrMergeTargetIsSource
 		}
 		mergeSources = append(mergeSources, sourceID)
 	}
 
 	if len(mergeSources) < 1 {
-		return errors.New("No merge sources found")
+		return ErrNoMergeSources
 	}
 
 	// perform a diff against the input and the current object

--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -3,6 +3,7 @@ package edit
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -96,6 +97,10 @@ func (m *PerformerEditProcessor) modifyEdit(input models.PerformerEditInput, inp
 
 	if input.Options != nil && input.Options.SetModifyAliases != nil {
 		performerEdit.SetModifyAliases = *input.Options.SetModifyAliases
+	}
+
+	if reflect.DeepEqual(performerEdit.Old, performerEdit.New) {
+		return errors.New("edit contains no changes")
 	}
 
 	return m.edit.SetData(performerEdit)

--- a/pkg/manager/edit/scene.go
+++ b/pkg/manager/edit/scene.go
@@ -230,7 +230,7 @@ func (m *SceneEditProcessor) mergeEdit(input models.SceneEditInput, inputSpecifi
 	}
 
 	if scene == nil {
-		return fmt.Errorf("%w: scene %s", ErrEntityNotFound, sceneID.String())
+		return fmt.Errorf("%w: target scene %s", ErrEntityNotFound, sceneID.String())
 	}
 
 	var mergeSources []uuid.UUID
@@ -241,7 +241,7 @@ func (m *SceneEditProcessor) mergeEdit(input models.SceneEditInput, inputSpecifi
 		}
 
 		if sourceScene == nil {
-			return fmt.Errorf("%w: scene %s", ErrEntityNotFound, sourceID.String())
+			return fmt.Errorf("%w: source scene %s", ErrEntityNotFound, sourceID.String())
 		}
 		if sceneID == sourceID {
 			return ErrMergeTargetIsSource

--- a/pkg/manager/edit/studio.go
+++ b/pkg/manager/edit/studio.go
@@ -113,7 +113,7 @@ func (m *StudioEditProcessor) mergeEdit(input models.StudioEditInput, inputSpeci
 	}
 
 	if studio == nil {
-		return fmt.Errorf("%w: studio %s", ErrEntityNotFound, studioID.String())
+		return fmt.Errorf("%w: target studio %s", ErrEntityNotFound, studioID.String())
 	}
 
 	var mergeSources []uuid.UUID
@@ -124,7 +124,7 @@ func (m *StudioEditProcessor) mergeEdit(input models.StudioEditInput, inputSpeci
 		}
 
 		if sourceStudio == nil {
-			return fmt.Errorf("%w: studio %s", ErrEntityNotFound, sourceID.String())
+			return fmt.Errorf("%w: source studio %s", ErrEntityNotFound, sourceID.String())
 		}
 		if studioID == sourceID {
 			return ErrMergeTargetIsSource

--- a/pkg/manager/edit/tag.go
+++ b/pkg/manager/edit/tag.go
@@ -1,7 +1,6 @@
 package edit
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -52,7 +51,7 @@ func (m *TagEditProcessor) modifyEdit(input models.TagEditInput, inputSpecified 
 	}
 
 	if tag == nil {
-		return errors.New("tag with id " + tagID.String() + " not found")
+		return fmt.Errorf("%w: tag %s", ErrEntityNotFound, tagID.String())
 	}
 
 	// perform a diff against the input and the current object
@@ -81,7 +80,7 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputSpecified I
 
 	// get the existing tag
 	if input.Edit.ID == nil {
-		return errors.New("Merge target ID is required")
+		return ErrMergeIDMissing
 	}
 	tagID := *input.Edit.ID
 	tag, err := tqb.Find(*input.Edit.ID)
@@ -91,7 +90,7 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputSpecified I
 	}
 
 	if tag == nil {
-		return errors.New("tag with id " + tagID.String() + " not found")
+		return fmt.Errorf("%w: tag %s", ErrEntityNotFound, tagID.String())
 	}
 
 	var mergeSources []uuid.UUID
@@ -102,16 +101,16 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputSpecified I
 		}
 
 		if sourceTag == nil {
-			return errors.New("tag with id " + sourceID.String() + " not found")
+			return fmt.Errorf("%w: tag %s", ErrEntityNotFound, sourceID.String())
 		}
 		if tagID == sourceID {
-			return errors.New("merge target cannot be used as source")
+			return ErrMergeTargetIsSource
 		}
 		mergeSources = append(mergeSources, sourceID)
 	}
 
 	if len(mergeSources) < 1 {
-		return errors.New("No merge sources found")
+		return ErrNoMergeSources
 	}
 
 	// perform a diff against the input and the current object
@@ -184,7 +183,7 @@ func (m *TagEditProcessor) apply() error {
 			return err
 		}
 		if tag == nil {
-			return errors.New("Tag not found: " + tagID.String())
+			return fmt.Errorf("%w: tag %s", ErrEntityNotFound, tagID.String())
 		}
 	}
 

--- a/pkg/manager/edit/tag.go
+++ b/pkg/manager/edit/tag.go
@@ -90,7 +90,7 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputSpecified I
 	}
 
 	if tag == nil {
-		return fmt.Errorf("%w: tag %s", ErrEntityNotFound, tagID.String())
+		return fmt.Errorf("%w: target tag %s", ErrEntityNotFound, tagID.String())
 	}
 
 	var mergeSources []uuid.UUID
@@ -101,7 +101,7 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputSpecified I
 		}
 
 		if sourceTag == nil {
-			return fmt.Errorf("%w: tag %s", ErrEntityNotFound, sourceID.String())
+			return fmt.Errorf("%w: source tag %s", ErrEntityNotFound, sourceID.String())
 		}
 		if tagID == sourceID {
 			return ErrMergeTargetIsSource

--- a/pkg/manager/edit/tag.go
+++ b/pkg/manager/edit/tag.go
@@ -3,6 +3,7 @@ package edit
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/gofrs/uuid"
 
@@ -66,6 +67,10 @@ func (m *TagEditProcessor) modifyEdit(input models.TagEditInput, inputSpecified 
 		}
 
 		tagEdit.New.AddedAliases, tagEdit.New.RemovedAliases = utils.StrSliceCompare(input.Details.Aliases, aliases)
+	}
+
+	if reflect.DeepEqual(tagEdit.Old, tagEdit.New) {
+		return ErrNoChanges
 	}
 
 	return m.edit.SetData(tagEdit)

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -3951,7 +3951,7 @@ type Query {
   findTag(id: ID, name: String): Tag @hasRole(role: READ)
   queryTags(tag_filter: TagFilterType, filter: QuerySpec): QueryTagsResultType! @hasRole(role: READ)
 
-  """Find a tag cateogry by ID"""
+  """Find a tag category by ID"""
   findTagCategory(id: ID!): TagCategory @hasRole(role: READ)
   queryTagCategories(filter: QuerySpec): QueryTagCategoriesResultType! @hasRole(role: READ)
 
@@ -3966,13 +3966,11 @@ type Query {
   """Finds scenes that match a list of hashes"""
   findScenesByFingerprints(fingerprints: [String!]!): [Scene!]! @hasRole(role: READ)
   findScenesByFullFingerprints(fingerprints: [FingerprintQueryInput!]!): [Scene!]! @hasRole(role: READ)
-
   queryScenes(scene_filter: SceneFilterType, filter: QuerySpec): QueryScenesResultType! @hasRole(role: READ)
 
   #### Edits ####
 
   findEdit(id: ID!): Edit @hasRole(role: READ)
-
   queryEdits(edit_filter: EditFilterType, filter: QuerySpec): QueryEditsResultType! @hasRole(role: READ)
 
   #### Users ####


### PR DESCRIPTION
Splitting out the edit diffing refactor + a few other changes from #140.
Probably needs a little bit more testing because I did make some changes here and there, overall is okay.

Not in the commit messages:
* Added "OTHER" to `utils.enum.ethnicityEnum` (was missing)
* Changed [`func (m *StudioEditProcessor) diffImages`](https://github.com/InfiniteTF/stash-box/blob/e0f391b41299a80a6bc04c21d83df8d312a04b51/pkg/manager/edit/studio.go#L99)'s return value to `nil`.

#140 rebased onto this branch: https://github.com/peolic/stash-box/tree/url-sites-rebased
The [`InfiniteTF/url-sites <--> peolic/url-sites-rebased` diff](https://github.com/InfiniteTF/stash-box/compare/url-sites..peolic:url-sites-rebased) is minimal so went over it, should be good.

Summary:
* Update libs
* Use `URLFragment` and `ImageFragment`
* Remove bootstrap-4 classes
* import order in api.integration_test
* Refactor edit diffing
  - StudioSelect:
	- change value shape
  - StudioForm:
    - add tabs
    - add preview of changes on confirm tab
    - rename `name` field
    - add image upload warning
  - PerformerForm:
    - fix auto breast type change on gender change
    - refactor preview of changes
* Add submission errors to edit pages
  - Prevent submission of empty tag edit
  - Replace errors in edit manager