### PR TITLE
README: clarify that direct TLS for SMTP is not supported, STARTTLS is.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The alternative is to use the user's api key. For this, the `ApiKey` header must
 | `min_destructive_voting_period` | `172800` | Minimum time, in seconds, that needs to pass before a destructive edit can be immediately applied with sufficient positive votes. |
 | `vote_cron_interval` | `5m` | Time between runs to close edits whose voting periods have ended. |
 | `email_host` | (none) | Address of the SMTP server. Required to send emails for activation and recovery purposes. |
-| `email_port` | `25` | Port of the SMTP server. |
+| `email_port` | `25` | Port of the SMTP server. Only STARTTLS is supported. Direct TLS connections are not supported. |
 | `email_user` | (none) | Username for the SMTP server. Optional. |
 | `email_password` | (none) | Password for the SMTP server. Optional. |
 | `email_from` | (none) | Email address from which to send emails. |


### PR DESCRIPTION
The current implementation of the stash-box email package uses the smtp.SendMail function which is part of the go standard library. But this function only supports plain tcp connections and upgrades them through STARTTLS. net/smtp has no function that can establish a TLS/TCP connection (aka SMTPS).

When stash-box is configured to use a TLS port for email, it initiates a plain tcp connection waiting for the SMTP server to start an SMTP handshake. But the SMTP(S) server is expecting a TLS handshake so stash-box hangs indefinitely until the TCP connection times out at which point it returns "EOF". This is confusing and time-consuming for administrators to investigate. Hopefully, this README clarification can help avoid this confusion in the future.

Ultimately, if someone wants to put in the effort to properly implement SMTPS support, it can be done with a higher-level package such as emersion/go-smtp.

https://pkg.go.dev/github.com/emersion/go-smtp#DialTLS