### PR TITLE
Fix new phash matching

### DIFF
--- a/pkg/sqlx/querybuilder_scene.go
+++ b/pkg/sqlx/querybuilder_scene.go
@@ -222,7 +222,7 @@ func (qb *sceneQueryBuilder) FindIdsBySceneFingerprints(fingerprints []*models.F
 		GROUP BY scene_id, hash
 	`
 	phashClause := `
-		SELECT scene_id, phash as hash
+		SELECT scene_id, to_hex(phash::::bigint) as hash
 		FROM UNNEST(ARRAY[:phashes]) phash
 		JOIN scene_fingerprints ON ('x' || hash)::::bit(64)::::bigint <@ (phash::::BIGINT, :distance)
 		AND algorithm = 'PHASH'


### PR DESCRIPTION
Fixes PHASH matching. (https://github.com/stashapp/stash/pull/2509#issuecomment-1144507043)
Initially, I noticed the first part of the `UNION` query returned hashes in hex format, but the PHASH part of the query returned a `bigint` as string. So I converted the hashes back to hex, and the matching worked again.
Then while trying to understand why *that* fixed it, I realized the **API query** failed to match ([resolver_query_find_scene.go:102-104](https://github.com/stashapp/stash-box/blob/master/pkg/api/resolver_query_find_scene.go#L102-L104)) the original PHashes to the ones returned by the database, due to the hashes not being the expected hex string.