### PR TITLE
Fix formatting to conform to 'prettier'

### DIFF
--- a/frontend/src/pages/sites/siteForm/SiteForm.tsx
+++ b/frontend/src/pages/sites/siteForm/SiteForm.tsx
@@ -97,11 +97,16 @@ const SiteForm: FC<SiteProps> = ({ site, callback }) => {
         />
         <Form.Text>
           An optional regular expression that will be used to clean links and
-          autofill the Site selection with this Site. Must contain a capture group of
-          the portion of the URL that will be kept.<br/>
-          Example:<br/>
-          This regexp <code>(https?://(?:www.)?example\.org/[^?#]*)</code><br/>
-          will match this string <code>http://example.org/foo/bar?id=69#top</code><br/>
+          autofill the Site selection with this Site. Must contain a capture
+          group of the portion of the URL that will be kept.
+          <br />
+          Example:
+          <br />
+          This regexp <code>(https?://(?:www.)?example\.org/[^?#]*)</code>
+          <br />
+          will match this string{" "}
+          <code>http://example.org/foo/bar?id=69#top</code>
+          <br />
           and will clean it into <code>http://example.org/foo/bar</code>
         </Form.Text>
       </Form.Group>


### PR DESCRIPTION
This fix is to comply with the `make ui-validate` check.
The patch is simply the result of `prettier --write`. Specifically:

    cd frontend/
    yarn run prettier -w -c src/pages/sites/siteForm/SiteForm.tsx
    
  This is the failing test, introduced in 076b56f