### PR TITLE
feat: Added hyperlink buttons to performers and scene links in the scene creation wizard

### DIFF
--- a/frontend/src/components/urlInput/urlInput.tsx
+++ b/frontend/src/components/urlInput/urlInput.tsx
@@ -1,6 +1,8 @@
 import { FC, useRef, useState } from "react";
 import { Button, Form, InputGroup } from "react-bootstrap";
+import { Icon } from "src/components/fragments";
 import { Control, useFieldArray, FieldError } from "react-hook-form";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 
 import { useSites, ValidSiteTypeEnum } from "src/graphql";
 import { Site_findSite as Site } from "src/graphql/definitions/Site";
@@ -117,6 +119,9 @@ const URLInput: FC<URLInputProps> = ({ control, type, errors }) => {
               <InputGroup.Text className="overflow-hidden">
                 {u.url}
               </InputGroup.Text>
+              <Button variant="primary" href={u.url} target="_blank">
+                <Icon icon={faExternalLinkAlt} />
+              </Button>
             </InputGroup>
             {errors?.[i]?.url && (
               <div className="text-danger">{errors?.[i]?.url?.message}</div>

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -4,7 +4,10 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import cx from "classnames";
 import { Button, Col, Form, InputGroup, Row, Tab, Tabs } from "react-bootstrap";
 import { Link } from "react-router-dom";
-import { faExclamationTriangle, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import {
+  faExclamationTriangle,
+  faExternalLinkAlt,
+} from "@fortawesome/free-solid-svg-icons";
 
 import { Scene_findScene as Scene } from "src/graphql/definitions/Scene";
 import { Tags_queryTags_tags as Tag } from "src/graphql/definitions/Tags";

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -4,11 +4,11 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import cx from "classnames";
 import { Button, Col, Form, InputGroup, Row, Tab, Tabs } from "react-bootstrap";
 import { Link } from "react-router-dom";
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faExclamationTriangle, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 
 import { Scene_findScene as Scene } from "src/graphql/definitions/Scene";
 import { Tags_queryTags_tags as Tag } from "src/graphql/definitions/Tags";
-import { formatDuration, parseDuration } from "src/utils";
+import { formatDuration, parseDuration, performerHref } from "src/utils";
 import { ValidSiteTypeEnum, SceneEditDetailsInput } from "src/graphql";
 
 import { renderSceneDetails } from "src/components/editCard/ModifyEdit";
@@ -199,19 +199,28 @@ const SceneForm: FC<SceneProps> = ({ scene, initial, callback, saving }) => {
                 searchType={SearchType.Performer}
               />
             ) : (
-              <InputGroup.Text className="flex-grow-1 text-start text-truncate">
-                <GenderIcon gender={p.gender} />
-                <span
-                  className={cx("performer-name text-truncate", {
-                    "text-decoration-line-through": p.deleted,
-                  })}
+              <>
+                <InputGroup.Text className="flex-grow-1 text-start text-truncate">
+                  <GenderIcon gender={p.gender} />
+                  <span
+                    className={cx("performer-name text-truncate", {
+                      "text-decoration-line-through": p.deleted,
+                    })}
+                  >
+                    <b>{p.name}</b>
+                    {p.disambiguation && (
+                      <small className="ms-1">({p.disambiguation})</small>
+                    )}
+                  </span>
+                </InputGroup.Text>
+                <Button
+                  variant="primary"
+                  href={performerHref({ id: p.performerId })}
+                  target="_blank"
                 >
-                  <b>{p.name}</b>
-                  {p.disambiguation && (
-                    <small className="ms-1">({p.disambiguation})</small>
-                  )}
-                </span>
-              </InputGroup.Text>
+                  <Icon icon={faExternalLinkAlt} />
+                </Button>
+              </>
             )}
           </>
         </InputGroup>


### PR DESCRIPTION
This pull request adds hyperlink buttons to the performers in the scene creation wizard as well as hyperlink buttons to the "Links" associated with a scene. This is useful, because often times when submitting a scene, you want to inspect the performer to check that the information is up to date and that there aren't any duplicates of the scene you are about to submit.