### PR TITLE
simple Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ generate: generate-backend generate-ui
 	ui-start \
 	ui-fmt \
 	ui-validate \
+	pre-ui \
 	clean
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ LDFLAGS := $(LDFLAGS)
 export CGO_ENABLED = 0
 
 .PHONY: \
+	stash-box \
 	generate-backend \
 	generate-ui \
 	generate-dataloaders \
@@ -19,6 +20,8 @@ export CGO_ENABLED = 0
 ifdef OUTPUT
   OUTPUT := -o $(OUTPUT)
 endif
+
+stash-box: pre-ui ui build
 
 pre-build:
 ifndef BUILD_DATE

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ generate: generate-backend generate-ui
 	ui \
 	ui-start \
 	ui-fmt \
-	ui-validate
+	ui-validate \
+	clean
+
+clean:
+	@ rm -rf stash-box stash-box-config.yml frontend/node_modules/ frontend/build/
 
 generate-backend:
 	go generate

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,25 @@ build-release-static: build
 # Regenerates GraphQL files
 generate: generate-backend generate-ui
 
-.PHONY: generate-backend
+.PHONY: \
+	generate-backend \
+	generate-ui \
+	generate-dataloaders \
+	test \
+	it \
+	fmt \
+	lint \
+	ui \
+	ui-start \
+	ui-fmt \
+	ui-validate
+
 generate-backend:
 	go generate
 
-.PHONY: generate-ui
 generate-ui:
 	cd frontend && yarn generate
 
-.PHONY: generate-dataloaders
 generate-dataloaders:
 	cd pkg/dataloader; \
 		go run github.com/vektah/dataloaden UUIDsLoader github.com/gofrs/uuid.UUID "[]github.com/gofrs/uuid.UUID"; \
@@ -55,43 +65,35 @@ generate-dataloaders:
 		go run github.com/vektah/dataloaden TagCategoryLoader github.com/gofrs/uuid.UUID "*github.com/stashapp/stash-box/pkg/models.TagCategory"; \
 		go run github.com/vektah/dataloaden SiteLoader github.com/gofrs/uuid.UUID "*github.com/stashapp/stash-box/pkg/models.Site";
 
-.PHONY: test
 test:
 	go test ./...
 
 # Runs the integration tests. -count=1 is used to ensure results are not
 # cached, which is important if the environment changes
-.PHONY: it
 it:
 	go test -tags=integration -count=1 ./...
 
 # Runs gofmt -w on the project's source code, modifying any files that do not match its style.
-.PHONY: fmt
 fmt:
 	go fmt ./...
 
 # Runs all configured linuters. golangci-lint needs to be installed locally first.
-.PHONY: lint
 lint:
 	golangci-lint run
 
 pre-ui:
 	cd frontend && yarn install --frozen-lockfile
 
-.PHONY: ui
 ui:
 	cd frontend && yarn build
 
-.PHONY: ui-start
 ui-start:
 	cd frontend && yarn start
 
-.PHONY: ui-fmt
 ui-fmt:
 	cd frontend && yarn format
 
 # runs tests and checks on the UI and builds it
-.PHONY: ui-validate
 ui-validate:
 	cd frontend && yarn run validate
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
 LDFLAGS := $(LDFLAGS)
+export CGO_ENABLED = 0
+
+.PHONY: \
+	generate-backend \
+	generate-ui \
+	generate-dataloaders \
+	test \
+	it \
+	fmt \
+	lint \
+	ui \
+	ui-start \
+	ui-fmt \
+	ui-validate \
+	pre-ui \
+	clean
+
 ifdef OUTPUT
   OUTPUT := -o $(OUTPUT)
 endif
@@ -20,8 +37,6 @@ ifndef BUILD_TYPE
 	$(eval BUILD_TYPE := LOCAL)
 endif
 
-export CGO_ENABLED = 0
-
 build: pre-build
 	$(eval LDFLAGS := $(LDFLAGS) -X 'github.com/stashapp/stash-box/pkg/api.version=$(STASH_BOX_VERSION)' -X 'github.com/stashapp/stash-box/pkg/api.buildstamp=$(BUILD_DATE)' -X 'github.com/stashapp/stash-box/pkg/api.githash=$(GITHASH)' -X 'github.com/stashapp/stash-box/pkg/api.buildtype=$(BUILD_TYPE)')
 	go build $(OUTPUT) -v -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)"
@@ -31,21 +46,6 @@ build-release-static: build
 
 # Regenerates GraphQL files
 generate: generate-backend generate-ui
-
-.PHONY: \
-	generate-backend \
-	generate-ui \
-	generate-dataloaders \
-	test \
-	it \
-	fmt \
-	lint \
-	ui \
-	ui-start \
-	ui-fmt \
-	ui-validate \
-	pre-ui \
-	clean
 
 clean:
 	@ rm -rf stash-box stash-box-config.yml frontend/node_modules frontend/build dist

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ generate: generate-backend generate-ui
 	clean
 
 clean:
-	@ rm -rf stash-box stash-box-config.yml frontend/node_modules/ frontend/build/
+	@ rm -rf stash-box stash-box-config.yml frontend/node_modules frontend/build dist
 
 generate-backend:
 	go generate

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-release-static: build
 generate: generate-backend generate-ui
 
 clean:
-	@ rm -rf stash-box stash-box-config.yml frontend/node_modules frontend/build dist
+	@ rm -rf stash-box frontend/node_modules frontend/build dist
 
 generate-backend:
 	go generate

--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ Releases TODO
 
 ## Initial setup
 
-Before building the binary the frontend project needs to be built.
-* Run `make pre-ui` to install frontend dependencies.
-* Run `make ui` to build the frontend bundles.
-* Run `make build` to build the binary.
+Run `make` to build the application.
 
 Stash-box requires access to a postgres database server. When stash-box is first run, or when it cannot find a configuration file (defaulting to `stash-box-config.yml` in the current working directory), then it generates a new configuration file with a default postgres connection string (`postgres@localhost/stash-box?sslmode=disable`). It prints a message indicating that the configuration file is generated, and allows you to adjust the default connection string as needed.
 


### PR DESCRIPTION
I've done some initial cleanup of the `Makefile`. In short, I have:

* made the default target do something useful (build  the application).
* grouped all the `.PHONY` declarations together so we can see at a glance all the make targets, and added a missing `.PHONY` for `pre-ui`. There are still some targets that need `.PHONY` declarations but I wasn't able to test those yet.
* added a `clean` target.

I wanted to open a pull request early to get feedback (and hopefully get this merged) because I would like to clean up the `Makefile` even more before I add more things like a `make debian` for building `.deb` packages with docker. Eventually this can even be a GitHub action and you can automatically have `.deb` and `.rpm` packages in your GitHub releases.