### PR TITLE
Default to pending when viewing user edits

### DIFF
--- a/frontend/src/pages/users/UserEdits.tsx
+++ b/frontend/src/pages/users/UserEdits.tsx
@@ -5,6 +5,7 @@ import { User_findUser as User } from "src/graphql/definitions/User";
 import { ROUTE_USER } from "src/constants/route";
 import { createHref } from "src/utils";
 import { EditList } from "src/components/list";
+import { VoteStatusEnum } from "src/graphql";
 
 interface Props {
   user: Pick<User, "id" | "name">;
@@ -15,7 +16,7 @@ const UserEditsComponent: FC<Props> = ({ user }) => (
     <h3>
       Edits by <Link to={createHref(ROUTE_USER, user)}>{user.name}</Link>
     </h3>
-    <EditList userId={user.id} />
+    <EditList userId={user.id} defaultVoteStatus={VoteStatusEnum.PENDING} />
   </>
 );
 


### PR DESCRIPTION
I think the most common use cases for viewing a user's edits are a user wanting to look at their current pending submissions for any comments, and when voting to deal with a batch of edits from a single user. Both cases only deal with pending edits, so to save some clicks and processing power, default to pending.