### PR TITLE
Fix for strict Yup casts (#645)

### DIFF
--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -189,7 +189,9 @@ const PerformerForm: FC<PerformerProps> = ({
   const [oldChanges, newChanges] = useMemo(
     () =>
       DiffPerformer(
-        PerformerSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        PerformerSchema.cast(fieldData, {
+          assert: "ignore-optionality",
+        }) as PerformerFormData,
         performer
       ),
     [fieldData, performer]

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -187,7 +187,11 @@ const PerformerForm: FC<PerformerProps> = ({
 
   const fieldData = watch();
   const [oldChanges, newChanges] = useMemo(
-    () => DiffPerformer(PerformerSchema.cast(fieldData), performer),
+    () =>
+      DiffPerformer(
+        PerformerSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        performer
+      ),
     [fieldData, performer]
   );
 

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -105,7 +105,9 @@ const SceneForm: FC<SceneProps> = ({
   const [oldSceneChanges, newSceneChanges] = useMemo(
     () =>
       DiffScene(
-        SceneSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        SceneSchema.cast(fieldData, {
+          assert: "ignore-optionality",
+        }) as SceneFormData,
         scene
       ),
     [fieldData, scene]

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -103,7 +103,11 @@ const SceneForm: FC<SceneProps> = ({
 
   const fieldData = watch();
   const [oldSceneChanges, newSceneChanges] = useMemo(
-    () => DiffScene(SceneSchema.cast(fieldData), scene),
+    () =>
+      DiffScene(
+        SceneSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        scene
+      ),
     [fieldData, scene]
   );
 

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -56,7 +56,11 @@ const StudioForm: FC<StudioProps> = ({
   const [file, setFile] = useState<File | undefined>();
   const fieldData = watch();
   const [oldStudioChanges, newStudioChanges] = useMemo(
-    () => DiffStudio(StudioSchema.cast(fieldData), studio),
+    () =>
+      DiffStudio(
+        StudioSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        studio
+      ),
     [fieldData, studio]
   );
 

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -58,7 +58,9 @@ const StudioForm: FC<StudioProps> = ({
   const [oldStudioChanges, newStudioChanges] = useMemo(
     () =>
       DiffStudio(
-        StudioSchema.cast(fieldData, { assert: "ignore-optionality" }),
+        StudioSchema.cast(fieldData, {
+          assert: "ignore-optionality",
+        }) as StudioFormData,
         studio
       ),
     [fieldData, studio]


### PR DESCRIPTION
Upgrading `yup` to >v1 [breaks the usage of `cast`](https://github.com/jquense/yup/issues/1906) for fields that are marked as required but are only defined in these forms when editing existing entities. The simplest fix is to use their [suggested upgrade path](https://github.com/jquense/yup/releases/tag/v1.0.0-beta.5) and allow these fields to be null or undefined on the initial render, since the form validation will ensure that they get filled in before the scene/performer/studio is actually created.

The real fix would be updating all of the schemas to handle the new semantics.