### PR TITLE
Fix tag query arguments

### DIFF
--- a/pkg/sqlx/querybuilder_tag.go
+++ b/pkg/sqlx/querybuilder_tag.go
@@ -129,7 +129,7 @@ func (qb *tagQueryBuilder) FindByNameOrAlias(name string) (*models.Tag, error) {
 		ORDER BY T.deleted ASC
 	`
 
-	args := []interface{}{name, name}
+	args := []interface{}{name}
 	results, err := qb.queryTags(query, args)
 	if err != nil || len(results) < 1 {
 		return nil, err


### PR DESCRIPTION
Confirmed to fix:
`Error executing query: \n\t\tSELECT T.* FROM tags T\n\t\tLEFT JOIN tag_aliases TA ON T.id = TA.tag_id\n\t\tWHERE LOWER(TA.alias) = LOWER($1) OR LOWER(T.name) = LOWER($1)\n\t\tORDER BY T.deleted ASC\n\t, with args: [African American African American]: pq: got 2 parameters but the statement requires 1`
for `tagQueryBuilder.FindByNameOrAlias`