### PR TITLE
Fix AddJoinTableFilter performance

### DIFF
--- a/pkg/sqlx/querybuilder_edit.go
+++ b/pkg/sqlx/querybuilder_edit.go
@@ -230,16 +230,6 @@ func (qb *editQueryBuilder) buildQuery(filter models.EditQueryInput, userID uuid
 		query.Eq("target_type", q.String())
 	}
 
-	if q := filter.Status; q != nil {
-		query.Eq("status", q.String())
-	}
-	if q := filter.Operation; q != nil {
-		query.Eq("operation", q.String())
-	}
-	if q := filter.Applied; q != nil {
-		query.Eq("applied", *q)
-	}
-
 	if q := filter.Voted; q != nil && *q != "" {
 		switch *filter.Voted {
 		case models.UserVotedFilterEnumNotVoted:
@@ -286,6 +276,16 @@ func (qb *editQueryBuilder) buildQuery(filter models.EditQueryInput, userID uuid
 		`
 		query.AddWhere(q)
 		query.AddArg(userID, userID, userID, userID, userID, userID)
+	}
+
+	if q := filter.Status; q != nil {
+		query.Eq("status", q.String())
+	}
+	if q := filter.Operation; q != nil {
+		query.Eq("operation", q.String())
+	}
+	if q := filter.Applied; q != nil {
+		query.Eq("applied", *q)
 	}
 
 	if q := filter.IsBot; q != nil {

--- a/pkg/sqlx/querybuilder_studio.go
+++ b/pkg/sqlx/querybuilder_studio.go
@@ -171,8 +171,6 @@ func (qb *studioQueryBuilder) Query(filter models.StudioQueryInput, userID uuid.
 	query := newQueryBuilder(studioDBTable)
 	query.Body += "LEFT JOIN studios as parent_studio ON studios.parent_studio_id = parent_studio.id"
 
-	query.Eq("studios.deleted", false)
-
 	if q := filter.Name; q != nil && *q != "" {
 		searchColumns := []string{"studios.name"}
 		clause, thisArgs := getSearchBinding(searchColumns, *q, false, true)
@@ -213,6 +211,8 @@ func (qb *studioQueryBuilder) Query(filter models.StudioQueryInput, userID uuid.
 
 	query.Sort = qb.getStudioSort(filter)
 	query.Pagination = getPagination(filter.Page, filter.PerPage)
+
+	query.Eq("studios.deleted", false)
 
 	var studios models.Studios
 	countResult, err := qb.dbi.Query(*query, &studios)


### PR DESCRIPTION
The old implementation using `WHERE EXISTS (...)` relied on postgres optimizing the query into a `JOIN () ON`. Unfortunately, it doesn't seem to do so consistently, and the scene pairings query in particular had terrible performance.

Rewriting into a JOIN is tedious since the query builder doesn't really support joins so we have to concat them and sort the filters so args don't get mixed up. I've tested all paths though, and they should work correctly.