### PR TITLE
Make tag diff more compact

### DIFF
--- a/frontend/src/components/editCard/EditExpiration.tsx
+++ b/frontend/src/components/editCard/EditExpiration.tsx
@@ -23,7 +23,12 @@ const ExpirationNotification: FC<Props> = ({ edit }) => {
   const { data } = useConfig();
   const config = data?.getConfig;
 
-  if (!config || edit.status !== VoteStatusEnum.PENDING) return <></>;
+  if (
+    !config ||
+    !config.vote_cron_interval ||
+    edit.status !== VoteStatusEnum.PENDING
+  )
+    return <></>;
 
   // Pending edits that have reached the voting threshold have shorter voting periods.
   // This will happen for destructive edits, or when votes are not unanimous.

--- a/frontend/src/components/editCard/styles.scss
+++ b/frontend/src/components/editCard/styles.scss
@@ -59,3 +59,16 @@
   margin-bottom: 20px;
   text-align: right;
 }
+
+.ListChangeRow {
+  &-Tags {
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+
+      li {
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/frontend/src/components/listChangeRow/ListChangeRow.tsx
+++ b/frontend/src/components/listChangeRow/ListChangeRow.tsx
@@ -23,7 +23,7 @@ const ListChangeRow = <T extends unknown>({
   showDiff,
 }: PropsWithChildren<ListChangeRowProps<T>>) =>
   (added ?? []).length > 0 || (removed ?? []).length > 0 ? (
-    <Row className={CLASSNAME}>
+    <Row className={`${CLASSNAME}-${name}`}>
       <b className="col-2 text-end">{name}</b>
       {showDiff && (
         <Col xs={5}>


### PR DESCRIPTION
- Make tag diff more compact (similar to tags list on scene page)
	| Modify | Create |
	| --- | --- |
	| ![modify](https://user-images.githubusercontent.com/66393006/151031500-029e12db-083c-4894-b003-644aafe8e97a.png) | ![create](https://user-images.githubusercontent.com/66393006/151031522-7719c2b5-56a5-4b3d-97b4-330b7d0c5098.png) |
- Hide edit expiration if cron job is disabled