### PR TITLE
Join multiple capture groups on URL input

### DIFF
--- a/frontend/src/components/urlInput/urlInput.tsx
+++ b/frontend/src/components/urlInput/urlInput.tsx
@@ -50,7 +50,12 @@ const URLInput: FC<URLInputProps> = ({ control, type, errors }) => {
     const regex = new RegExp(regexStr);
     const match = regex.exec(url);
 
-    return match?.[1];
+    if (match.length > 1) {
+      match.shift();
+      return match.join("");
+    } else {
+      return match?.[1];
+    }
   };
 
   const handleAdd = () => {

--- a/frontend/src/components/urlInput/urlInput.tsx
+++ b/frontend/src/components/urlInput/urlInput.tsx
@@ -50,11 +50,11 @@ const URLInput: FC<URLInputProps> = ({ control, type, errors }) => {
     const regex = new RegExp(regexStr);
     const match = regex.exec(url);
 
-    if (match.length > 1) {
+    if (match == null || match.length < 2) {
+      return match?.[1];
+    } else {
       match.shift();
       return match.join("");
-    } else {
-      return match?.[1];
     }
   };
 


### PR DESCRIPTION
This idea was came up for me when looking at the URLs for `theNude`. You will often see a URL like this `https://www.thenude.com/Kelly%20Nichols_48976.htm`. However everything between `.com/` and `_` is garbage and doesn't matter to the site. You can change that URL to `https://www.thenude.com/sdkhfkdsahdfkjwhedsfkj_48976.htm` or `https://www.thenude.com/_48976.htm` and it works exactly the same. I've seen a few other DBs catch onto this and clean their URLs so I wanted to do the same, but couldn't do that when I can only use a single capture group.

I've edited the logic here to act the same way as before if there are 0 or 1 capture groups, however if there are more than one capture groups, it joins them all together. This allows for a regex statement like `(https?:\/\/[www.thenude.com](http://www.thenude.com/)\/).*((?:_\d+).htm)` to clean up links for `theNude` when inputted. 

Sample of this code in action running my PR locally:
![example](https://monosnap.com/image/zDb8TeiejjoupIXmVZjByNQBAkOWlV)