### PR TITLE
Allow configuration of s3 upload headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `s3.bucket` | (none) | Name of S3 bucket used to store images. |
 | `s3.access_key` | (none) | Access key used for authentication. |
 | `s3.secret ` | (none) | Secret Access key used for authentication. |
-| `s3.max_dimension` | (none) | If set, a resized copy will be created for any image whose dimensions exceed this number. This copy will be served in place of the original.
+| `s3.max_dimension` | (none) | If set, a resized copy will be created for any image whose dimensions exceed this number. This copy will be served in place of the original. |
+| `s3.upload_headers` | (none) | A map of headers to send with each upload request. For example, DigitalOcean requires the `x-amz-acl` header to be set to `public-read` or it does not make the uploaded images available. |
 | `phash_distance` | 0 | Determines what binary distance is considered a match when querying with a pHash fingeprint. Using more than 8 is not recommended and may lead to large amounts of false positives. **Note**: The [pg-spgist_hamming extension](#phash-distance-matching) must be installed to use distance matching, otherwise you will get errors. |
 | `favicon_path` | (none) | Location where favicons for linked sites should be stored. Leave empty to disable. |
 | `draft_time_limit` | (24h) | Time, in seconds, before a draft is deleted. |

--- a/pkg/image/s3.go
+++ b/pkg/image/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 
 	"github.com/minio/minio-go/v7"
@@ -17,35 +18,37 @@ type S3Backend struct{}
 
 func (s *S3Backend) WriteFile(file *bytes.Reader, image *models.Image) error {
 	s3config := config.GetS3Config()
+	headers := s3config.UploadHeaders
+
 	minioClient, err := minio.New(s3config.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(s3config.AccessKey, s3config.Secret, ""),
 		Secure: true,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("creating minio client: %w", err)
 	}
 
 	buf := new(bytes.Buffer)
 	if _, err = buf.ReadFrom(file); err != nil {
-		return err
+		return fmt.Errorf("reading from file: %w", err)
 	}
-	if err := uploadS3File(*minioClient, buf.Bytes(), s3config.Bucket, image.ID.String()); err != nil {
-		return err
+	if err := uploadS3File(*minioClient, buf.Bytes(), s3config.Bucket, image.ID.String(), headers); err != nil {
+		return fmt.Errorf("uploading to s3: %w", err)
 	}
 
 	if s3config.MaxDimension != 0 && (image.Width > s3config.MaxDimension || image.Height > s3config.MaxDimension) {
 		if _, err = file.Seek(0, 0); err != nil {
-			return err
+			return fmt.Errorf("seeking in file: %w", err)
 		}
 		resized, err := resizeImage(file, s3config.MaxDimension)
 		if err != nil {
-			return err
+			return fmt.Errorf("resizing image: %w", err)
 		}
 
 		hash := md5.Sum([]byte(image.ID.String() + "-resized"))
 		resizedID := hex.EncodeToString(hash[:])
-		if err := uploadS3File(*minioClient, resized, s3config.Bucket, resizedID); err != nil {
-			return err
+		if err := uploadS3File(*minioClient, resized, s3config.Bucket, resizedID, headers); err != nil {
+			return fmt.Errorf("uploading resized image to s3: %w", err)
 		}
 	}
 
@@ -79,7 +82,7 @@ func (s *S3Backend) DestroyFile(image *models.Image) error {
 	return nil
 }
 
-func uploadS3File(client minio.Client, file []byte, bucket string, id string) error {
+func uploadS3File(client minio.Client, file []byte, bucket string, id string, headers map[string]string) error {
 	ctx := context.TODO()
 
 	// SVG is not correctly detected so we set it manually if the file is xml
@@ -96,7 +99,8 @@ func uploadS3File(client minio.Client, file []byte, bucket string, id string) er
 		bytes.NewReader(file),
 		int64(len(file)),
 		minio.PutObjectOptions{
-			ContentType: contentType,
+			ContentType:  contentType,
+			UserMetadata: headers,
 		},
 	)
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -11,12 +11,13 @@ import (
 )
 
 type S3Config struct {
-	BaseURL      string `mapstructure:"base_url"`
-	Endpoint     string `mapstructure:"endpoint"`
-	Bucket       string `mapstructure:"bucket"`
-	AccessKey    string `mapstructure:"access_key"`
-	Secret       string `mapstructure:"secret"`
-	MaxDimension int64  `mapstructure:"max_dimension"`
+	BaseURL       string            `mapstructure:"base_url"`
+	Endpoint      string            `mapstructure:"endpoint"`
+	Bucket        string            `mapstructure:"bucket"`
+	AccessKey     string            `mapstructure:"access_key"`
+	Secret        string            `mapstructure:"secret"`
+	MaxDimension  int64             `mapstructure:"max_dimension"`
+	UploadHeaders map[string]string `mapstructure:"upload_headers"`
 }
 
 type PostgresConfig struct {


### PR DESCRIPTION
Resolves #657.

Adds a new optional field to the s3 configuration, `upload_headers`. This is a map of headers to values, which will be set in the upload file request to s3.

An example for DigitalOcean spaces is as follows:
```
s3:
 ...
 upload_headers:
  x-amz-acl: public-read
```