### PR TITLE
Refactor `SearchField` to use Promises

### DIFF
--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -1415,6 +1415,9 @@ export interface ApplyEdit_applyEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: ApplyEdit_applyEdit_comments[];
   votes: ApplyEdit_applyEdit_votes[];

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -1415,6 +1415,9 @@ export interface Edit_findEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: Edit_findEdit_comments[];
   votes: Edit_findEdit_votes[];

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -1415,6 +1415,9 @@ export interface EditFragment {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: EditFragment_comments[];
   votes: EditFragment_votes[];

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -1415,6 +1415,9 @@ export interface Edits_queryEdits_edits {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: Edits_queryEdits_edits_comments[];
   votes: Edits_queryEdits_edits_votes[];

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -1415,6 +1415,9 @@ export interface PerformerEdit_performerEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: PerformerEdit_performerEdit_comments[];
   votes: PerformerEdit_performerEdit_votes[];

--- a/frontend/src/graphql/definitions/SceneEdit.ts
+++ b/frontend/src/graphql/definitions/SceneEdit.ts
@@ -1415,6 +1415,9 @@ export interface SceneEdit_sceneEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: SceneEdit_sceneEdit_comments[];
   votes: SceneEdit_sceneEdit_votes[];

--- a/frontend/src/graphql/definitions/StudioEdit.ts
+++ b/frontend/src/graphql/definitions/StudioEdit.ts
@@ -1415,6 +1415,9 @@ export interface StudioEdit_studioEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: StudioEdit_studioEdit_comments[];
   votes: StudioEdit_studioEdit_votes[];

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -1415,6 +1415,9 @@ export interface TagEdit_tagEdit {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: TagEdit_tagEdit_comments[];
   votes: TagEdit_tagEdit_votes[];

--- a/frontend/src/graphql/definitions/Vote.ts
+++ b/frontend/src/graphql/definitions/Vote.ts
@@ -1415,6 +1415,9 @@ export interface Vote_editVote {
    *  = Accepted - Rejected
    */
   vote_count: number;
+  /**
+   * Is the edit considered destructive.
+   */
   destructive: boolean;
   comments: Vote_editVote_comments[];
   votes: Vote_editVote_votes[];

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -3144,6 +3144,7 @@ type Edit {
     votes: [EditVote!]!
     """ = Accepted - Rejected"""
     vote_count: Int!
+    """Is the edit considered destructive."""
     destructive: Boolean!
     status: VoteStatusEnum!
     applied: Boolean!


### PR DESCRIPTION
Due to a regression in `@apollo/client@3.5.6` (possibly since `3.5`), the `onCompleted` function is not executed reliably after each call to `search()` starting from the second search.
Awaiting the `Promise` of `search()` is also not a viable solution, as the data in its result is outdated (as in, of the previous query), again, starting from the second search.

This refactors the search to use `client.query` instead of `useLazyQuery`, much like [`TagSelect`](https://github.com/stashapp/stash-box/blob/af2785f91ea9adf467a2591e438e2f7f8aab5526/frontend/src/components/tagSelect/TagSelect.tsx#L73-L79) and [`StudioSelect`](https://github.com/stashapp/stash-box/blob/af2785f91ea9adf467a2591e438e2f7f8aab5526/frontend/src/components/studioSelect/StudioSelect.tsx#L47-L50).