### PR TITLE
ensure the ordering of substudios is case-insensitive

### DIFF
--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -42,7 +42,9 @@ const StudioComponent: FC<Props> = ({ studio }) => {
 
   const studioImage = getImage(studio.images, "landscape");
 
-  const subStudios = sortBy(studio.child_studios, (s) => s.name).map((s) => (
+  const subStudios = sortBy(studio.child_studios, (s) =>
+    s.name.toLowerCase()
+  ).map((s) => (
     <li key={s.id}>
       <Link to={studioHref(s)}>{s.name}</Link>
     </li>


### PR DESCRIPTION
This resolves https://github.com/stashapp/stash-box/issues/462 which is my own issue that I noticed.

Before:
![image](https://user-images.githubusercontent.com/1358708/182045979-e638b99d-b160-404f-a603-8bce3e813c5b.png)

After:
![image](https://user-images.githubusercontent.com/1358708/182045951-415bd9b4-3657-4a62-8223-54a413da4f2d.png)
