### PR TITLE
Fix destroyfingerprint

### DIFF
--- a/pkg/sqlx/querybuilder_scene.go
+++ b/pkg/sqlx/querybuilder_scene.go
@@ -92,8 +92,8 @@ func (qb *sceneQueryBuilder) UpdateFingerprints(sceneID uuid.UUID, updatedJoins 
 
 func (qb *sceneQueryBuilder) DestroyFingerprints(sceneID uuid.UUID, toDestroy models.SceneFingerprints) error {
 	for _, fp := range toDestroy {
-		query := qb.dbi.db().Rebind(`DELETE FROM ` + sceneFingerprintTable.name + ` WHERE algorithm = ? AND HASH = ? AND user_id = ?`)
-		if _, err := qb.dbi.db().Exec(query, fp.Algorithm, fp.Hash, fp.UserID); err != nil {
+		query := qb.dbi.db().Rebind(`DELETE FROM ` + sceneFingerprintTable.name + ` WHERE algorithm = ? AND HASH = ? AND user_id = ? AND scene_id = ?`)
+		if _, err := qb.dbi.db().Exec(query, fp.Algorithm, fp.Hash, fp.UserID, fp.SceneID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### Bugfix description

As discussed on Discord,
`DestroyFingerprints` takes `scene_id` as a parameter, suggesting it's intended behaviour is to only delete the fingerprint for *this* scene.

The only GQL endpoint calling this is `submitFingerprint` when `unmatch = true`
Impact of this change is null since it's not used anywhere in StashBox *yet*.
I also checked in Stash and the `unmatch` parameter is not used either.

### Test the bug & bugfix
To test it, ensure you have 2 scenes with the same fingerprint submitted by the same user.
This can be faked by calling
```
mutation {
  submitFingerprint(input: {
    unmatch: false
    scene_id: "YOUR_SCENE_ID"
    fingerprint: {
      hash: "8a153047363fc53f"
      algorithm: PHASH
      duration: 50
    }
  })
}
```

Without the bugfix, calling the same endpoint with `unmatch: true` will delete the fingerprint from *both* scenes.
With the bugfix, the fingerprint will only be deleted for *YOUR_SCENE_ID*
