### PR TITLE
Expand bot edit filter

### DIFF
--- a/frontend/src/components/list/EditList.tsx
+++ b/frontend/src/components/list/EditList.tsx
@@ -25,7 +25,7 @@ interface EditsProps {
   userId?: string;
   defaultVoteStatus?: VoteStatusEnum;
   defaultVoted?: UserVotedFilterEnum;
-  defaultBot?: "false" | "true" | undefined;
+  defaultBot?: "include" | "exclude" | "only";
   showVotedFilter?: boolean;
 }
 
@@ -79,9 +79,9 @@ const EditListComponent: FC<EditsProps> = ({
       user_id: userId,
       is_favorite: selectedFavorite,
       is_bot:
-        selectedBot === "true"
+        selectedBot === "only"
           ? true
-          : selectedBot === "false"
+          : selectedBot === "exclude"
           ? false
           : undefined,
       page,

--- a/frontend/src/components/list/EditList.tsx
+++ b/frontend/src/components/list/EditList.tsx
@@ -25,6 +25,7 @@ interface EditsProps {
   userId?: string;
   defaultVoteStatus?: VoteStatusEnum;
   defaultVoted?: UserVotedFilterEnum;
+  defaultBot?: "false" | "true" | undefined;
   showVotedFilter?: boolean;
 }
 
@@ -41,6 +42,7 @@ const EditListComponent: FC<EditsProps> = ({
   userId,
   defaultVoteStatus,
   defaultVoted,
+  defaultBot,
   showVotedFilter,
 }) => {
   const { page, setPage } = usePagination();
@@ -65,6 +67,7 @@ const EditListComponent: FC<EditsProps> = ({
     showVotedFilter,
     defaultVoteStatus,
     defaultVoted,
+    defaultBot,
   });
   const { data, loading } = useEdits({
     input: {
@@ -75,7 +78,12 @@ const EditListComponent: FC<EditsProps> = ({
       voted: selectedVoted,
       user_id: userId,
       is_favorite: selectedFavorite,
-      is_bot: selectedBot,
+      is_bot:
+        selectedBot === "true"
+          ? true
+          : selectedBot === "false"
+          ? false
+          : undefined,
       page,
       per_page: PER_PAGE,
       sort: selectedSort,

--- a/frontend/src/components/list/styles.scss
+++ b/frontend/src/components/list/styles.scss
@@ -10,3 +10,7 @@
 .FavoriteFilter {
   width: 240px;
 }
+
+.BotFilter {
+  width: 120px;
+}

--- a/frontend/src/hooks/useEditFilter.tsx
+++ b/frontend/src/hooks/useEditFilter.tsx
@@ -29,6 +29,21 @@ const sortOptions = [
   { value: EditSortEnum.UPDATED_AT, label: "Date updated" },
 ];
 
+const botOptions = [
+  {
+    label: "Include",
+    value: "all",
+  },
+  {
+    label: "Exclude",
+    value: "false",
+  },
+  {
+    label: "Only",
+    value: "true",
+  },
+];
+
 interface EditFilterProps {
   sort?: EditSortEnum;
   direction?: SortDirectionEnum;
@@ -42,6 +57,7 @@ interface EditFilterProps {
   showVotedFilter?: boolean;
   defaultVoteStatus?: VoteStatusEnum | "all";
   defaultVoted?: UserVotedFilterEnum;
+  defaultBot?: "true" | "false" | "all";
 }
 
 const useEditFilter = ({
@@ -57,6 +73,7 @@ const useEditFilter = ({
   showVotedFilter = true,
   defaultVoteStatus = "all",
   defaultVoted,
+  defaultBot = "all",
 }: EditFilterProps) => {
   const [params, setParams] = useQueryParams({
     query: { name: "query", type: "string", default: "" },
@@ -71,7 +88,7 @@ const useEditFilter = ({
     status: { name: "status", type: "string", default: defaultVoteStatus },
     type: { name: "type", type: "string", default: "" },
     favorite: { name: "favorite", type: "string", default: "false" },
-    bot: { name: "bot", type: "string", default: "" },
+    bot: { name: "bot", type: "string", default: defaultBot },
   });
 
   const sort = ensureEnum(EditSortEnum, params.sort);
@@ -81,7 +98,6 @@ const useEditFilter = ({
   const status = resolveEnum(VoteStatusEnum, params.status, undefined);
   const type = resolveEnum(TargetTypeEnum, params.type);
   const favorite = params.favorite === "true";
-  const bot = params.bot === "true" ? true : params.bot === "false" ? false : undefined;
 
   const selectedSort = fixedSort ?? sort;
   const selectedDirection = fixedDirection ?? direction;
@@ -90,7 +106,8 @@ const useEditFilter = ({
   const selectedOperation = fixedOperation ?? operation;
   const selectedVoted = fixedVoted ?? voted;
   const selectedFavorite = fixedFavorite ?? favorite;
-  const selectedBot = fixedBot ?? bot;
+  const selectedBot = fixedBot ?? params.bot;
+  console.log(selectedBot);
 
   const enumToOptions = (e: Record<string, string>) =>
     Object.keys(e).map((key) => (
@@ -208,24 +225,13 @@ const useEditFilter = ({
           className="BotFilter"
           classNamePrefix="react-select"
           onChange={(option) => setParams("bot", option?.value ?? "")}
-          defaultValue={{ label: "Include", value: ""}}
           isClearable={false}
           components={{ IndicatorSeparator: null }}
-          styles={{ valueContainer: (props) => ({ ...props, fontWeight: 400 })}}
-          options={[
-            {
-              label: "Include",
-              value: "",
-            },
-            {
-              label: "Exclude",
-              value: "false",
-            },
-            {
-              label: "Only",
-              value: "true",
-            },
-          ]}
+          styles={{
+            valueContainer: (props) => ({ ...props, fontWeight: 400 }),
+          }}
+          options={botOptions}
+          value={botOptions.find((opt) => opt.value === selectedBot)}
         />
       </Form.Group>
     </Form>

--- a/frontend/src/hooks/useEditFilter.tsx
+++ b/frontend/src/hooks/useEditFilter.tsx
@@ -32,15 +32,15 @@ const sortOptions = [
 const botOptions = [
   {
     label: "Include",
-    value: "all",
+    value: "include",
   },
   {
     label: "Exclude",
-    value: "false",
+    value: "exclude",
   },
   {
     label: "Only",
-    value: "true",
+    value: "only",
   },
 ];
 
@@ -57,7 +57,7 @@ interface EditFilterProps {
   showVotedFilter?: boolean;
   defaultVoteStatus?: VoteStatusEnum | "all";
   defaultVoted?: UserVotedFilterEnum;
-  defaultBot?: "true" | "false" | "all";
+  defaultBot?: "include" | "exclude" | "only";
 }
 
 const useEditFilter = ({
@@ -73,7 +73,7 @@ const useEditFilter = ({
   showVotedFilter = true,
   defaultVoteStatus = "all",
   defaultVoted,
-  defaultBot = "all",
+  defaultBot = "include",
 }: EditFilterProps) => {
   const [params, setParams] = useQueryParams({
     query: { name: "query", type: "string", default: "" },
@@ -107,7 +107,6 @@ const useEditFilter = ({
   const selectedVoted = fixedVoted ?? voted;
   const selectedFavorite = fixedFavorite ?? favorite;
   const selectedBot = fixedBot ?? params.bot;
-  console.log(selectedBot);
 
   const enumToOptions = (e: Record<string, string>) =>
     Object.keys(e).map((key) => (

--- a/frontend/src/hooks/useEditFilter.tsx
+++ b/frontend/src/hooks/useEditFilter.tsx
@@ -1,4 +1,5 @@
 import { Button, Form, InputGroup } from "react-bootstrap";
+import Select from "react-select";
 import {
   faSortAmountUp,
   faSortAmountDown,
@@ -70,7 +71,7 @@ const useEditFilter = ({
     status: { name: "status", type: "string", default: defaultVoteStatus },
     type: { name: "type", type: "string", default: "" },
     favorite: { name: "favorite", type: "string", default: "false" },
-    bot: { name: "bot", type: "string", default: "false" },
+    bot: { name: "bot", type: "string", default: "" },
   });
 
   const sort = ensureEnum(EditSortEnum, params.sort);
@@ -80,7 +81,7 @@ const useEditFilter = ({
   const status = resolveEnum(VoteStatusEnum, params.status, undefined);
   const type = resolveEnum(TargetTypeEnum, params.type);
   const favorite = params.favorite === "true";
-  const bot = params.bot === "true";
+  const bot = params.bot === "true" ? true : params.bot === "false" ? false : undefined;
 
   const selectedSort = fixedSort ?? sort;
   const selectedDirection = fixedDirection ?? direction;
@@ -203,11 +204,28 @@ const useEditFilter = ({
       )}
       <Form.Group controlId="bot" className="text-center ms-3">
         <Form.Label>Bot Edits</Form.Label>
-        <Form.Check
-          className="mt-2"
-          type="switch"
-          defaultChecked={bot}
-          onChange={(e) => setParams("bot", e.currentTarget.checked.toString())}
+        <Select
+          className="BotFilter"
+          classNamePrefix="react-select"
+          onChange={(option) => setParams("bot", option?.value ?? "")}
+          defaultValue={{ label: "Include", value: ""}}
+          isClearable={false}
+          components={{ IndicatorSeparator: null }}
+          styles={{ valueContainer: (props) => ({ ...props, fontWeight: 400 })}}
+          options={[
+            {
+              label: "Include",
+              value: "",
+            },
+            {
+              label: "Exclude",
+              value: "false",
+            },
+            {
+              label: "Only",
+              value: "true",
+            },
+          ]}
         />
       </Form.Group>
     </Form>

--- a/frontend/src/pages/edits/Edits.tsx
+++ b/frontend/src/pages/edits/Edits.tsx
@@ -11,7 +11,7 @@ const EditsComponent: FC = () => (
     <EditList
       defaultVoteStatus={VoteStatusEnum.PENDING}
       defaultVoted={UserVotedFilterEnum.NOT_VOTED}
-      defaultBot="false"
+      defaultBot="exclude"
     />
   </>
 );

--- a/frontend/src/pages/edits/Edits.tsx
+++ b/frontend/src/pages/edits/Edits.tsx
@@ -11,6 +11,7 @@ const EditsComponent: FC = () => (
     <EditList
       defaultVoteStatus={VoteStatusEnum.PENDING}
       defaultVoted={UserVotedFilterEnum.NOT_VOTED}
+      defaultBot="false"
     />
   </>
 );


### PR DESCRIPTION
Hides bot edits in main edits list, but defaults to showing all edits elsewhere.

Resolves #636