### PR TITLE
StudioSelect parent studio

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -17,6 +17,7 @@
 @import "./components/performerSelect/styles";
 @import "./components/sceneCard/styles";
 @import "./components/searchField/styles";
+@import "./components/studioSelect/styles";
 @import "./components/tagSelect/styles";
 @import "./components/editImages/styles";
 @import "./components/urlInput/styles";

--- a/frontend/src/components/studioSelect/StudioSelect.tsx
+++ b/frontend/src/components/studioSelect/StudioSelect.tsx
@@ -15,7 +15,14 @@ import { Studios, StudiosVariables } from "src/graphql/definitions/Studios";
 import { SortDirectionEnum, StudioSortEnum } from "src/graphql";
 import { isUUID } from "src/utils";
 
-type StudioSlim = Pick<Studio_findStudio, "id" | "name">;
+type StudioSlim = Pick<Studio_findStudio, "id" | "name"> &
+  Partial<Pick<Studio_findStudio, "parent">>;
+
+interface IOptionType {
+  value: string;
+  label: string;
+  sublabel?: string;
+}
 
 interface StudioSelectProps {
   initialStudio?: StudioSlim | null;
@@ -39,7 +46,7 @@ const StudioSelect: FC<StudioSelectProps> = ({
 }) => {
   const client = useApolloClient();
 
-  const fetchStudios = async (term: string) => {
+  const fetchStudios = async (term: string): Promise<IOptionType[]> => {
     const value = term.trim();
     if (isUUID(value)) {
       if (value === excludeStudio) {
@@ -56,7 +63,13 @@ const StudioSelect: FC<StudioSelectProps> = ({
         return [];
       }
 
-      return [{ value: studio.id, label: studio.name }];
+      return [
+        {
+          value: studio.id,
+          label: studio.name,
+          sublabel: studio.parent?.name,
+        },
+      ];
     }
 
     const { data } = await client.query<Studios, StudiosVariables>({
@@ -77,6 +90,7 @@ const StudioSelect: FC<StudioSelectProps> = ({
       .map((s) => ({
         value: s.id,
         label: s.name,
+        sublabel: s.parent?.name,
       }))
       .filter((s) => s.value !== excludeStudio);
   };
@@ -84,11 +98,19 @@ const StudioSelect: FC<StudioSelectProps> = ({
   const debouncedLoad = debounce(fetchStudios, 200);
 
   const defaultValue = initialStudio
-    ? {
+    ? ({
         value: initialStudio.id,
         label: initialStudio.name,
-      }
+        sublabel: initialStudio.parent?.name,
+      } as IOptionType)
     : undefined;
+
+  const formatStudioName = (opt: IOptionType) => (
+    <>
+      <span>{opt.label}</span>
+      {opt.sublabel && <span className="parent-studio">({opt.sublabel})</span>}
+    </>
+  );
 
   return (
     <div className={CLASSNAME}>
@@ -104,6 +126,7 @@ const StudioSelect: FC<StudioSelectProps> = ({
           inputValue === "" ? null : `No studios found for "${inputValue}"`
         }
         isClearable={isClearable}
+        formatOptionLabel={formatStudioName}
       />
     </div>
   );

--- a/frontend/src/components/studioSelect/StudioSelect.tsx
+++ b/frontend/src/components/studioSelect/StudioSelect.tsx
@@ -21,7 +21,7 @@ type StudioSlim = Pick<Studio_findStudio, "id" | "name"> &
 interface IOptionType {
   value: string;
   label: string;
-  sublabel?: string;
+  sublabel: string | undefined;
 }
 
 interface StudioSelectProps {
@@ -98,11 +98,11 @@ const StudioSelect: FC<StudioSelectProps> = ({
   const debouncedLoad = debounce(fetchStudios, 200);
 
   const defaultValue = initialStudio
-    ? ({
+    ? {
         value: initialStudio.id,
         label: initialStudio.name,
         sublabel: initialStudio.parent?.name,
-      } as IOptionType)
+      }
     : undefined;
 
   const formatStudioName = (opt: IOptionType) => (

--- a/frontend/src/components/studioSelect/StudioSelect.tsx
+++ b/frontend/src/components/studioSelect/StudioSelect.tsx
@@ -108,7 +108,9 @@ const StudioSelect: FC<StudioSelectProps> = ({
   const formatStudioName = (opt: IOptionType) => (
     <>
       <span>{opt.label}</span>
-      {opt.sublabel && <span className="parent-studio">({opt.sublabel})</span>}
+      {opt.sublabel && (
+        <small className="bullet-separator parent-studio">{opt.sublabel}</small>
+      )}
     </>
   );
 

--- a/frontend/src/components/studioSelect/styles.scss
+++ b/frontend/src/components/studioSelect/styles.scss
@@ -1,6 +1,5 @@
 .StudioSelect {
   .parent-studio {
-    margin-left: 0.25rem;
     color: $text-muted;
   }
 

--- a/frontend/src/components/studioSelect/styles.scss
+++ b/frontend/src/components/studioSelect/styles.scss
@@ -1,17 +1,12 @@
 .StudioSelect {
-  margin-top: 0.5rem;
-
-  &-list {
-    margin-bottom: 1rem;
+  .parent-studio {
+    margin-left: 0.25rem;
+    color: $text-muted;
   }
 
-  &-container {
-    display: flex;
-  }
-
-  &-select {
-    display: inline-block;
-    margin-left: auto;
-    width: 25rem;
+  .react-select__value-container {
+    .parent-studio {
+      color: rgba($black, 0.5);
+    }
   }
 }

--- a/frontend/src/graphql/definitions/ApplyEdit.ts
+++ b/frontend/src/graphql/definitions/ApplyEdit.ts
@@ -189,10 +189,17 @@ export interface ApplyEdit_applyEdit_target_Scene_images {
   height: number;
 }
 
+export interface ApplyEdit_applyEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface ApplyEdit_applyEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: ApplyEdit_applyEdit_target_Scene_studio_parent | null;
 }
 
 export interface ApplyEdit_applyEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface ApplyEdit_applyEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface ApplyEdit_applyEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface ApplyEdit_applyEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: ApplyEdit_applyEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface ApplyEdit_applyEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/Edit.ts
+++ b/frontend/src/graphql/definitions/Edit.ts
@@ -189,10 +189,17 @@ export interface Edit_findEdit_target_Scene_images {
   height: number;
 }
 
+export interface Edit_findEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Edit_findEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Edit_findEdit_target_Scene_studio_parent | null;
 }
 
 export interface Edit_findEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface Edit_findEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface Edit_findEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Edit_findEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Edit_findEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface Edit_findEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/EditFragment.ts
+++ b/frontend/src/graphql/definitions/EditFragment.ts
@@ -189,10 +189,17 @@ export interface EditFragment_target_Scene_images {
   height: number;
 }
 
+export interface EditFragment_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface EditFragment_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: EditFragment_target_Scene_studio_parent | null;
 }
 
 export interface EditFragment_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface EditFragment_merge_sources_Scene_images {
   height: number;
 }
 
+export interface EditFragment_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface EditFragment_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: EditFragment_merge_sources_Scene_studio_parent | null;
 }
 
 export interface EditFragment_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/EditUpdate.ts
+++ b/frontend/src/graphql/definitions/EditUpdate.ts
@@ -162,10 +162,17 @@ export interface EditUpdate_findEdit_target_Scene_images {
   height: number;
 }
 
+export interface EditUpdate_findEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface EditUpdate_findEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: EditUpdate_findEdit_target_Scene_studio_parent | null;
 }
 
 export interface EditUpdate_findEdit_target_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/Edits.ts
+++ b/frontend/src/graphql/definitions/Edits.ts
@@ -189,10 +189,17 @@ export interface Edits_queryEdits_edits_target_Scene_images {
   height: number;
 }
 
+export interface Edits_queryEdits_edits_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Edits_queryEdits_edits_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Edits_queryEdits_edits_target_Scene_studio_parent | null;
 }
 
 export interface Edits_queryEdits_edits_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface Edits_queryEdits_edits_merge_sources_Scene_images {
   height: number;
 }
 
+export interface Edits_queryEdits_edits_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Edits_queryEdits_edits_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Edits_queryEdits_edits_merge_sources_Scene_studio_parent | null;
 }
 
 export interface Edits_queryEdits_edits_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/PerformerEdit.ts
+++ b/frontend/src/graphql/definitions/PerformerEdit.ts
@@ -189,10 +189,17 @@ export interface PerformerEdit_performerEdit_target_Scene_images {
   height: number;
 }
 
+export interface PerformerEdit_performerEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface PerformerEdit_performerEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: PerformerEdit_performerEdit_target_Scene_studio_parent | null;
 }
 
 export interface PerformerEdit_performerEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface PerformerEdit_performerEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface PerformerEdit_performerEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface PerformerEdit_performerEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: PerformerEdit_performerEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface PerformerEdit_performerEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/PerformerEditUpdate.ts
+++ b/frontend/src/graphql/definitions/PerformerEditUpdate.ts
@@ -189,10 +189,17 @@ export interface PerformerEditUpdate_performerEditUpdate_target_Scene_images {
   height: number;
 }
 
+export interface PerformerEditUpdate_performerEditUpdate_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface PerformerEditUpdate_performerEditUpdate_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: PerformerEditUpdate_performerEditUpdate_target_Scene_studio_parent | null;
 }
 
 export interface PerformerEditUpdate_performerEditUpdate_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface PerformerEditUpdate_performerEditUpdate_merge_sources_Scene_ima
   height: number;
 }
 
+export interface PerformerEditUpdate_performerEditUpdate_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface PerformerEditUpdate_performerEditUpdate_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: PerformerEditUpdate_performerEditUpdate_merge_sources_Scene_studio_parent | null;
 }
 
 export interface PerformerEditUpdate_performerEditUpdate_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/Scene.ts
+++ b/frontend/src/graphql/definitions/Scene.ts
@@ -30,10 +30,17 @@ export interface Scene_findScene_images {
   height: number;
 }
 
+export interface Scene_findScene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Scene_findScene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Scene_findScene_studio_parent | null;
 }
 
 export interface Scene_findScene_performers_performer {

--- a/frontend/src/graphql/definitions/SceneEdit.ts
+++ b/frontend/src/graphql/definitions/SceneEdit.ts
@@ -189,10 +189,17 @@ export interface SceneEdit_sceneEdit_target_Scene_images {
   height: number;
 }
 
+export interface SceneEdit_sceneEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface SceneEdit_sceneEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: SceneEdit_sceneEdit_target_Scene_studio_parent | null;
 }
 
 export interface SceneEdit_sceneEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface SceneEdit_sceneEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface SceneEdit_sceneEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface SceneEdit_sceneEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: SceneEdit_sceneEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface SceneEdit_sceneEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/SceneEditUpdate.ts
+++ b/frontend/src/graphql/definitions/SceneEditUpdate.ts
@@ -189,10 +189,17 @@ export interface SceneEditUpdate_sceneEditUpdate_target_Scene_images {
   height: number;
 }
 
+export interface SceneEditUpdate_sceneEditUpdate_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface SceneEditUpdate_sceneEditUpdate_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: SceneEditUpdate_sceneEditUpdate_target_Scene_studio_parent | null;
 }
 
 export interface SceneEditUpdate_sceneEditUpdate_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface SceneEditUpdate_sceneEditUpdate_merge_sources_Scene_images {
   height: number;
 }
 
+export interface SceneEditUpdate_sceneEditUpdate_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface SceneEditUpdate_sceneEditUpdate_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: SceneEditUpdate_sceneEditUpdate_merge_sources_Scene_studio_parent | null;
 }
 
 export interface SceneEditUpdate_sceneEditUpdate_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/SceneFragment.ts
+++ b/frontend/src/graphql/definitions/SceneFragment.ts
@@ -30,10 +30,17 @@ export interface SceneFragment_images {
   height: number;
 }
 
+export interface SceneFragment_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface SceneFragment_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: SceneFragment_studio_parent | null;
 }
 
 export interface SceneFragment_performers_performer {

--- a/frontend/src/graphql/definitions/StudioEdit.ts
+++ b/frontend/src/graphql/definitions/StudioEdit.ts
@@ -189,10 +189,17 @@ export interface StudioEdit_studioEdit_target_Scene_images {
   height: number;
 }
 
+export interface StudioEdit_studioEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface StudioEdit_studioEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: StudioEdit_studioEdit_target_Scene_studio_parent | null;
 }
 
 export interface StudioEdit_studioEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface StudioEdit_studioEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface StudioEdit_studioEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface StudioEdit_studioEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: StudioEdit_studioEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface StudioEdit_studioEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/StudioEditUpdate.ts
+++ b/frontend/src/graphql/definitions/StudioEditUpdate.ts
@@ -189,10 +189,17 @@ export interface StudioEditUpdate_studioEditUpdate_target_Scene_images {
   height: number;
 }
 
+export interface StudioEditUpdate_studioEditUpdate_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface StudioEditUpdate_studioEditUpdate_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: StudioEditUpdate_studioEditUpdate_target_Scene_studio_parent | null;
 }
 
 export interface StudioEditUpdate_studioEditUpdate_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface StudioEditUpdate_studioEditUpdate_merge_sources_Scene_images {
   height: number;
 }
 
+export interface StudioEditUpdate_studioEditUpdate_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface StudioEditUpdate_studioEditUpdate_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: StudioEditUpdate_studioEditUpdate_merge_sources_Scene_studio_parent | null;
 }
 
 export interface StudioEditUpdate_studioEditUpdate_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/TagEdit.ts
+++ b/frontend/src/graphql/definitions/TagEdit.ts
@@ -189,10 +189,17 @@ export interface TagEdit_tagEdit_target_Scene_images {
   height: number;
 }
 
+export interface TagEdit_tagEdit_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface TagEdit_tagEdit_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: TagEdit_tagEdit_target_Scene_studio_parent | null;
 }
 
 export interface TagEdit_tagEdit_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface TagEdit_tagEdit_merge_sources_Scene_images {
   height: number;
 }
 
+export interface TagEdit_tagEdit_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface TagEdit_tagEdit_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: TagEdit_tagEdit_merge_sources_Scene_studio_parent | null;
 }
 
 export interface TagEdit_tagEdit_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/TagEditUpdate.ts
+++ b/frontend/src/graphql/definitions/TagEditUpdate.ts
@@ -189,10 +189,17 @@ export interface TagEditUpdate_tagEditUpdate_target_Scene_images {
   height: number;
 }
 
+export interface TagEditUpdate_tagEditUpdate_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface TagEditUpdate_tagEditUpdate_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: TagEditUpdate_tagEditUpdate_target_Scene_studio_parent | null;
 }
 
 export interface TagEditUpdate_tagEditUpdate_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface TagEditUpdate_tagEditUpdate_merge_sources_Scene_images {
   height: number;
 }
 
+export interface TagEditUpdate_tagEditUpdate_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface TagEditUpdate_tagEditUpdate_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: TagEditUpdate_tagEditUpdate_merge_sources_Scene_studio_parent | null;
 }
 
 export interface TagEditUpdate_tagEditUpdate_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/definitions/Vote.ts
