### PR TITLE
Limit concurrent build workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
in order to prevent develop release race condition.

this is an experiment and I'm not sure if it would work as expected.
docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency