### PR TITLE
Sort tags in scene edits/form

### DIFF
--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -28,6 +28,7 @@ import {
   isSceneOldDetails,
   studioHref,
   categoryHref,
+  compareByName,
 } from "src/utils";
 import { Icon } from "src/components/fragments";
 import ChangeRow from "src/components/changeRow";
@@ -427,8 +428,8 @@ export const renderSceneDetails = (
     />
     <ListChangeRow
       name="Tags"
-      added={sceneDetails.added_tags}
-      removed={sceneDetails.removed_tags}
+      added={sceneDetails.added_tags?.slice().sort(compareByName)}
+      removed={sceneDetails.removed_tags?.slice().sort(compareByName)}
       renderItem={renderTag}
       getKey={(o) => o.id}
       showDiff={showDiff}

--- a/frontend/src/components/tagSelect/TagSelect.tsx
+++ b/frontend/src/components/tagSelect/TagSelect.tsx
@@ -14,6 +14,7 @@ import {
 import { SortDirectionEnum, TagSortEnum } from "src/graphql";
 import { TagLink } from "src/components/fragments";
 import { tagHref } from "src/utils/route";
+import { compareByName } from "src/utils";
 
 type TagSlim = {
   id: string;
@@ -66,7 +67,7 @@ const TagSelect: FC<TagSelectProps> = ({
   };
 
   const tagList = [...(tags ?? [])]
-    .sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0))
+    .sort(compareByName)
     .map((tag) => (
       <TagLink
         title={tag.name}

--- a/frontend/src/pages/scenes/Scene.tsx
+++ b/frontend/src/pages/scenes/Scene.tsx
@@ -19,6 +19,7 @@ import {
   formatDateTime,
   formatPendingEdits,
   getUrlBySite,
+  compareByName,
 } from "src/utils";
 import {
   ROUTE_SCENE_EDIT,
@@ -103,17 +104,11 @@ const SceneComponent: FC<Props> = ({ scene }) => {
       <td>{formatDateTime(fingerprint.updated)}</td>
     </tr>
   ));
-  const tags = [...scene.tags]
-    .sort((a, b) => {
-      if (a.name > b.name) return 1;
-      if (a.name < b.name) return -1;
-      return 0;
-    })
-    .map((tag) => (
-      <li key={tag.name}>
-        <TagLink title={tag.name} link={tagHref(tag)} />
-      </li>
-    ));
+  const tags = [...scene.tags].sort(compareByName).map((tag) => (
+    <li key={tag.name}>
+      <TagLink title={tag.name} link={tagHref(tag)} />
+    </li>
+  ));
 
   const studioURL = getUrlBySite(scene.urls, "Studio");
 

--- a/frontend/src/utils/data.ts
+++ b/frontend/src/utils/data.ts
@@ -1,2 +1,5 @@
 export const filterData = <T>(data?: (T | null | undefined)[] | null) =>
   data ? (data.filter((item) => item) as T[]) : [];
+
+export const compareByName = <T extends { name: string }>(a: T, b: T) =>
+  a.name > b.name ? 1 : a.name < b.name ? -1 : 0;


### PR DESCRIPTION
Closes #412
Ended up sorting in the UI as seems like both of the other instances where tags were being rendered did the same.