### PR TITLE
Fix 'update aliases' checkbox in performer draft form

### DIFF
--- a/frontend/src/pages/drafts/PerformerDraft.tsx
+++ b/frontend/src/pages/drafts/PerformerDraft.tsx
@@ -38,7 +38,8 @@ const AddPerformerDraft: FC<Props> = ({ draft }) => {
 
   const doInsert = (
     updateData: PerformerEditDetailsInput,
-    editNote: string
+    editNote: string,
+    setModifyAliases: boolean
   ) => {
     const details: PerformerEditDetailsInput = {
       ...updateData,
@@ -54,6 +55,9 @@ const AddPerformerDraft: FC<Props> = ({ draft }) => {
             comment: editNote,
           },
           details,
+          options: {
+            set_modify_aliases: isUpdate ? setModifyAliases : undefined,
+          },
         },
       },
     });


### PR DESCRIPTION
1. Fix performer update via draft not submitting 'update aliases' checkbox value
	Fixes #491
2. ~Fix 'update aliases' checkbox reset when updating edit~
	Doesn't work as expected, [commit](https://github.com/peolic/stash-box/commit/0ebcff3d00aa01339b529e33ea5b9ab9fb1ea923) removed.