### PR TITLE
add error propagation and logging in favicon-related functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifdef OUTPUT
   OUTPUT := -o $(OUTPUT)
 endif
 
-stash-box: pre-ui generate ui build
+stash-box: pre-ui generate ui lint build
 
 pre-build:
 ifndef BUILD_DATE

--- a/pkg/api/routes_image.go
+++ b/pkg/api/routes_image.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/gofrs/uuid"
 	"github.com/stashapp/stash-box/pkg/image"
+	"github.com/stashapp/stash-box/pkg/logger"
 	"github.com/stashapp/stash-box/pkg/manager/config"
 )
 
@@ -44,7 +45,10 @@ func (rs imageRoutes) siteImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := image.GetSiteIcon(r.Context(), *site)
+	data, err := image.GetSiteIcon(r.Context(), *site)
+	if err != nil {
+		logger.Error("Couldn't get favicon:", err)
+	}
 
 	if data == nil {
 		w.Header().Add("Cache-Control", "max-age=86400")

--- a/pkg/image/favicon.go
+++ b/pkg/image/favicon.go
@@ -64,7 +64,7 @@ func GetSiteIcon(ctx context.Context, site models.Site) ([]byte, error) {
 }
 
 func downloadIcon(ctx context.Context, iconPath string, siteURL string) error {
-	err := errors.New("No site url given.")
+	err := errors.New("no site url given")
 	if siteURL == "" {
 		return err
 	}

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -360,11 +360,11 @@ func GetTitle() string {
 	return C.Title
 }
 
-func GetFaviconPath() *string {
+func GetFaviconPath() (*string, error) {
 	if len(C.FaviconPath) == 0 {
-		return nil
+		return nil, errors.New("favicon_path not set")
 	}
-	return &C.FaviconPath
+	return &C.FaviconPath, nil
 }
 
 func GetDraftTimeLimit() int {


### PR DESCRIPTION
If favicon fetching or serving fails for any reason, or if favicon_path is not configured, log an error.

Related to #655