### PR TITLE
Improve Site regexp help text

### DIFF
--- a/frontend/src/pages/sites/siteForm/SiteForm.tsx
+++ b/frontend/src/pages/sites/siteForm/SiteForm.tsx
@@ -96,10 +96,13 @@ const SiteForm: FC<SiteProps> = ({ site, callback }) => {
           {...register("regex")}
         />
         <Form.Text>
-          A regular expression that will be optionally used to clean links. Must
-          contain a capture group of the portion of the URL that is considered
-          valid. For instance: <code>(https://example.org/.*)\??</code> which
-          will capture everything before the first question mark.
+          An optional regular expression that will be used to clean links and
+          autofill the Site selection with this Site. Must contain a capture group of
+          the portion of the URL that will be kept.<br/>
+          Example:<br/>
+          This regexp <code>(https?://(?:www.)?example\.org/[^?#]*)</code><br/>
+          will match this string <code>http://example.org/foo/bar?id=69#top</code><br/>
+          and will clean it into <code>http://example.org/foo/bar</code>
         </Form.Text>
       </Form.Group>
 


### PR DESCRIPTION
The current help text achieves the following:

* Clarifies that the regexp is used not just to clean the url but also to autofill the Site selection.
* Offers a more useful example regexp. The previous example regexp didn't even work as described: 
    * It captured everything including the question mark "?" and everything after it. 
    * It also contained an unescaped period "." which matches any character when it is clearly intended to be interpreted literally.
* The example regexp is now also accompanied by example input and the resulting clean url.

**Screenshot**
![add site](https://user-images.githubusercontent.com/115620677/196680516-891b416b-8c2c-45e1-8ff3-6627848ec23b.png)
