### PR TITLE
prevent submitting fingerprints to deleted scenes

### DIFF
--- a/pkg/scene/scene.go
+++ b/pkg/scene/scene.go
@@ -242,6 +242,14 @@ func SubmitFingerprint(ctx context.Context, fac models.Repo, input models.Finger
 		return false, err
 	}
 
+	if scene.Deleted {
+		// FIXME: this should error out, but due to the use-case in Stash,
+		//       it will stop submitting fingerprints if a single one fails
+		//       see https://github.com/stashapp/stash/blob/v0.16.1/pkg/scraper/stashbox/stash_box.go#L254-L257
+		return true, nil
+		// return false, fmt.Errorf("scene is deleted, unable to submit fingerprint")
+	}
+
 	// if no user is set, or if the current user does not have the modify
 	// role, then set users to the current user
 	if len(input.Fingerprint.UserIds) == 0 || !user.IsRole(ctx, models.RoleEnumModify) {

--- a/pkg/sqlx/querybuilder_scene.go
+++ b/pkg/sqlx/querybuilder_scene.go
@@ -218,7 +218,8 @@ func (qb *sceneQueryBuilder) FindIdsBySceneFingerprints(fingerprints []*models.F
 	hashClause := `
 		SELECT scene_id, hash
 		FROM scene_fingerprints
-		WHERE hash IN (:hashes)
+		JOIN scenes ON scene_id = scenes.id
+		WHERE hash IN (:hashes) AND deleted = FALSE
 		GROUP BY scene_id, hash
 	`
 	phashClause := `
@@ -226,6 +227,8 @@ func (qb *sceneQueryBuilder) FindIdsBySceneFingerprints(fingerprints []*models.F
 		FROM UNNEST(ARRAY[:phashes]) phash
 		JOIN scene_fingerprints ON ('x' || hash)::::bit(64)::::bigint <@ (phash::::BIGINT, :distance)
 		AND algorithm = 'PHASH'
+		JOIN scenes ON scene_id = scenes.id
+		WHERE deleted = FALSE
 		GROUP BY scene_id, phash
 	`
 


### PR DESCRIPTION
Fixes https://github.com/stashapp/stash/issues/2867
Fixes #467
Feel free to reject, I didn't put much thought into it, so it's just:
- Preventing fingerprint submissions to deleted scenes
- Hiding deleted scenes from results of fingerprint matches.

I'm guessing there's already a few, but it's not something I can check.
**Deleted scenes with fingerprints:**
```sql
SELECT sf.scene_id, count(sf) fingerprints
FROM scene_fingerprints sf
JOIN scenes s ON sf.scene_id = s.id
WHERE s.deleted = TRUE
GROUP BY sf.scene_id;
```