### PR TITLE
Link performer drafts to edit

### DIFF
--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -299,6 +299,16 @@ export const renderPerformerDetails = (
       oldImages={performerDetails.removed_images}
       showDiff={showDiff}
     />
+    {performerDetails.draft_id && (
+      <Row className="mb-2">
+        <Col xs={{ offset: 2 }}>
+          <h6>
+            <Icon icon={faEdit} color="green" />
+            <span className="ms-1">Submitted by draft</span>
+          </h6>
+        </Col>
+      </Row>
+    )}
   </>
 );
 

--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -219,6 +219,8 @@ func (m *PerformerEditProcessor) createEdit(input models.PerformerEditInput, inp
 		performerEdit.New.AddedImages = input.Details.ImageIds
 	}
 
+	performerEdit.New.DraftID = input.Details.DraftID
+
 	return m.edit.SetData(performerEdit)
 }
 


### PR DESCRIPTION
performer create edits from drafts never had the "submitted by draft" attached.
found out this was because the draft ID was never attached to the edits.
based on the `scene` counterpart: https://github.com/stashapp/stash-box/blob/85b1a313510d255e6cbcf885083d51054fc77bd4/pkg/manager/edit/scene.go#L274

~~**this is untested yet**~~