### PR TITLE
Fix edit ordering on closed_at/updated_at

### DIFF
--- a/pkg/sqlx/querybuilder_sql.go
+++ b/pkg/sqlx/querybuilder_sql.go
@@ -47,10 +47,16 @@ func getPagination(page int, perPage int) string {
 	return " LIMIT " + strconv.Itoa(count) + " OFFSET " + strconv.Itoa(offset) + " "
 }
 
-func getSort(sort string, direction string, tableName string, secondarySort *string) string {
+func getSortDirection(direction string) string {
 	if direction != "ASC" && direction != "DESC" {
-		direction = "ASC"
+		return "ASC"
+	} else {
+		return direction
 	}
+}
+
+func getSort(sort string, direction string, tableName string, secondarySort *string) string {
+	direction = getSortDirection(direction)
 
 	switch {
 	case strings.Contains(sort, "_count"):

--- a/pkg/sqlx/querybuilder_sql.go
+++ b/pkg/sqlx/querybuilder_sql.go
@@ -50,9 +50,8 @@ func getPagination(page int, perPage int) string {
 func getSortDirection(direction string) string {
 	if direction != "ASC" && direction != "DESC" {
 		return "ASC"
-	} else {
-		return direction
 	}
+	return direction
 }
 
 func getSort(sort string, direction string, tableName string, secondarySort *string) string {


### PR DESCRIPTION
Another go at #388 (reverted #391).

Edits: Status=All, Sort=Closed At/Updated At
If the field is null, it will fallback to Created At, placing the edit in the correct spot in the edits list.
I also added the secondary sort by "id", since technically edits can have identical timestamps, this should keep it stable

by `closed_at`:
|id|created_at|updated_at|closed_at|
|--|----------|----------|---------|
|`54ab1423-dd11-47d3-94eb-388ca5a6b72f`|2022-08-12 21:28:59.846||2022-08-13 03:57:00.276|
|`36687f2a-dde7-487f-92d5-aede533bc33d`|2022-08-12 21:27:05.920||2022-08-13 03:56:35.038|
|`0e3422ff-b4a5-40b5-bdcf-263405947e3b`|2022-08-12 21:18:46.906||2022-08-13 03:56:03.370|
|`0d2ffb5b-ff3e-4562-abf5-b3176d00ce67`|2022-08-12 21:14:19.476||2022-08-13 03:56:01.461|
|`14ae0afc-eec7-4be3-be7d-5674ff7d2785`|2022-08-13 03:55:55.569|||


by `updated_at`:
|id|created_at|updated_at|closed_at|
|--|----------|----------|---------|
|`eb54d5f1-9974-4d2a-a70a-569bf3f0997a`|2022-08-12 23:08:41.264|2022-08-13 03:59:53.312||
|`14ae0afc-eec7-4be3-be7d-5674ff7d2785`|2022-08-13 03:55:55.569|||
|`6dbf3db7-ec5b-44fc-b385-7843b50739ab`|2022-08-13 03:54:41.835|||
|`45e8a28f-a157-49b9-bfcb-f65048077819`|2022-08-13 03:54:06.420|||
|`0870b02f-8561-42aa-a7ac-31c556f24aaf`|2022-08-13 03:49:29.939|||

