### PR TITLE
Fix edit comment order

### DIFF
--- a/pkg/api/resolver_model_edit.go
+++ b/pkg/api/resolver_model_edit.go
@@ -258,16 +258,11 @@ func (r *editResolver) Comments(ctx context.Context, obj *models.Edit) ([]*model
 		return nil, err
 	}
 
-	var ret []*models.EditComment
-	for _, comment := range comments {
-		ret = append(ret, comment)
-	}
-
 	sort.Slice(comments, func(i, j int) bool {
 		return comments[i].CreatedAt.Timestamp.Before(comments[j].CreatedAt.Timestamp)
 	})
 
-	return ret, nil
+	return comments, nil
 }
 
 func (r *editResolver) Votes(ctx context.Context, obj *models.Edit) ([]*models.EditVote, error) {


### PR DESCRIPTION
Fixes #306.
Recreated by making 2 or more comments on an edit, then removing the oldest comment row from the database and re-adding it.
Seems like the sorted list was unused/not-returned by mistake - [`7a19beb` (#66)](https://github.com/stashapp/stash-box/pull/66/commits/7a19bebb853ab88ae333282d9ea555d57e04b6aa).
I removed the slice creation, the return type of `GetComments` matches... If there's a reason to create a new slice, I fail to see it.