### PR TITLE
Allow admins to update user edits

### DIFF
--- a/frontend/src/pages/edits/Edit.tsx
+++ b/frontend/src/pages/edits/Edit.tsx
@@ -81,7 +81,7 @@ const EditComponent: FC = () => {
   const buttons = (isAdmin(auth.user) || auth.user?.id === edit.user?.id) &&
     edit.status === VoteStatusEnum.PENDING && (
       <div className="d-flex justify-content-end">
-        {auth.user?.id === edit.user?.id &&
+        {(auth.user?.id === edit.user?.id || isAdmin(auth.user)) &&
           edit.operation !== OperationEnum.DESTROY &&
           !edit.updated && (
             <Link to={createHref(ROUTE_EDIT_UPDATE, edit)} className="me-2">

--- a/frontend/src/pages/edits/EditUpdate.tsx
+++ b/frontend/src/pages/edits/EditUpdate.tsx
@@ -8,6 +8,7 @@ import { SceneEditUpdate } from "src/pages/scenes/SceneEditUpdate";
 import { PerformerEditUpdate } from "src/pages/performers/PerformerEditUpdate";
 import { TagEditUpdate } from "src/pages/tags/TagEditUpdate";
 import { StudioEditUpdate } from "src/pages/studios/StudioEditUpdate";
+import { isAdmin } from "src/utils";
 
 const EditUpdateComponent: FC = () => {
   const auth = useContext(AuthContext);
@@ -18,7 +19,7 @@ const EditUpdateComponent: FC = () => {
 
   const edit = data?.findEdit;
   if (!edit) return <ErrorMessage error="Failed to load edit." />;
-  if (edit.user?.id != auth.user?.id)
+  if (edit.user?.id != auth.user?.id && !isAdmin(auth.user))
     return <ErrorMessage error="Only the creator can update edits." />;
   if (edit.updated)
     return <ErrorMessage error="Edits can only be updated once." />;

--- a/pkg/api/resolver_mutation_edit.go
+++ b/pkg/api/resolver_mutation_edit.go
@@ -74,7 +74,7 @@ func (r *mutationResolver) SceneEditUpdate(ctx context.Context, id uuid.UUID, in
 		return nil, err
 	}
 
-	if existingEdit.UserID.UUID != currentUser.ID {
+	if validateUserOrAdmin(ctx, existingEdit.UserID.UUID) != nil {
 		return nil, ErrUnauthorizedUpdate
 	}
 
@@ -151,7 +151,7 @@ func (r *mutationResolver) StudioEditUpdate(ctx context.Context, id uuid.UUID, i
 		return nil, err
 	}
 
-	if existingEdit.UserID.UUID != currentUser.ID {
+	if validateUserOrAdmin(ctx, existingEdit.UserID.UUID) != nil {
 		return nil, ErrUnauthorizedUpdate
 	}
 
@@ -228,7 +228,7 @@ func (r *mutationResolver) TagEditUpdate(ctx context.Context, id uuid.UUID, inpu
 		return nil, err
 	}
 
-	if existingEdit.UserID.UUID != currentUser.ID {
+	if validateUserOrAdmin(ctx, existingEdit.UserID.UUID) != nil {
 		return nil, ErrUnauthorizedUpdate
 	}
 
@@ -311,7 +311,7 @@ func (r *mutationResolver) PerformerEditUpdate(ctx context.Context, id uuid.UUID
 		return nil, err
 	}
 
-	if existingEdit.UserID.UUID != currentUser.ID {
+	if validateUserOrAdmin(ctx, existingEdit.UserID.UUID) != nil {
 		return nil, ErrUnauthorizedUpdate
 	}
 


### PR DESCRIPTION
Allows admins to edit all user pending edits. Still requires them to submit an edit comment.