### PR TITLE
Add missing page titles

### DIFF
--- a/frontend/src/components/editCard/renderEntity.tsx
+++ b/frontend/src/components/editCard/renderEntity.tsx
@@ -14,11 +14,7 @@ export const renderPerformer = (appearance: {
     "name" | "id" | "gender" | "name" | "disambiguation" | "deleted"
   >;
 }) => (
-  <Link
-    key={appearance.performer.id}
-    to={performerHref(appearance.performer)}
-    className="scene-performer"
-  >
+  <Link key={appearance.performer.id} to={performerHref(appearance.performer)}>
     <GenderIcon gender={appearance.performer.gender} />
     <PerformerName performer={appearance.performer} as={appearance.as} />
   </Link>

--- a/frontend/src/pages/performers/PerformerEditUpdate.tsx
+++ b/frontend/src/pages/performers/PerformerEditUpdate.tsx
@@ -7,6 +7,7 @@ import PerformerForm from "./performerForm";
 
 import { EditUpdate_findEdit as Edit } from "src/graphql/definitions/EditUpdate";
 import { ROUTE_EDIT } from "src/constants";
+import Title from "src/components/title";
 
 export const PerformerEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
   const history = useHistory();
@@ -57,12 +58,15 @@ export const PerformerEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
     });
   };
 
+  const performerName = edit.target?.name ?? edit.details.name;
+
   return (
     <div>
+      <Title page={`Update performer edit for "${performerName}"`} />
       <h3>
         Update performer edit for
         <i className="ms-2">
-          <b>{edit.target?.name ?? edit.details.name}</b>
+          <b>{performerName}</b>
         </i>
       </h3>
       <hr />

--- a/frontend/src/pages/scenes/SceneEditUpdate.tsx
+++ b/frontend/src/pages/scenes/SceneEditUpdate.tsx
@@ -7,6 +7,7 @@ import SceneForm from "./sceneForm";
 
 import { EditUpdate_findEdit as Edit } from "src/graphql/definitions/EditUpdate";
 import { ROUTE_EDIT } from "src/constants";
+import Title from "src/components/title";
 
 export const SceneEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
   const history = useHistory();
@@ -46,12 +47,15 @@ export const SceneEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
     });
   };
 
+  const sceneTitle = edit.target?.title ?? edit.details.title;
+
   return (
     <div>
+      <Title page={`Update scene edit for "${sceneTitle}"`} />
       <h3>
         Update scene edit for
         <i className="ms-2">
-          <b>{edit.target?.title ?? edit.details.title}</b>
+          <b>{sceneTitle}</b>
         </i>
       </h3>
       <hr />

--- a/frontend/src/pages/studios/StudioEditUpdate.tsx
+++ b/frontend/src/pages/studios/StudioEditUpdate.tsx
@@ -7,6 +7,7 @@ import StudioForm from "./studioForm";
 
 import { EditUpdate_findEdit as Edit } from "src/graphql/definitions/EditUpdate";
 import { ROUTE_EDIT } from "src/constants";
+import Title from "src/components/title";
 
 export const StudioEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
   const history = useHistory();
@@ -43,12 +44,15 @@ export const StudioEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
     });
   };
 
+  const studioName = edit?.target?.name ?? edit.details?.name;
+
   return (
     <div>
+      <Title page={`Update studio edit for "${studioName}"`} />
       <h3>
         Update studio edit for
         <i className="ms-2">
-          <b>{edit?.target?.name ?? edit.details?.name}</b>
+          <b>{studioName}</b>
         </i>
       </h3>
       <hr />

--- a/frontend/src/pages/tags/TagEditUpdate.tsx
+++ b/frontend/src/pages/tags/TagEditUpdate.tsx
@@ -7,6 +7,7 @@ import TagForm from "./tagForm";
 
 import { EditUpdate_findEdit as Edit } from "src/graphql/definitions/EditUpdate";
 import { ROUTE_EDIT } from "src/constants";
+import Title from "src/components/title";
 
 export const TagEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
   const history = useHistory();
@@ -40,12 +41,15 @@ export const TagEditUpdate: FC<{ edit: Edit }> = ({ edit }) => {
     });
   };
 
+  const tagName = edit.target?.name ?? edit.details.name;
+
   return (
     <div>
+      <Title page={`Update tag edit for "${tagName}"`} />
       <h3>
         Update tag edit for
         <i className="ms-2">
-          <b>{edit.target?.name ?? edit.details.name}</b>
+          <b>{tagName}</b>
         </i>
       </h3>
       <hr />


### PR DESCRIPTION
1. Add missing page titles to edit-update routes.
2. Fix this:
![before](https://user-images.githubusercontent.com/66393006/169900681-c3adb2ac-b6c0-4643-9512-f7cbe111a1b7.png)
![after](https://user-images.githubusercontent.com/66393006/169900688-86bd96d1-8b74-4080-add1-43373fa2bbb2.png)

~~Draft because untested, I'll test it ASAP, but can be merged if works as intended.~~