### PR TITLE
Remove `v` prefix from version link

### DIFF
--- a/frontend/src/graphql/queries/EditUpdate.gql
+++ b/frontend/src/graphql/queries/EditUpdate.gql
@@ -13,7 +13,7 @@ query EditUpdate($id: ID!) {
     created
     updated
     vote_count
-     merge_sources {
+    merge_sources {
       ... on Tag {
         id
       }

--- a/frontend/src/pages/version/Version.tsx
+++ b/frontend/src/pages/version/Version.tsx
@@ -9,7 +9,7 @@ const Version: FC = () => {
   let link = "";
   switch (data.version.build_type) {
     case "OFFICIAL":
-      link = `https://github.com/stashapp/stash-box/releases/tag/v${data.version.version}`;
+      link = `https://github.com/stashapp/stash-box/releases/tag/${data.version.version}`;
       break;
     case "DEVELOPMENT":
     case "PR":


### PR DESCRIPTION
Not needed since the move away from using goreleaser