+++ b/frontend/src/graphql/definitions/Vote.ts
@@ -189,10 +189,17 @@ export interface Vote_editVote_target_Scene_images {
   height: number;
 }
 
+export interface Vote_editVote_target_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Vote_editVote_target_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Vote_editVote_target_Scene_studio_parent | null;
 }
 
 export interface Vote_editVote_target_Scene_performers_performer {
@@ -1317,10 +1324,17 @@ export interface Vote_editVote_merge_sources_Scene_images {
   height: number;
 }
 
+export interface Vote_editVote_merge_sources_Scene_studio_parent {
+  __typename: "Studio";
+  id: string;
+  name: string;
+}
+
 export interface Vote_editVote_merge_sources_Scene_studio {
   __typename: "Studio";
   id: string;
   name: string;
+  parent: Vote_editVote_merge_sources_Scene_studio_parent | null;
 }
 
 export interface Vote_editVote_merge_sources_Scene_performers_performer {

--- a/frontend/src/graphql/fragments/SceneFragment.gql
+++ b/frontend/src/graphql/fragments/SceneFragment.gql
@@ -19,6 +19,10 @@ fragment SceneFragment on Scene {
   studio {
     id
     name
+    parent {
+      id
+      name
+    }
   }
   performers {
     as


### PR DESCRIPTION
found this branch I had forgotten about, but was practically ready.


display parent studio in Studio Select component:

![image](https://user-images.githubusercontent.com/66393006/169652566-45ff27ae-ae0a-4553-a8a8-dd81a376cba3.png)


existing (scene) studio is supported:

![image](https://user-images.githubusercontent.com/66393006/169652546-7ff387ff-b25a-4a86-9749-0e7d95845bbf.png)
