### PR TITLE
Hide "Favorites" edit filter when a fixed type is provided

### DIFF
--- a/frontend/src/components/list/EditList.tsx
+++ b/frontend/src/components/list/EditList.tsx
@@ -49,6 +49,7 @@ const EditListComponent: FC<EditsProps> = ({
     type,
     status,
     operation,
+    showFavoriteOption: id === undefined,
   });
   const { data, loading } = useEdits({
     input: {

--- a/frontend/src/hooks/UseEditFilter.tsx
+++ b/frontend/src/hooks/UseEditFilter.tsx
@@ -184,20 +184,22 @@ const useEditFilter = ({
           {enumToOptions(EditOperationTypes)}
         </Form.Select>
       </Form.Group>
-      <Form.Group controlId="favorite">
-        <Form.Label>Favorites</Form.Label>
-        <Form.Check
-          className="ms-3 mt-2"
-          type="switch"
-          defaultChecked={favorite}
-          onChange={(e) =>
-            handleChange(
-              "favorite",
-              e.currentTarget.checked ? "true" : undefined
-            )
-          }
-        />
-      </Form.Group>
+      {!fixedType && (
+        <Form.Group controlId="favorite">
+          <Form.Label>Favorites</Form.Label>
+          <Form.Check
+            className="ms-3 mt-2"
+            type="switch"
+            defaultChecked={favorite}
+            onChange={(e) =>
+              handleChange(
+                "favorite",
+                e.currentTarget.checked ? "true" : undefined
+              )
+            }
+          />
+        </Form.Group>
+      )}
     </Form>
   );
 

--- a/frontend/src/hooks/UseEditFilter.tsx
+++ b/frontend/src/hooks/UseEditFilter.tsx
@@ -43,6 +43,7 @@ interface EditFilterProps {
   status?: VoteStatusEnum;
   operation?: OperationEnum;
   favorite?: boolean;
+  showFavoriteOption?: boolean;
 }
 
 const useEditFilter = ({
@@ -52,6 +53,7 @@ const useEditFilter = ({
   status: fixedStatus,
   operation: fixedOperation,
   favorite: fixedFavorite,
+  showFavoriteOption = true,
 }: EditFilterProps) => {
   const history = useHistory();
   const query = queryString.parse(history.location.search);
@@ -184,7 +186,7 @@ const useEditFilter = ({
           {enumToOptions(EditOperationTypes)}
         </Form.Select>
       </Form.Group>
-      {!fixedType && (
+      {showFavoriteOption && (
         <Form.Group controlId="favorite">
           <Form.Label>Favorites</Form.Label>
           <Form.Check


### PR DESCRIPTION
If a fixed type filter is provided, there's no use for filtering favorites (currently?)
Resolves #302