### PR TITLE
Ensure trending scenes order across pagination

### DIFF
--- a/pkg/sqlx/querybuilder_scene.go
+++ b/pkg/sqlx/querybuilder_scene.go
@@ -362,7 +362,7 @@ func (qb *sceneQueryBuilder) buildQuery(filter models.SceneQueryInput, isCount b
 				` + limit + `
 			) T ON scenes.id = T.scene_id
 		`
-		query.Sort = " ORDER BY T.count DESC "
+		query.Sort = " ORDER BY T.count DESC, T.scene_id DESC "
 	} else {
 		query.Sort = qb.getSceneSort(filter)
 		query.Pagination = getPagination(filter.Page, filter.PerPage)


### PR DESCRIPTION
Possibly fixes #293? I couldn't test this.
This is based on #172 which works. My guess here is that multiple trending scenes with the same `count` value can cause this.