### PR TITLE
Fix unsubmittable studio/tag forms

### DIFF
--- a/frontend/src/pages/studios/studioForm/schema.ts
+++ b/frontend/src/pages/studios/studioForm/schema.ts
@@ -31,7 +31,8 @@ export const StudioSchema = yup.object({
       id: yup.string().required(),
       name: yup.string().required(),
     })
-    .nullable(),
+    .nullable()
+    .default(null),
   note: yup.string().required("Edit note is required"),
 });
 

--- a/frontend/src/pages/tags/tagForm/schema.ts
+++ b/frontend/src/pages/tags/tagForm/schema.ts
@@ -10,7 +10,7 @@ export const TagSchema = yup.object({
       name: yup.string().required(),
     })
     .nullable()
-    .defined(),
+    .default(null),
   note: yup.string().required("Edit note is required"),
 });
 


### PR DESCRIPTION
It was due to the category / network being `undefined` and not `null`.
I once again tried to fix the form errors for the `{ id, name }` objects, but TypeScript is throwing a fit over types...