### PR TITLE
Replace deprecated `io/ioutil`

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"path"
 	"runtime/debug"
 	"strconv"
@@ -262,12 +262,12 @@ func GetVersion() (string, string, string) {
 }
 
 func makeTLSConfig() *tls.Config {
-	cert, err := ioutil.ReadFile(paths.GetSSLCert())
+	cert, err := os.ReadFile(paths.GetSSLCert())
 	if err != nil {
 		return nil
 	}
 
-	key, err := ioutil.ReadFile(paths.GetSSLKey())
+	key, err := os.ReadFile(paths.GetSSLKey())
 	if err != nil {
 		return nil
 	}

--- a/pkg/image/file.go
+++ b/pkg/image/file.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 
 	"github.com/stashapp/stash-box/pkg/manager/config"
@@ -29,7 +28,7 @@ func (s *FileBackend) WriteFile(file *bytes.Reader, image *models.Image) error {
 
 	// write the file
 	path := GetImagePath(fileDir, image.Checksum)
-	if err := ioutil.WriteFile(path, buf.Bytes(), os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(path, buf.Bytes(), os.FileMode(0644)); err != nil {
 		_ = os.Remove(path)
 		return err
 	}


### PR DESCRIPTION
`io/ioutil` has been deprecated since go1.16, `staticcheck` [throws an error when run with go1.19](https://github.com/stashapp/stash-box/runs/7826251055?check_suite_focus=true#step:3:77).

`Error: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (staticcheck)`