### PR TITLE
Fix missing pagination per-page value

### DIFF
--- a/frontend/src/components/list/EditList.tsx
+++ b/frontend/src/components/list/EditList.tsx
@@ -84,6 +84,7 @@ const EditListComponent: FC<EditsProps> = ({
       filters={editFilter}
       page={page}
       setPage={setPage}
+      perPage={PER_PAGE}
     >
       <div>{edits}</div>
     </List>

--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -157,6 +157,7 @@ const PerformersComponent: FC = () => {
         page={page}
         filters={filters}
         setPage={setPage}
+        perPage={PER_PAGE}
         loading={loading}
         listCount={data?.queryPerformers.count}
       >


### PR DESCRIPTION
Noticed pagination was wrong on performers list (too many pages).
As part of #428 didn't realize `perPage` wasn't provided like the other instances of `<List>`