### PR TITLE
update latin label to be gender neutral

### DIFF
--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -93,7 +93,7 @@ const ETHNICITY: OptionEnum[] = [
   { value: "BLACK", label: "Black" },
   { value: "ASIAN", label: "Asian" },
   { value: "INDIAN", label: "Indian" },
-  { value: "LATIN", label: "Latino" },
+  { value: "LATIN", label: "Latin" },
   { value: "MIDDLE_EASTERN", label: "Middle Eastern" },
   { value: "MIXED", label: "Mixed" },
   { value: "OTHER", label: "Other" },


### PR DESCRIPTION
The current label for `Latin` was set to `Latino` which is male gendered (female version being `Latina`). I've updated the label to be gender neutral like the other labels in the list.