### PR TITLE
Fix `dateWithinRange` for nullable dates

### DIFF
--- a/frontend/src/pages/performers/performerForm/schema.ts
+++ b/frontend/src/pages/performers/performerForm/schema.ts
@@ -26,7 +26,7 @@ export const PerformerSchema = yup.object({
   disambiguation: yup.string().trim().transform(nullCheck).nullable(),
   birthdate: yup
     .string()
-    .defined()
+    .trim()
     .transform(nullCheck)
     .matches(/^\d{4}$|^\d{4}-\d{2}$|^\d{4}-\d{2}-\d{2}$/, {
       excludeEmptyString: true,

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -20,7 +20,7 @@ export const dateWithinRange = (
   start?: string | Date,
   end?: string | Date
 ) => {
-  if (!date || (!start && !end)) return false;
+  if (!date || (!start && !end)) return true;
 
   const parsedDate = parseISO(date);
   if (start) {


### PR DESCRIPTION
Schema validation will fail for performers with no birthdate because `dateWithinRange` returns `false` when `date` is `null`. Since this field is supposed to be optional, a `null` value should pass validation.