### PR TITLE
allow scenes to be sorted by title

### DIFF
--- a/frontend/src/components/list/SceneList.tsx
+++ b/frontend/src/components/list/SceneList.tsx
@@ -26,6 +26,7 @@ interface Props {
 
 const sortOptions = [
   { value: SceneSortEnum.DATE, label: "Release Date" },
+  { value: SceneSortEnum.TITLE, label: "Title" },
   { value: SceneSortEnum.TRENDING, label: "Trending" },
   { value: SceneSortEnum.CREATED_AT, label: "Created At" },
   { value: SceneSortEnum.UPDATED_AT, label: "Updated At" },


### PR DESCRIPTION
I'm assuming this was just an oversight. The option to sort scenes by title already existed in the `SceneSortEnum` here:
https://github.com/stashapp/stash-box/blob/404a21da6134ac9f8e9637d74299ecc0cfde133a/graphql/schema/types/scene.graphql#L176-L182

It was just never added to the `sortOptions`:
https://github.com/stashapp/stash-box/blob/48069473441f608f7700735ab69c95bcf67819b2/frontend/src/components/list/SceneList.tsx#L27-L32

This PR corrects that. Works when I tested it locally:

![demo](https://monosnap.com/image/cbwEkRgnxAqFbHXIyP06e6UyUJAFWU)