### PR TITLE
Fix version link & default scene sort

### DIFF
--- a/frontend/src/pages/version/Version.tsx
+++ b/frontend/src/pages/version/Version.tsx
@@ -9,7 +9,7 @@ const Version: FC = () => {
   let link = "";
   switch (data.version.build_type) {
     case "OFFICIAL":
-      link = `https://github.com/stashapp/stash-box/releases/tag/${data.version.version}`;
+      link = `https://github.com/stashapp/stash-box/releases/tag/v${data.version.version}`;
       break;
     case "DEVELOPMENT":
     case "PR":

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -203,7 +203,7 @@ input SceneQueryInput {
   page: Int! = 1
   per_page: Int! = 25
   direction: SortDirectionEnum! = DESC
-  sort: SceneSortEnum! = RELEASE_DATE
+  sort: SceneSortEnum! = DATE
 }
 
 union SceneDraftStudio = Studio | DraftEntity

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -4482,7 +4482,7 @@ input SceneQueryInput {
   page: Int! = 1
   per_page: Int! = 25
   direction: SortDirectionEnum! = DESC
-  sort: SceneSortEnum! = RELEASE_DATE
+  sort: SceneSortEnum! = DATE
 }
 
 union SceneDraftStudio = Studio | DraftEntity
@@ -23678,7 +23678,7 @@ func (ec *executionContext) unmarshalInputSceneQueryInput(ctx context.Context, o
 		asMap["direction"] = "DESC"
 	}
 	if _, present := asMap["sort"]; !present {
-		asMap["sort"] = "RELEASE_DATE"
+		asMap["sort"] = "DATE"
 	}
 
 	for k, v := range asMap {


### PR DESCRIPTION
>https://goreleaser.com/customization/templates/
>The v prefix is stripped and it might be changed in snapshot and nightly builds. [↩](https://goreleaser.com/customization/templates/#fnref:1)

-----

Fix default value for `SceneQueryInput.sort`