### PR TITLE
Replace all `IMMEDIATE_REJECTED` with `CANCELED`

### DIFF
--- a/pkg/database/migrations/postgres/17_edit_votes.up.sql
+++ b/pkg/database/migrations/postgres/17_edit_votes.up.sql
@@ -1,4 +1,5 @@
 UPDATE edits SET status = 'REJECTED', updated_at = NOW() WHERE status = 'PENDING';
+UPDATE edits SET status = 'CANCELED' WHERE status = 'IMMEDIATE_REJECTED';
 
 CREATE TABLE "edit_votes" (
   "edit_id" UUID NOT NULL,


### PR DESCRIPTION
As part of the edit voting migration, a `CANCELED` edit status was added.
Prior to this change, any edit cancellation, whether it was by an admin or by the submitter, had its status set to `IMMEDIATE_REJECT`, and the UI showed "CANCELLED".

This was raised during a discussion on Discord.
This makes sense for StashDB, as most `IMMEDIATE_REJECTED` edits are actually cancellations made by the submitter.
And even if it's not "most edits",
I think it's more fair to have them listed as cancellations instead of them being "rejected by an admin",
as the new UI now separates the two and clearly states "... was rejected by an admin" and "... was cancelled".