### PR TITLE
Validate dates

### DIFF
--- a/frontend/src/pages/performers/performerForm/schema.ts
+++ b/frontend/src/pages/performers/performerForm/schema.ts
@@ -7,6 +7,7 @@ import {
   BreastTypeEnum,
   EthnicityEnum,
 } from "src/graphql";
+import { isValidFuzzyDate } from "src/utils";
 
 const nullCheck = (input: string | null) =>
   input === "" || input === "null" ? null : input;
@@ -30,6 +31,7 @@ export const PerformerSchema = yup.object({
       excludeEmptyString: true,
       message: "Invalid date, must be YYYY, YYYY-MM, or YYYY-MM-DD",
     })
+    .test("valid-date", "Invalid date", isValidFuzzyDate)
     .nullable(),
   career_start_year: yup
     .number()

--- a/frontend/src/pages/scenes/sceneForm/schema.ts
+++ b/frontend/src/pages/scenes/sceneForm/schema.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { GenderEnum } from "src/graphql";
+import { isValidDate } from "src/utils";
 
 const nullCheck = (input: string | null) =>
   input === "" || input === "null" ? null : input;
@@ -14,6 +15,7 @@ export const SceneSchema = yup.object({
       excludeEmptyString: true,
       message: "Invalid date",
     })
+    .test("valid-date", "Invalid date", isValidDate)
     .nullable()
     .required("Release date is required"),
   duration: yup

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,3 +1,4 @@
+import { isValid, parseISO } from "date-fns";
 import { FuzzyDateInput, DateAccuracyEnum } from "src/graphql";
 
 export const parseFuzzyDate = (date?: string | null): FuzzyDateInput | null => {
@@ -49,4 +50,12 @@ export const formatFuzzyDateComponents = (
   if (accuracy === DateAccuracyEnum.DAY) return date;
   if (accuracy === DateAccuracyEnum.MONTH) return date.slice(0, 7);
   return date.slice(0, 4);
+};
+
+export const isValidDate = (date?: string) => !date || isValid(parseISO(date));
+
+export const isValidFuzzyDate = (date?: string) => {
+  if (!date) return true;
+  const fullDate = parseFuzzyDate(date)?.date as string;
+  return !fullDate || isValidDate(fullDate);
 };

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,7 +1,7 @@
 import { isValid, parseISO } from "date-fns";
 import { FuzzyDateInput, DateAccuracyEnum } from "src/graphql";
 
-export const parseFuzzyDate = (date?: string | null): FuzzyDateInput | null => {
+export const parseFuzzyDate = (date?: string | null) => {
   if (!date) return null;
   if (date.length === 10)
     return {
@@ -56,6 +56,6 @@ export const isValidDate = (date?: string) => !date || isValid(parseISO(date));
 
 export const isValidFuzzyDate = (date?: string) => {
   if (!date) return true;
-  const fullDate = parseFuzzyDate(date)?.date as string;
+  const fullDate = parseFuzzyDate(date)?.date;
   return !fullDate || isValidDate(fullDate);
 };


### PR DESCRIPTION
prevent invalid dates like `2008-17-04`
a scene create edit was submitted with this date, the edit was applied and the scene had no date.
maybe it should also verify on the backend.