### PR TITLE
Skip deleted studios when searching by name

### DIFF
--- a/pkg/sqlx/querybuilder_studio.go
+++ b/pkg/sqlx/querybuilder_studio.go
@@ -146,7 +146,7 @@ func (qb *studioQueryBuilder) FindByNames(names []string) (models.Studios, error
 }
 
 func (qb *studioQueryBuilder) FindByName(name string) (*models.Studio, error) {
-	query := "SELECT * FROM studios WHERE upper(name) = upper(?)"
+	query := "SELECT * FROM studios WHERE upper(name) = upper(?) AND deleted = FALSE"
 	var args []interface{}
 	args = append(args, name)
 	results, err := qb.queryStudios(query, args)


### PR DESCRIPTION
The new Stash app studio tagger searches for studios by name, and Stash-box returns the first one that matches.
If a studio was deleted but a new one created with the same name, the search could return the deleted one and have no way to find the current one, unless you search by id.
A current example where this occurs is trying to tag the studio True Lesbian, it returns https://stashdb.org/studios/6275dedb-64f0-4480-b4c4-8b48e6c35692 instead of https://stashdb.org/studios/a3343c55-164e-4545-bb5f-2338c2a52b88