### PR TITLE
fix editValidator value translation

### DIFF
--- a/pkg/models/translate.go
+++ b/pkg/models/translate.go
@@ -220,6 +220,10 @@ func (v *editValidator) uuid(field string, old *uuid.UUID, current uuid.NullUUID
 	}
 
 	if old != nil && (!current.Valid || (*old != current.UUID)) {
-		v.err = v.error(field, *old, current)
+		currentUUID := ""
+		if current.Valid {
+			currentUUID = current.UUID.String()
+		}
+		v.err = v.error(field, old.String(), currentUUID)
 	}
 }

--- a/pkg/models/translate.go
+++ b/pkg/models/translate.go
@@ -17,11 +17,11 @@ type ErrEditPrerequisiteFailed struct {
 func (e *ErrEditPrerequisiteFailed) Error() string {
 	expected := "_blank_"
 	if e.expected != "" {
-		expected = fmt.Sprintf("“**%s**”", e.expected)
+		expected = fmt.Sprintf("“**%v**”", e.expected)
 	}
 	actual := "_blank_"
 	if e.actual != "" {
-		actual = fmt.Sprintf("“**%s**”", e.actual)
+		actual = fmt.Sprintf("“**%v**”", e.actual)
 	}
 	return fmt.Sprintf("Expected %s to be %s, but was %s.", e.field, expected, actual)
 }


### PR DESCRIPTION
Not sure if this is the right fix, other one being to modify `ErrEditPrerequisiteFailed` to only accept string and work from there (modifying the `int64` and `uuid` functions of `editValidator` below)

Works for `int64`:

![image](https://user-images.githubusercontent.com/66393006/151189652-fe8eb601-a566-430e-a56b-a09c953970c4.png)

For `UUID`, I guess this will need to be manually changed to... an empty string?

![image](https://user-images.githubusercontent.com/66393006/151190395-5ec5404f-3ffe-4d63-bc5e-3655db360dbf.png)


Now: 
![image](https://user-images.githubusercontent.com/66393006/151196424-0b173744-31b6-49a6-843f-b1778c1232b2.png)

