### PR TITLE
Submit fields `director` and (studio) `code` to scene drafts

### DIFF
--- a/frontend/src/graphql/mutations/AddScene.gql
+++ b/frontend/src/graphql/mutations/AddScene.gql
@@ -3,7 +3,9 @@ mutation AddScene($sceneData: SceneCreateInput!) {
     id
     release_date
     title
+    code
     details
+    director
     urls {
       url
       site {

--- a/frontend/src/graphql/queries/Draft.gql
+++ b/frontend/src/graphql/queries/Draft.gql
@@ -34,7 +34,9 @@ query Draft($id: ID!) {
       ... on SceneDraft {
         id
         title
+        code
         details
+        director
         date
         url {
           ...URLFragment

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1291,8 +1291,10 @@ export type SceneDestroyInput = {
 
 export type SceneDraft = {
   __typename: "SceneDraft";
+  code?: Maybe<Scalars["String"]>;
   date?: Maybe<Scalars["String"]>;
   details?: Maybe<Scalars["String"]>;
+  director?: Maybe<Scalars["String"]>;
   fingerprints: Array<DraftFingerprint>;
   id?: Maybe<Scalars["ID"]>;
   image?: Maybe<Image>;
@@ -1304,8 +1306,10 @@ export type SceneDraft = {
 };
 
 export type SceneDraftInput = {
+  code?: InputMaybe<Scalars["String"]>;
   date?: InputMaybe<Scalars["String"]>;
   details?: InputMaybe<Scalars["String"]>;
+  director?: InputMaybe<Scalars["String"]>;
   fingerprints: Array<FingerprintInput>;
   id?: InputMaybe<Scalars["ID"]>;
   image?: InputMaybe<Scalars["Upload"]>;
@@ -3044,7 +3048,9 @@ export type AddSceneMutation = {
     id: string;
     release_date?: string | null;
     title?: string | null;
+    code?: string | null;
     details?: string | null;
+    director?: string | null;
     urls: Array<{
       __typename: "URL";
       url: string;
@@ -13859,7 +13865,9 @@ export type DraftQuery = {
           __typename: "SceneDraft";
           id?: string | null;
           title?: string | null;
+          code?: string | null;
           details?: string | null;
+          director?: string | null;
           date?: string | null;
           url?: {
             __typename: "URL";

--- a/frontend/src/pages/drafts/parse.ts
+++ b/frontend/src/pages/drafts/parse.ts
@@ -69,8 +69,8 @@ export const parseSceneDraft = (
     details: draft.details,
     urls: joinURLs(draft.url, existingScene?.urls),
     studio: draft.studio?.__typename === "Studio" ? draft.studio : null,
-    director: null,
-    code: null,
+    director: draft.director,
+    code: draft.code,
     duration: draft.fingerprints?.[0]?.duration ?? null,
     images: draft.image ? [draft.image] : existingScene?.images,
     tags: joinTags(

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -223,7 +223,9 @@ union SceneDraftTag = Tag | DraftEntity
 type SceneDraft {
   id: ID
   title: String
+  code: String
   details: String
+  director: String
   url: URL
   date: String
   studio: SceneDraftStudio
@@ -236,7 +238,9 @@ type SceneDraft {
 input SceneDraftInput {
   id: ID
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
   studio: DraftEntityInput

--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ import (
 	"github.com/stashapp/stash-box/pkg/user"
 )
 
-//nolint
+// nolint
+//
 //go:embed frontend/build
 var ui embed.FS
 

--- a/pkg/api/resolver_mutation_draft.go
+++ b/pkg/api/resolver_mutation_draft.go
@@ -23,7 +23,9 @@ func (r *mutationResolver) SubmitSceneDraft(ctx context.Context, input models.Sc
 	data := models.SceneDraft{
 		ID:           input.ID,
 		Title:        input.Title,
+		Code:         input.Code,
 		Details:      input.Details,
+		Director:     input.Director,
 		URL:          input.URL,
 		Date:         input.Date,
 		Studio:       translateDraftEntity(input.Studio),

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -420,8 +420,10 @@ type ComplexityRoot struct {
 	}
 
 	SceneDraft struct {
+		Code         func(childComplexity int) int
 		Date         func(childComplexity int) int
 		Details      func(childComplexity int) int
+		Director     func(childComplexity int) int
 		Fingerprints func(childComplexity int) int
 		ID           func(childComplexity int) int
 		Image        func(childComplexity int) int
@@ -3063,6 +3065,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Scene.Urls(childComplexity), true
 
+	case "SceneDraft.code":
+		if e.complexity.SceneDraft.Code == nil {
+			break
+		}
+
+		return e.complexity.SceneDraft.Code(childComplexity), true
+
 	case "SceneDraft.date":
 		if e.complexity.SceneDraft.Date == nil {
 			break
@@ -3076,6 +3085,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SceneDraft.Details(childComplexity), true
+
+	case "SceneDraft.director":
+		if e.complexity.SceneDraft.Director == nil {
+			break
+		}
+
+		return e.complexity.SceneDraft.Director(childComplexity), true
 
 	case "SceneDraft.fingerprints":
 		if e.complexity.SceneDraft.Fingerprints == nil {
@@ -4913,7 +4929,9 @@ union SceneDraftTag = Tag | DraftEntity
 type SceneDraft {
   id: ID
   title: String
+  code: String
   details: String
+  director: String
   url: URL
   date: String
   studio: SceneDraftStudio
@@ -4926,7 +4944,9 @@ type SceneDraft {
 input SceneDraftInput {
   id: ID
   title: String
+  code: String
   details: String
+  director: String
   url: String
   date: String
   studio: DraftEntityInput
@@ -22888,6 +22908,47 @@ func (ec *executionContext) fieldContext_SceneDraft_title(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _SceneDraft_code(ctx context.Context, field graphql.CollectedField, obj *SceneDraft) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SceneDraft_code(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Code, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SceneDraft_code(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SceneDraft",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SceneDraft_details(ctx context.Context, field graphql.CollectedField, obj *SceneDraft) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SceneDraft_details(ctx, field)
 	if err != nil {
@@ -22917,6 +22978,47 @@ func (ec *executionContext) _SceneDraft_details(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext_SceneDraft_details(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SceneDraft",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SceneDraft_director(ctx context.Context, field graphql.CollectedField, obj *SceneDraft) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SceneDraft_director(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Director, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SceneDraft_director(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SceneDraft",
 		Field:      field,
@@ -32812,7 +32914,7 @@ func (ec *executionContext) unmarshalInputSceneDraftInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "title", "details", "url", "date", "studio", "performers", "tags", "image", "fingerprints"}
+	fieldsInOrder := [...]string{"id", "title", "code", "details", "director", "url", "date", "studio", "performers", "tags", "image", "fingerprints"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -32835,11 +32937,27 @@ func (ec *executionContext) unmarshalInputSceneDraftInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
+		case "code":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("code"))
+			it.Code, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "details":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("details"))
 			it.Details, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "director":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("director"))
+			it.Director, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -38767,9 +38885,17 @@ func (ec *executionContext) _SceneDraft(ctx context.Context, sel ast.SelectionSe
 
 			out.Values[i] = ec._SceneDraft_title(ctx, field, obj)
 
+		case "code":
+
+			out.Values[i] = ec._SceneDraft_code(ctx, field, obj)
+
 		case "details":
 
 			out.Values[i] = ec._SceneDraft_details(ctx, field, obj)
+
+		case "director":
+
+			out.Values[i] = ec._SceneDraft_director(ctx, field, obj)
 
 		case "url":
 			field := field

--- a/pkg/models/generated_models.go
+++ b/pkg/models/generated_models.go
@@ -466,7 +466,9 @@ type SceneDestroyInput struct {
 type SceneDraftInput struct {
 	ID           *uuid.UUID          `json:"id"`
 	Title        *string             `json:"title"`
+	Code         *string             `json:"code"`
 	Details      *string             `json:"details"`
+	Director     *string             `json:"director"`
 	URL          *string             `json:"url"`
 	Date         *string             `json:"date"`
 	Studio       *DraftEntityInput   `json:"studio"`

--- a/pkg/models/model_draft.go
+++ b/pkg/models/model_draft.go
@@ -29,7 +29,9 @@ func (DraftEntity) IsSceneDraftStudio()    {}
 type SceneDraft struct {
 	ID           *uuid.UUID         `json:"id,omitempty"`
 	Title        *string            `json:"title,omitempty"`
+	Code         *string            `json:"code,omitempty"`
 	Details      *string            `json:"details,omitempty"`
+	Director     *string            `json:"director,omitempty"`
 	URL          *string            `json:"url,omitempty"`
 	Date         *string            `json:"date,omitempty"`
 	Studio       *DraftEntity       `json:"studio,omitempty"`


### PR DESCRIPTION
In a PR for stash I've added the fields `director` and `code` to their Scene data model as these already exist in stash-box ([stashapp/stash#3051](https://github.com/stashapp/stash/pull/3051)). Now I want to include these fields when submitting a scene draft from stash to stash-box. Adding the fields to the `SceneDraft` and `SceneDraftInput` data structures worked well and the fields get added to the scene draft in the database.

However these fields aren't populated when opening the scene draft in the webbrowser, although they exist in the database (see screenshot). Unfortunately I couldn't find the frontend code that handles this. Can someone help me to find the frontend code that needs to be adjusted (I'm an absolute react newbie 😅)?
![image](https://user-images.githubusercontent.com/95097933/198017768-ac3a746d-91f8-4373-8054-4c902e7302db.png)
