### PR TITLE
Performer form/merge updates

### DIFF
--- a/frontend/src/pages/performers/PerformerMerge.tsx
+++ b/frontend/src/pages/performers/PerformerMerge.tsx
@@ -38,15 +38,14 @@ const PerformerMerge: FC<Props> = ({ performer }) => {
     },
   });
 
-  useEffect(() => {
-    if (!mergeActive) return;
+  const toggleMerge = () => {
+    setMergeActive(true);
     const sameName = mergeSources.every(
       ({ name }) => name.trim() === performer.name.trim()
     );
     // Don't update aliases by default if the names match
     setAliasUpdating(!sameName);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mergeActive]);
+  };
 
   const doUpdate = (
     insertData: PerformerEditDetailsInput,
@@ -92,10 +91,7 @@ const PerformerMerge: FC<Props> = ({ performer }) => {
                 ]}
               />
               {mergeSources.length > 0 && (
-                <Button
-                  onClick={() => setMergeActive(true)}
-                  className="ms-auto"
-                >
+                <Button onClick={toggleMerge} className="ms-auto">
                   Continue
                 </Button>
               )}

--- a/frontend/src/pages/performers/PerformerMerge.tsx
+++ b/frontend/src/pages/performers/PerformerMerge.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import { flatMap } from "lodash-es";
@@ -37,6 +37,16 @@ const PerformerMerge: FC<Props> = ({ performer }) => {
       if (data.performerEdit.id) history.push(editHref(data.performerEdit));
     },
   });
+
+  useEffect(() => {
+    if (!mergeActive) return;
+    const sameName = mergeSources.every(
+      ({ name }) => name.trim() === performer.name.trim()
+    );
+    // Don't update aliases by default if the names match
+    setAliasUpdating(!sameName);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mergeActive]);
 
   const doUpdate = (
     insertData: PerformerEditDetailsInput,

--- a/frontend/src/pages/performers/PerformerMerge.tsx
+++ b/frontend/src/pages/performers/PerformerMerge.tsx
@@ -15,6 +15,11 @@ import PerformerSelect from "src/components/performerSelect";
 import PerformerCard from "src/components/performerCard";
 import { editHref } from "src/utils";
 import PerformerForm from "./performerForm";
+import { Help } from "src/components/fragments";
+
+const UPDATE_ALIAS_MESSAGE = `Enabling this option sets each merged performer's name as an alias on every scene that performer does not have an alias on.
+In most cases, it should be enabled when merging aliases of a performer, and disabled when the performers share the same name.
+`;
 
 const CLASSNAME = "PerformerMerge";
 
@@ -124,7 +129,9 @@ const PerformerMerge: FC<Props> = ({ performer }) => {
             checked={aliasUpdating}
             onChange={() => setAliasUpdating(!aliasUpdating)}
             label="Update scene performance aliases on merged performers to old performer name."
+            className="d-inline-block"
           />
+          <Help message={UPDATE_ALIAS_MESSAGE} />
           <h5 className="mt-4">
             Update performer metadata for <em>{performer.name}</em>
           </h5>

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -99,8 +99,8 @@ const ETHNICITY: OptionEnum[] = [
   { value: "OTHER", label: "Other" },
 ];
 
-const UPDATE_ALIAS_MESSAGE = `When changing from alias A to B, it may be desirable to enable this so all unset performances will continue to have the old name.
-If however a typo in the name is corrected, this should not be used.
+const UPDATE_ALIAS_MESSAGE = `Enabling this option sets the current name as an alias on every scene that this performer does not have an alias on.
+In most cases, it should be enabled when renaming a performer to a different alias, and disabled when correcting a typo in the name.
 `;
 
 const getEnumValue = (enumArray: OptionEnum[], val: string) => {

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -175,6 +175,14 @@ const PerformerForm: FC<PerformerProps> = ({
     [fieldData, performer]
   );
 
+  const changedName =
+    !!performer.id &&
+    fieldData.name !== undefined &&
+    performer.name !== fieldData.name;
+  useEffect(() => {
+    setUpdateAliases(changedName);
+  }, [changedName, setUpdateAliases]);
+
   const showBreastType =
     fieldData.gender !== GenderEnum.MALE &&
     fieldData.gender !== GenderEnum.TRANSGENDER_MALE;
@@ -296,22 +304,20 @@ const PerformerForm: FC<PerformerProps> = ({
             </Form.Group>
           </Row>
 
-          {performer.id &&
-            fieldData.name !== undefined &&
-            performer.name !== fieldData.name && (
-              <Row>
-                <Form.Group className="col mb-3">
-                  <Form.Check
-                    id="update-modify-aliases"
-                    checked={updateAliases}
-                    onChange={() => setUpdateAliases(!updateAliases)}
-                    label="Set unset performance aliases to old name"
-                    className="d-inline-block"
-                  />
-                  <Help message={UPDATE_ALIAS_MESSAGE} />
-                </Form.Group>
-              </Row>
-            )}
+          {changedName && (
+            <Row>
+              <Form.Group className="col mb-3">
+                <Form.Check
+                  id="update-modify-aliases"
+                  checked={updateAliases}
+                  onChange={() => setUpdateAliases(!updateAliases)}
+                  label="Set unset performance aliases to old name"
+                  className="d-inline-block"
+                />
+                <Help message={UPDATE_ALIAS_MESSAGE} />
+              </Form.Group>
+            </Row>
+          )}
 
           <Row>
             <Form.Group controlId="aliases" className="col mb-3">

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -179,6 +179,7 @@ const PerformerForm: FC<PerformerProps> = ({
     !!performer.id &&
     fieldData.name !== undefined &&
     performer.name !== fieldData.name;
+
   useEffect(() => {
     setUpdateAliases(changedName);
   }, [changedName, setUpdateAliases]);

--- a/pkg/models/model_edit.go
+++ b/pkg/models/model_edit.go
@@ -165,6 +165,11 @@ func (e *Edit) IsDestructive() bool {
 	if e.Operation == OperationEnumDestroy.String() || e.Operation == OperationEnumMerge.String() {
 		return true
 	}
+	// When renaming a performer and not updating the performance aliases
+	if (e.Operation == OperationEnumModify.String() || e.Operation == OperationEnumMerge.String()) && e.TargetType == TargetTypeEnumPerformer.String() {
+		data, _ := e.GetPerformerData()
+		return data.New.Name != nil && !data.SetModifyAliases
+	}
 	return false
 }
 


### PR DESCRIPTION
- _Update performer rename help message:_
	This may be the most confusing part for newcomers when editing performers.
	I believe it was suggested to provide an example, but I didn't have an idea for how to do that,
	so I just updated the text and tried to explain it more plainly.
- _Add help string to performer merging aliases:_
	Less of an issue, but probably best to have some explanation next to that checkbox as well.
	Same as above about providing an example.
- _Set merge checkbox to false if all source names match:_
	When merging `A` with `A` (or `A `), there's no reason for it to be enabled by default. That's all.
	Could also be expanded to be a case-**in*sensitive compare.
- _Check update aliases by default on performer rename:_
	Like the first commit above, this has been confusing.
	It seems most edits do need it enabled, you only need to uncheck this on rare occasions (as said, typos).
	Implementation detail - In order for the form callback to not send this value as true when the name isn't changed I opted to use `useEffect` instead of changing the default state to true. It works, but if you have a better idea, go for it.
- _Consider performer renames as destructive:_
	I'm not sure about this commit, but I included it anyway.