### PR TITLE
Performer form fixes

### DIFF
--- a/frontend/src/components/multiSelect/MultiSelect.tsx
+++ b/frontend/src/components/multiSelect/MultiSelect.tsx
@@ -3,7 +3,7 @@ import CreatableSelect from "react-select/creatable";
 import { OnChangeValue } from "react-select";
 
 interface MultiSelectProps {
-  values: string[];
+  initialValues: string[];
   onChange: (values: string[]) => void;
   placeholder?: string;
 }
@@ -14,7 +14,7 @@ interface IOptionType {
 }
 
 const MultiSelect: FC<MultiSelectProps> = ({
-  values: initialValues,
+  initialValues,
   onChange,
   placeholder = "Select...",
 }) => {

--- a/frontend/src/components/performerSelect/PerformerSelect.tsx
+++ b/frontend/src/components/performerSelect/PerformerSelect.tsx
@@ -41,7 +41,10 @@ const PerformerSelect: FC<PerformerSelectProps> = ({
     .sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0))
     .map((performer) => (
       <TagLink
-        title={performer.name}
+        title={
+          performer.name +
+          (performer.disambiguation ? ` (${performer.disambiguation})` : "")
+        }
         link={performerHref(performer)}
         onRemove={() => removePerformer(performer.id)}
         key={performer.id}

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -141,7 +141,7 @@ const PerformerForm: FC<PerformerProps> = ({
       name: initial?.name ?? performer?.name ?? "",
       disambiguation: initial?.disambiguation ?? performer?.disambiguation,
       aliases: initial?.aliases ?? performer?.aliases ?? [],
-      gender: initial?.gender ?? performer?.gender,
+      gender: initial?.gender ?? performer?.gender ?? "",
       birthdate: initial?.birthdate ?? performer?.birth_date ?? undefined,
       eye_color: getEnumValue(
         EYE,

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -127,6 +127,7 @@ const PerformerForm: FC<PerformerProps> = ({
   initial,
   saving,
 }) => {
+  const initialAliases = initial?.aliases ?? performer?.aliases ?? [];
   const {
     register,
     control,
@@ -140,7 +141,7 @@ const PerformerForm: FC<PerformerProps> = ({
     defaultValues: {
       name: initial?.name ?? performer?.name ?? "",
       disambiguation: initial?.disambiguation ?? performer?.disambiguation,
-      aliases: initial?.aliases ?? performer?.aliases ?? [],
+      aliases: initialAliases,
       gender: initial?.gender ?? performer?.gender ?? "",
       birthdate: initial?.birthdate ?? performer?.birth_date ?? undefined,
       eye_color: getEnumValue(
@@ -343,9 +344,9 @@ const PerformerForm: FC<PerformerProps> = ({
               <Controller
                 control={control}
                 name="aliases"
-                render={({ field: { onChange, value } }) => (
+                render={({ field: { onChange } }) => (
                   <MultiSelect
-                    values={value}
+                    initialValues={initialAliases}
                     onChange={onChange}
                     placeholder="Enter name..."
                   />

--- a/frontend/src/pages/tags/tagForm/TagForm.tsx
+++ b/frontend/src/pages/tags/tagForm/TagForm.tsx
@@ -29,6 +29,7 @@ interface TagProps {
 
 const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
   const history = useHistory();
+  const initialAliases = initial?.aliases ?? tag?.aliases ?? [];
   const {
     register,
     handleSubmit,
@@ -39,7 +40,7 @@ const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
     defaultValues: {
       name: initial?.name ?? tag?.name ?? "",
       description: initial?.description ?? tag?.description ?? "",
-      aliases: initial?.aliases ?? tag?.aliases ?? [],
+      aliases: initialAliases,
       category: initial?.category ?? tag?.category,
     },
   });
@@ -95,9 +96,9 @@ const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
         <Controller
           name="aliases"
           control={control}
-          render={({ field: { onChange, value } }) => (
+          render={({ field: { onChange } }) => (
             <MultiSelect
-              values={value}
+              initialValues={initialAliases}
               onChange={onChange}
               placeholder="Enter name..."
             />


### PR DESCRIPTION
1. Add disambiguation on performer merge sources selection.
2. Make performer gender required again.
	(`null` = "Unknown" option was pre-selected instead of the "Select gender..." option)
3. Fix #419 for performer and tag forms.
	[I seem to have misunderstood how `MultiSelect` works](https://github.com/stashapp/stash-box/pull/247/commits/011be7a85af360911fb9a83ba207b3fa51c6e0a1#diff-880813649763b2f673efbf4f63885ffe1598d32f84016c1489a4b3d858401d61), so the (initial) values being passed to the component via a property were linked to RHF and getting updated with every change to the aliases.