### PR TITLE
Now displays each image's dimensions in Edits

### DIFF
--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -14,22 +14,19 @@ export interface ImageChangeRowProps {
 
 const Images: FC<{
   images: (Pick<Image, "id" | "url"> | null)[] | null | undefined;
-}> = ({ images }) =>
-{
-  const [imgDimensions, setImgDimensions] = useState<{[key: string]: {height: int, width: int}} | null>(
-    {},
-  );
+}> = ({ images }) => {
+  const [imgDimensions, setImgDimensions] = useState<{
+    [key: string]: { height: int; width: int };
+  } | null>({});
 
-  const onImgLoad = ( event: React.SyntheticEvent<HTMLImageElement, Event> ) => {
-    setImgDimensions(
-      {
-        ...imgDimensions,
-        [event.currentTarget.src]: {
-          height: event.currentTarget.naturalHeight,
-          width: event.currentTarget.naturalWidth
-        }
-      }
-    )
+  const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    setImgDimensions({
+      ...imgDimensions,
+      [event.currentTarget.src]: {
+        height: event.currentTarget.naturalHeight,
+        width: event.currentTarget.naturalWidth,
+      },
+    });
   };
 
   return (
@@ -38,26 +35,27 @@ const Images: FC<{
         image === null ? (
           <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
         ) : (
-            <div>
-              <img
-                src={image.url}
-                className={CLASSNAME_IMAGE}
-                alt=""
-                key={image.id}
-                onLoad={onImgLoad}
-              />
-              <div className={"text-center"}>
-                {imgDimensions[image.url] ? (
-                  String(imgDimensions[image.url].height) + " x " + String(imgDimensions[image.url].width)
-                ) : ""
-                }
-              </div>
+          <div>
+            <img
+              src={image.url}
+              className={CLASSNAME_IMAGE}
+              alt=""
+              key={image.id}
+              onLoad={onImgLoad}
+            />
+            <div className={"text-center"}>
+              {imgDimensions[image.url]
+                ? String(imgDimensions[image.url].height) +
+                  " x " +
+                  String(imgDimensions[image.url].width)
+                : ""}
             </div>
+          </div>
         )
       )}
     </>
   );
-}
+};
 
 const ImageChangeRow: FC<ImageChangeRowProps> = ({
   newImages,

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Col, Row } from "react-bootstrap";
 
 import { ImageFragment as Image } from "src/graphql/definitions/ImageFragment";
@@ -14,22 +14,50 @@ export interface ImageChangeRowProps {
 
 const Images: FC<{
   images: (Pick<Image, "id" | "url"> | null)[] | null | undefined;
-}> = ({ images }) => (
-  <>
-    {(images ?? []).map((image, i) =>
-      image === null ? (
-        <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
-      ) : (
-        <img
-          src={image.url}
-          className={CLASSNAME_IMAGE}
-          alt=""
-          key={image.id}
-        />
-      )
-    )}
-  </>
-);
+}> = ({ images }) =>
+{
+  const [imgDimensions, setImgDimensions] = useState<{[key: string]: {height: int, width: int}} | null>(
+    {},
+  );
+
+  const onImgLoad = ( event: React.SyntheticEvent<HTMLImageElement, Event> ) => {
+    setImgDimensions(
+      {
+        ...imgDimensions,
+        [event.currentTarget.src]: {
+          height: event.currentTarget.naturalHeight,
+          width: event.currentTarget.naturalWidth
+        }
+      }
+    )
+  };
+
+  return (
+    <>
+      {(images ?? []).map((image, i) =>
+        image === null ? (
+          <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
+        ) : (
+            <div>
+              <img
+                src={image.url}
+                className={CLASSNAME_IMAGE}
+                alt=""
+                key={image.id}
+                onLoad={onImgLoad}
+              />
+              <div className={"text-center"}>
+                {imgDimensions[image.url] ? (
+                  String(imgDimensions[image.url].height) + " x " + String(imgDimensions[image.url].width)
+                ) : ""
+                }
+              </div>
+            </div>
+        )
+      )}
+    </>
+  );
+}
 
 const ImageChangeRow: FC<ImageChangeRowProps> = ({
   newImages,

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -17,7 +17,7 @@ const Images: FC<{
 }> = ({ images }) => {
   const [imgDimensions, setImgDimensions] = useState<{
     [key: string]: { height: number; width: number };
-  } | null>({});
+  }>({});
 
   const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
     setImgDimensions({
@@ -35,19 +35,18 @@ const Images: FC<{
         image === null ? (
           <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
         ) : (
-          <div>
+          <div key={image.id}>
             <img
               src={image.url}
               className={CLASSNAME_IMAGE}
               alt=""
-              key={image.id}
               onLoad={onImgLoad}
             />
             <div className={"text-center"}>
               {imgDimensions && imgDimensions[image.url]
-                ? String(imgDimensions[image.url].height) +
-                  " x " +
-                  String(imgDimensions[image.url].width)
+                ? `${imgDimensions[image.url].width} x ${
+                    imgDimensions[image.url].height
+                  }`
                 : ""}
             </div>
           </div>

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -16,7 +16,7 @@ const Images: FC<{
   images: (Pick<Image, "id" | "url"> | null)[] | null | undefined;
 }> = ({ images }) => {
   const [imgDimensions, setImgDimensions] = useState<{
-    [key: string]: { height: int; width: int };
+    [key: string]: { height: number; width: number };
   } | null>({});
 
   const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
@@ -44,7 +44,7 @@ const Images: FC<{
               onLoad={onImgLoad}
             />
             <div className={"text-center"}>
-              {imgDimensions[image.url]
+              {imgDimensions && imgDimensions[image.url]
                 ? String(imgDimensions[image.url].height) +
                   " x " +
                   String(imgDimensions[image.url].width)


### PR DESCRIPTION
Replicates the behavior of peolic's script, displaying each image's dimensions in a text div below the image.

For now, only in the Edits page.