### PR TITLE
Make performers list cards better fit 2:3 images

### DIFF
--- a/frontend/src/components/list/List.tsx
+++ b/frontend/src/components/list/List.tsx
@@ -33,7 +33,7 @@ const List: FC<Props> = ({
   const currentCount = count ?? listCount;
 
   return (
-    <>
+    <div className={`${entityName}-list`}>
       <div className="d-flex mt-2 align-items-start">
         {filters}
         <Pagination
@@ -61,7 +61,7 @@ const List: FC<Props> = ({
           active={page}
         />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -22,7 +22,7 @@ import AuthContext from "src/AuthContext";
 import { List } from "src/components/list";
 import { ROUTE_PERFORMER_ADD, GenderFilterTypes } from "src/constants";
 
-const PER_PAGE = 20;
+const PER_PAGE = 25;
 
 const genderOptions = Object.keys(GenderFilterEnum).map((g) => ({
   value: g,

--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -68,7 +68,7 @@ const PerformersComponent: FC = () => {
 
   const performers = (data?.queryPerformers.performers ?? []).map(
     (performer) => (
-      <Col xs={3} key={performer.id}>
+      <Col xs="auto" key={performer.id}>
         <PerformerCard performer={performer} />
       </Col>
     )

--- a/frontend/src/pages/performers/styles.scss
+++ b/frontend/src/pages/performers/styles.scss
@@ -33,6 +33,12 @@
   }
 }
 
+.performers-list {
+  .col-auto {
+    width: 20%;
+  }
+}
+
 .PerformerScenes {
   .CheckboxSelect {
     float: left;

--- a/frontend/src/pages/users/Users.tsx
+++ b/frontend/src/pages/users/Users.tsx
@@ -74,6 +74,7 @@ const UsersComponent: FC = () => {
         </Link>
       </div>
       <List
+        entityName="users"
         page={page}
         setPage={setPage}
         perPage={PER_PAGE}


### PR DESCRIPTION
New image size is `220.8×320`, with 2:3 being `213.333...×320` or `220.8×331.2`.
Increase performers per page 20 -> 25

I think it's a better fit, but it's kind of subjective.