### PR TITLE
Fix clearing entity fields in edits

### DIFF
--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -76,7 +76,7 @@ const StudioForm: FC<StudioProps> = ({
         site_id: u.site.id,
       })),
       image_ids: data.images.map((i) => i.id),
-      parent_id: data.parent?.id,
+      parent_id: data.parent?.id ?? null,
     };
     callback(callbackData, data.note);
   };

--- a/pkg/api/performer_edit_integration_test.go
+++ b/pkg/api/performer_edit_integration_test.go
@@ -508,7 +508,7 @@ func (s *performerEditTestRunner) testApplyModifyUnsetPerformerEdit() {
 		mutation {
 			performerEdit(input: {
 				edit: {id: "%v", operation: MODIFY}
-				details: { aliases: [], tattoos: [], piercings: [], urls: [] }
+				details: { aliases: [], tattoos: [], piercings: [], urls: [], disambiguation: null }
 			}) {
 				id
 			}
@@ -547,7 +547,7 @@ func (s *performerEditTestRunner) testApplyModifyUnsetPerformerEdit() {
 		}
 	`, id), &performer)
 
-	assert.Equal(s.t, performer.FindPerformer.Disambiguation, *performerData.Disambiguation)
+	assert.Equal(s.t, performer.FindPerformer.Disambiguation, "")
 	assert.Check(s.t, len(performer.FindPerformer.Aliases) == 0)
 	assert.Check(s.t, len(performer.FindPerformer.URLs) == 0)
 	assert.Check(s.t, len(performer.FindPerformer.Piercings) == 0)

--- a/pkg/api/performer_edit_integration_test.go
+++ b/pkg/api/performer_edit_integration_test.go
@@ -520,6 +520,7 @@ func (s *performerEditTestRunner) testApplyModifyUnsetPerformerEdit() {
 
 	var performer struct {
 		FindPerformer struct {
+			Height         int
 			ID             string
 			Disambiguation string
 			Aliases        []string
@@ -533,6 +534,7 @@ func (s *performerEditTestRunner) testApplyModifyUnsetPerformerEdit() {
 		query {
 			findPerformer(id: "%v") {
 				disambiguation
+				height
 				aliases
 				urls {
 					url
@@ -548,6 +550,7 @@ func (s *performerEditTestRunner) testApplyModifyUnsetPerformerEdit() {
 	`, id), &performer)
 
 	assert.Equal(s.t, performer.FindPerformer.Disambiguation, "")
+	assert.Equal(s.t, performer.FindPerformer.Height, *performerData.Height)
 	assert.Check(s.t, len(performer.FindPerformer.Aliases) == 0)
 	assert.Check(s.t, len(performer.FindPerformer.URLs) == 0)
 	assert.Check(s.t, len(performer.FindPerformer.Piercings) == 0)

--- a/pkg/api/scene_edit_integration_test.go
+++ b/pkg/api/scene_edit_integration_test.go
@@ -322,7 +322,7 @@ func (s *sceneEditTestRunner) testApplyModifyUnsetSceneEdit() {
 		mutation {
 			sceneEdit(input: {
 				edit: {id: "%v", operation: MODIFY}
-				details: { urls: [] }
+				details: { urls: [], director: null }
 			}) {
 				id
 			}
@@ -336,6 +336,7 @@ func (s *sceneEditTestRunner) testApplyModifyUnsetSceneEdit() {
 		FindScene struct {
 			Director string
 			URLs     []models.URL
+			Tags     []models.Tag
 		}
 	}
 
@@ -346,12 +347,16 @@ func (s *sceneEditTestRunner) testApplyModifyUnsetSceneEdit() {
 				urls {
 					url
 				}
+				tags {
+				  id
+				}
 			}
 		}
 	`, id), &scene)
 
-	assert.Equal(s.t, scene.FindScene.Director, *sceneData.Director)
+	assert.Equal(s.t, scene.FindScene.Director, "")
 	assert.Assert(s.t, len(scene.FindScene.URLs) == 0)
+	assert.Assert(s.t, len(scene.FindScene.Tags) == len(sceneData.TagIds))
 }
 
 func (s *sceneEditTestRunner) testApplyDestroySceneEdit() {

--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -56,7 +56,8 @@ func (m *PerformerEditProcessor) modifyEdit(input models.PerformerEditInput, inp
 	}
 
 	// perform a diff against the input and the current object
-	performerEdit, err := input.Details.PerformerEditFromDiff(*performer, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	performerEdit, err := input.Details.PerformerEditFromDiff(*performer, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/scene.go
+++ b/pkg/manager/edit/scene.go
@@ -56,7 +56,8 @@ func (m *SceneEditProcessor) modifyEdit(input models.SceneEditInput, inputArgs u
 	}
 
 	// perform a diff against the input and the current object
-	sceneEdit, err := input.Details.SceneEditFromDiff(*scene, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	sceneEdit, err := input.Details.SceneEditFromDiff(*scene, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/studio.go
+++ b/pkg/manager/edit/studio.go
@@ -56,7 +56,8 @@ func (m *StudioEditProcessor) modifyEdit(input models.StudioEditInput, inputArgs
 	}
 
 	// perform a diff against the input and the current object
-	studioEdit, err := input.Details.StudioEditFromDiff(*studio, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	studioEdit, err := input.Details.StudioEditFromDiff(*studio, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/tag.go
+++ b/pkg/manager/edit/tag.go
@@ -56,7 +56,8 @@ func (m *TagEditProcessor) modifyEdit(input models.TagEditInput, inputArgs utils
 	}
 
 	// perform a diff against the input and the current object
-	tagEdit := input.Details.TagEditFromDiff(*tag, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	tagEdit := input.Details.TagEditFromDiff(*tag, detailArgs)
 
 	aliases, err := tqb.GetAliases(tagID)
 	if err != nil {


### PR DESCRIPTION
The field null checking is not typed so any typos results in false results. Unfortunately I screwed up all edit validation, and apparently we don't have any test coverage for it.

Resolves #587