### PR TITLE
Fix Markdown footnotes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,7 @@
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-hook-form": "7.19.5",
-    "react-markdown": "^7.1.0",
+    "react-markdown": "^8.0.0",
     "react-responsive-carousel": "^3.2.20",
     "react-router-dom": "^5.2.0",
     "react-select": "^5.2.1",

--- a/frontend/src/components/editCard/EditCard.tsx
+++ b/frontend/src/components/editCard/EditCard.tsx
@@ -39,7 +39,7 @@ const EditCardComponent: FC<Props> = ({ edit, showVotes = false }) => {
     />
   );
   const comments = (edit.comments ?? []).map((comment) => (
-    <EditComment {...comment} key={`${comment.user?.id}-${comment.date}`} />
+    <EditComment {...comment} key={comment.id} />
   ));
 
   return (

--- a/frontend/src/components/editCard/EditComment.tsx
+++ b/frontend/src/components/editCard/EditComment.tsx
@@ -8,15 +8,16 @@ import { formatDateTime, userHref, Markdown } from "src/utils";
 const CLASSNAME = "EditComment";
 
 interface Props {
+  id: string;
   comment: string;
   date: string;
   user?: Pick<User, "name"> | null;
 }
 
-const EditComment: FC<Props> = ({ comment, date, user }) => (
+const EditComment: FC<Props> = ({ id, comment, date, user }) => (
   <Card className={CLASSNAME}>
     <Card.Body className="pb-0">
-      <Markdown text={comment} />
+      <Markdown text={comment} unique={id} />
     </Card.Body>
     <Card.Footer className="text-end">
       {user ? (

--- a/frontend/src/components/form/NoteInput.tsx
+++ b/frontend/src/components/form/NoteInput.tsx
@@ -29,6 +29,7 @@ const NoteInput: FC<IProps> = ({
   };
 
   const textareaProps = register ? register("note") : { name: "note" };
+  const now = new Date().toISOString();
 
   return (
     <div className={cx("NoteInput", { "is-invalid": hasError })}>
@@ -44,8 +45,9 @@ const NoteInput: FC<IProps> = ({
         </Tab>
         <Tab eventKey="preview" title="Preview" unmountOnExit mountOnEnter>
           <EditComment
+            id={`${auth.user?.id}-${now}`}
             comment={comment}
-            date={new Date().toString()}
+            date={now}
             user={auth.user}
           />
         </Tab>

--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -17,6 +17,7 @@ export interface ApplyEdit_applyEdit_comments_user {
 
 export interface ApplyEdit_applyEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: ApplyEdit_applyEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/CommentFragment.ts
+++ b/frontend/src/graphql/definitions/CommentFragment.ts
@@ -15,6 +15,7 @@ export interface CommentFragment_user {
 
 export interface CommentFragment {
   __typename: "EditComment";
+  id: string;
   user: CommentFragment_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -17,6 +17,7 @@ export interface Edit_findEdit_comments_user {
 
 export interface Edit_findEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: Edit_findEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/EditComment.ts
+++ b/frontend/src/graphql/definitions/EditComment.ts
@@ -17,6 +17,7 @@ export interface EditComment_editComment_comments_user {
 
 export interface EditComment_editComment_comments {
   __typename: "EditComment";
+  id: string;
   user: EditComment_editComment_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -17,6 +17,7 @@ export interface EditFragment_comments_user {
 
 export interface EditFragment_comments {
   __typename: "EditComment";
+  id: string;
   user: EditFragment_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -17,6 +17,7 @@ export interface Edits_queryEdits_edits_comments_user {
 
 export interface Edits_queryEdits_edits_comments {
   __typename: "EditComment";
+  id: string;
   user: Edits_queryEdits_edits_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -17,6 +17,7 @@ export interface PerformerEdit_performerEdit_comments_user {
 
 export interface PerformerEdit_performerEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: PerformerEdit_performerEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/SceneEdit.ts
+++ b/frontend/src/graphql/definitions/SceneEdit.ts
@@ -17,6 +17,7 @@ export interface SceneEdit_sceneEdit_comments_user {
 
 export interface SceneEdit_sceneEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: SceneEdit_sceneEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/StudioEdit.ts
+++ b/frontend/src/graphql/definitions/StudioEdit.ts
@@ -17,6 +17,7 @@ export interface StudioEdit_studioEdit_comments_user {
 
 export interface StudioEdit_studioEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: StudioEdit_studioEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -17,6 +17,7 @@ export interface TagEdit_tagEdit_comments_user {
 
 export interface TagEdit_tagEdit_comments {
   __typename: "EditComment";
+  id: string;
   user: TagEdit_tagEdit_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/definitions/Vote.ts
+++ b/frontend/src/graphql/definitions/Vote.ts
@@ -17,6 +17,7 @@ export interface Vote_editVote_comments_user {
 
 export interface Vote_editVote_comments {
   __typename: "EditComment";
+  id: string;
   user: Vote_editVote_comments_user | null;
   date: any;
   comment: string;

--- a/frontend/src/graphql/fragments/CommentFragment.gql
+++ b/frontend/src/graphql/fragments/CommentFragment.gql
@@ -1,4 +1,5 @@
 fragment CommentFragment on EditComment {
+  id
   user {
     id
     name

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -340,3 +340,7 @@ textarea.text-input {
   min-height: 12ex;
   overflow-y: scroll;
 }
+
+.sr-only {
+  @include visually-hidden;
+}

--- a/frontend/src/utils/markdown.tsx
+++ b/frontend/src/utils/markdown.tsx
@@ -6,13 +6,17 @@ import RehypeExternalLinks from "rehype-external-links";
 
 interface Props {
   text: string | null | undefined;
+  unique?: string;
 }
 
-export const Markdown: FC<Props> = ({ text }) =>
+export const Markdown: FC<Props> = ({ text, unique }) =>
   text ? (
     <ReactMarkdown
       remarkPlugins={[RemarkGFM, RemarkBreaks]}
       rehypePlugins={[RehypeExternalLinks]}
+      remarkRehypeOptions={{
+        clobberPrefix: unique ? `${unique}-` : undefined,
+      }}
       transformImageUri={() => ""}
     >
       {text}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3888,16 +3888,17 @@ mdast-util-gfm@^2.0.0:
     mdast-util-gfm-table "^1.0.0"
     mdast-util-gfm-task-list-item "^1.0.0"
 
-mdast-util-to-hast@^11.0.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-11.3.0.tgz#ea9220617a710e80aa5cc3ac7cc9d4bb0440ae7a"
-  integrity sha512-4o3Cli3hXPmm1LhB+6rqhfsIUBjnKFlIUZvudaermXB+4/KONdd/W4saWWkC+LBLbPMqhFSSTSRgafHsT5fVJw==
+mdast-util-to-hast@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.1.0.tgz#5942207baf1b46fc04a588fd6bf37bfcfb4043b2"
+  integrity sha512-dHfCt9Yh05AXEeghoziB3DjJV8oCIKdQmBJOPoAT1NlgMDBy+/MQn7Pxfq0jI8YRO1IfzcnmA/OU3FVVn/E5Sg==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/mdast" "^3.0.0"
     "@types/mdurl" "^1.0.0"
     mdast-util-definitions "^5.0.0"
     mdurl "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
     unist-builder "^3.0.0"
     unist-util-generated "^2.0.0"
     unist-util-position "^4.0.0"
@@ -4928,10 +4929,10 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-markdown@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-7.1.1.tgz#cb4d2c2fa3bc1292c889b068a5bf064ae4be1c60"
-  integrity sha512-bXS7indkcPlCLB6wRFFzX8Xdghr62TBxUF2587o+CUkaZlNaoILb2qNt+5pYmTZuCOC+OeEcdJ+06mu5whtCVQ==
+react-markdown@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-8.0.0.tgz#3243296a59ddb0f451d262cc2e11123674b416c2"
+  integrity sha512-qbrWpLny6Ef2xHqnYqtot948LXP+4FtC+MWIuaN1kvSnowM+r1qEeEHpSaU0TDBOisQuj+Qe6eFY15cNL3gLAw==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/unist" "^2.0.0"
@@ -4941,7 +4942,7 @@ react-markdown@^7.1.0:
     property-information "^6.0.0"
     react-is "^17.0.0"
     remark-parse "^10.0.0"
-    remark-rehype "^9.0.0"
+    remark-rehype "^10.0.0"
     space-separated-tokens "^2.0.0"
     style-to-object "^0.3.0"
     unified "^10.0.0"
@@ -5153,14 +5154,14 @@ remark-parse@^10.0.0:
     mdast-util-from-markdown "^1.0.0"
     unified "^10.0.0"
 
-remark-rehype@^9.0.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-9.1.0.tgz#e4b5b6e19c125b3780343eb66c3e9b99b0f06a81"
-  integrity sha512-oLa6YmgAYg19zb0ZrBACh40hpBLteYROaPLhBXzLgjqyHQrN+gVP9N/FJvfzuNNuzCutktkroXEZBrxAxKhh7Q==
+remark-rehype@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
+  integrity sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/mdast" "^3.0.0"
-    mdast-util-to-hast "^11.0.0"
+    mdast-util-to-hast "^12.1.0"
     unified "^10.0.0"
 
 require-from-string@^2.0.2:

--- a/graphql/schema/types/edit.graphql
+++ b/graphql/schema/types/edit.graphql
@@ -32,6 +32,7 @@ type EditVote {
 }
 
 type EditComment {
+    id: ID!
     user: User
     date: Time!
     comment: String!

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -94,6 +94,7 @@ type ComplexityRoot struct {
 	EditComment struct {
 		Comment func(childComplexity int) int
 		Date    func(childComplexity int) int
+		ID      func(childComplexity int) int
 		User    func(childComplexity int) int
 	}
 
@@ -847,6 +848,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EditComment.Date(childComplexity), true
+
+	case "EditComment.id":
+		if e.complexity.EditComment.ID == nil {
+			break
+		}
+
+		return e.complexity.EditComment.ID(childComplexity), true
 
 	case "EditComment.user":
 		if e.complexity.EditComment.User == nil {
@@ -3110,6 +3118,7 @@ type EditVote {
 }
 
 type EditComment {
+    id: ID!
     user: User
     date: Time!
     comment: String!
@@ -6057,6 +6066,41 @@ func (ec *executionContext) _Edit_updated(ctx context.Context, field graphql.Col
 	res := resTmp.(*time.Time)
 	fc.Result = res
 	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _EditComment_id(ctx context.Context, field graphql.CollectedField, obj *EditComment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "EditComment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgofrsᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EditComment_user(ctx context.Context, field graphql.CollectedField, obj *EditComment) (ret graphql.Marshaler) {
@@ -21930,6 +21974,11 @@ func (ec *executionContext) _EditComment(ctx context.Context, sel ast.SelectionS
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("EditComment")
+		case "id":
+			out.Values[i] = ec._EditComment_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "user":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {


### PR DESCRIPTION
Fixes footnote/back-reference links not being unique per comment, by using the comment ID (and `` `${userID}-${timestamp}` `` in the case of comment previews).
`.sr-only` class is needed because the generated footnote code uses it and Bootstrap 5 renamed the class to `.visually-hidden`.