### PR TITLE
Validate image location on file backed WriteFile

### DIFF
--- a/pkg/image/file.go
+++ b/pkg/image/file.go
@@ -12,6 +12,10 @@ import (
 type FileBackend struct{}
 
 func (s *FileBackend) WriteFile(file *bytes.Reader, image *models.Image) error {
+	if err := config.ValidateImageLocation(); err != nil {
+		return err
+	}
+
 	fileDir := config.GetImageLocation()
 
 	// check fileDir for the identical file


### PR DESCRIPTION
Validates and returns an error when writing to the file backend if the image location has not been set.