### PR TITLE
fix example regex in form text

### DIFF
--- a/frontend/src/pages/sites/siteForm/SiteForm.tsx
+++ b/frontend/src/pages/sites/siteForm/SiteForm.tsx
@@ -98,7 +98,7 @@ const SiteForm: FC<SiteProps> = ({ site, callback }) => {
         <Form.Text>
           A regular expression that will be optionally used to clean links. Must
           contain a capture group of the portion of the URL that is considered
-          valid. For instance: <code>(https://example.org/.*)\??</code> which
+          valid. For instance: <code>(https://example\.org/.*)\??</code> which
           will capture everything before the first question mark.
         </Form.Text>
       </Form.Group>


### PR DESCRIPTION
**EDIT:** *⚠️ This is a WIP. There are various issues with how regexps are handled and presented to the user. I'm trying to untangle it a bit.*
Periods must be escaped to be interpreted literally.

P.S. I just started using stash, so here's a trivial fix to say "hello"👋.