### PR TITLE
Fix the Incorrect Image Size bug

### DIFF
--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -35,10 +35,10 @@ type OldDetails = EditFragment["old_details"];
 type Options = EditFragment["options"];
 
 type Image = {
-  height?: number | undefined;
+  height: number;
   id: string;
   url: string;
-  width?: number | undefined;
+  width: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/frontend/src/components/editCard/ModifyEdit.tsx
+++ b/frontend/src/components/editCard/ModifyEdit.tsx
@@ -34,6 +34,13 @@ type Details = EditFragment["details"];
 type OldDetails = EditFragment["old_details"];
 type Options = EditFragment["options"];
 
+type Image = {
+  height?: number | undefined;
+  id: string;
+  url: string;
+  width?: number | undefined;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StartingWith<T, K extends string> = T extends `${K}${infer _}` ? T : never;
 type TargetOldDetails<T> = Omit<
@@ -95,11 +102,6 @@ type BodyMod = {
   description?: string | null;
 };
 
-type Image = {
-  id: string;
-  url: string;
-};
-
 export interface PerformerDetails {
   name?: string | null;
   gender?: GenderEnum | null;
@@ -123,8 +125,8 @@ export interface PerformerDetails {
   removed_piercings?: BodyMod[] | null;
   added_aliases?: string[] | null;
   removed_aliases?: string[] | null;
-  added_images?: NullableImage[] | null;
-  removed_images?: NullableImage[] | null;
+  added_images?: (Image | null)[] | null;
+  removed_images?: (Image | null)[] | null;
   added_urls?: URL[] | null;
   removed_urls?: URL[] | null;
   draft_id?: string | null;
@@ -303,8 +305,6 @@ type ScenePerformance = {
   >;
 };
 
-type NullableImage = Image | null;
-
 export interface SceneDetails {
   title?: string | null;
   date?: string | null;
@@ -318,8 +318,8 @@ export interface SceneDetails {
   } | null;
   added_performers?: ScenePerformance[] | null;
   removed_performers?: ScenePerformance[] | null;
-  added_images?: NullableImage[] | null;
-  removed_images?: NullableImage[] | null;
+  added_images?: (Image | null)[] | null;
+  removed_images?: (Image | null)[] | null;
   added_urls?: URL[] | null;
   removed_urls?: URL[] | null;
   added_tags?:
@@ -464,8 +464,8 @@ export interface StudioDetails {
     id: string;
     name: string;
   } | null;
-  added_images?: NullableImage[] | null;
-  removed_images?: NullableImage[] | null;
+  added_images?: (Image | null)[] | null;
+  removed_images?: (Image | null)[] | null;
   added_urls?: URL[] | null;
   removed_urls?: URL[] | null;
 }

--- a/frontend/src/components/editImages/editImages.tsx
+++ b/frontend/src/components/editImages/editImages.tsx
@@ -5,7 +5,7 @@ import type { Control } from "react-hook-form";
 import { faImages } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 
-import { useAddImage } from "src/graphql";
+import { ImageFragment as Image, useAddImage } from "src/graphql";
 import { Image as ImageInput } from "src/components/form";
 import { Icon, LoadingIndicator } from "src/components/fragments";
 
@@ -17,11 +17,6 @@ const CLASSNAME_DROP = `${CLASSNAME}-drop`;
 const CLASSNAME_PLACEHOLDER = `${CLASSNAME}-placeholder`;
 const CLASSNAME_IMAGE = `${CLASSNAME}-image`;
 const CLASSNAME_UPLOADING = `${CLASSNAME_IMAGE}-uploading`;
-
-type Image = {
-  id: string;
-  url: string;
-};
 
 type ControlType =
   | Control<{ images?: Image[] | undefined }, "images">
@@ -35,7 +30,7 @@ interface EditImagesProps {
   maxImages?: number;
   /** Whether to allow svg/png image input */
   allowLossless?: boolean;
-  original?: { id: string; url: string }[] | undefined;
+  original?: Image[] | undefined;
 }
 
 const EditImages: FC<EditImagesProps> = ({
@@ -72,6 +67,7 @@ const EditImages: FC<EditImagesProps> = ({
         if (i.data?.imageCreate?.id) {
           if (!images.some((image) => image.id === i.data?.imageCreate?.id)) {
             append(i.data.imageCreate);
+            console.log(i.data.imageCreate);
           }
           setFile(undefined);
           setImageData("");

--- a/frontend/src/components/editImages/editImages.tsx
+++ b/frontend/src/components/editImages/editImages.tsx
@@ -67,7 +67,6 @@ const EditImages: FC<EditImagesProps> = ({
         if (i.data?.imageCreate?.id) {
           if (!images.some((image) => image.id === i.data?.imageCreate?.id)) {
             append(i.data.imageCreate);
-            console.log(i.data.imageCreate);
           }
           setFile(undefined);
           setImageData("");

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -1,34 +1,25 @@
-import { FC, useState } from "react";
+import { FC } from "react";
 import { Col, Row } from "react-bootstrap";
 
-import { ImageFragment as Image } from "src/graphql";
+type Image = {
+  height?: number | undefined;
+  id: string;
+  url: string;
+  width?: number | undefined;
+};
 
 const CLASSNAME = "ImageChangeRow";
 const CLASSNAME_IMAGE = `${CLASSNAME}-image`;
 
 export interface ImageChangeRowProps {
-  newImages?: (Pick<Image, "id" | "url"> | null)[] | null;
-  oldImages?: (Pick<Image, "id" | "url"> | null)[] | null;
+  newImages?: (Image | null)[] | null;
+  oldImages?: (Image | null)[] | null;
   showDiff?: boolean;
 }
 
 const Images: FC<{
-  images: (Pick<Image, "id" | "url"> | null)[] | null | undefined;
+  images: (Image | null)[] | null | undefined;
 }> = ({ images }) => {
-  const [imgDimensions, setImgDimensions] = useState<{
-    [key: string]: { height: number; width: number };
-  }>({});
-
-  const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
-    setImgDimensions({
-      ...imgDimensions,
-      [event.currentTarget.src]: {
-        height: event.currentTarget.naturalHeight,
-        width: event.currentTarget.naturalWidth,
-      },
-    });
-  };
-
   return (
     <>
       {(images ?? []).map((image, i) =>
@@ -36,18 +27,9 @@ const Images: FC<{
           <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
         ) : (
           <div key={image.id}>
-            <img
-              src={image.url}
-              className={CLASSNAME_IMAGE}
-              alt=""
-              onLoad={onImgLoad}
-            />
+            <img src={image.url} className={CLASSNAME_IMAGE} alt="" />
             <div className={"text-center"}>
-              {imgDimensions && imgDimensions[image.url]
-                ? `${imgDimensions[image.url].width} x ${
-                    imgDimensions[image.url].height
-                  }`
-                : ""}
+              {image.width} x {image.height}
             </div>
           </div>
         )

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -2,10 +2,10 @@ import { FC } from "react";
 import { Col, Row } from "react-bootstrap";
 
 type Image = {
-  height?: number | undefined;
+  height: number;
   id: string;
   url: string;
-  width?: number | undefined;
+  width: number;
 };
 
 const CLASSNAME = "ImageChangeRow";

--- a/frontend/src/pages/performers/performerForm/schema.ts
+++ b/frontend/src/pages/performers/performerForm/schema.ts
@@ -115,6 +115,8 @@ export const PerformerSchema = yup.object({
       yup.object({
         id: yup.string().required(),
         url: yup.string().required(),
+        width: yup.number().default(0),
+        height: yup.number().default(0),
       })
     )
     .required(),

--- a/frontend/src/pages/scenes/sceneForm/schema.ts
+++ b/frontend/src/pages/scenes/sceneForm/schema.ts
@@ -81,6 +81,8 @@ export const SceneSchema = yup.object({
       yup.object({
         id: yup.string().required(),
         url: yup.string().required(),
+        width: yup.number().default(0),
+        height: yup.number().default(0),
       })
     )
     .required(),

--- a/frontend/src/pages/scenes/sceneForm/schema.ts
+++ b/frontend/src/pages/scenes/sceneForm/schema.ts
@@ -81,8 +81,8 @@ export const SceneSchema = yup.object({
       yup.object({
         id: yup.string().required(),
         url: yup.string().required(),
-        width: yup.number().default(0),
-        height: yup.number().default(0),
+        width: yup.number().required(),
+        height: yup.number().required(),
       })
     )
     .required(),

--- a/frontend/src/pages/studios/studioForm/schema.ts
+++ b/frontend/src/pages/studios/studioForm/schema.ts
@@ -23,6 +23,8 @@ export const StudioSchema = yup.object({
       yup.object({
         id: yup.string().required(),
         url: yup.string().required(),
+        width: yup.number().default(0),
+        height: yup.number().default(0),
       })
     )
     .required(),

--- a/frontend/src/pages/studios/studioForm/schema.ts
+++ b/frontend/src/pages/studios/studioForm/schema.ts
@@ -23,8 +23,8 @@ export const StudioSchema = yup.object({
       yup.object({
         id: yup.string().required(),
         url: yup.string().required(),
-        width: yup.number().default(0),
-        height: yup.number().default(0),
+        width: yup.number().required(),
+        height: yup.number().required(),
       })
     )
     .required(),

--- a/frontend/src/utils/diff.ts
+++ b/frontend/src/utils/diff.ts
@@ -15,8 +15,15 @@ export const diffValue = <T extends unknown>(
 ): T | null => (a && a !== b ? a : null);
 
 export const diffImages = (
-  newImages: { id: string | undefined; url: string | undefined }[] | undefined,
-  oldImages: { id: string; url: string }[]
+  newImages:
+    | {
+        id: string | undefined;
+        url: string | undefined;
+        width: number | undefined;
+        height: number | undefined;
+      }[]
+    | undefined,
+  oldImages: { id: string; url: string; width: number; height: number }[]
 ) =>
   diffArray(
     (newImages ?? []).flatMap((i) =>
@@ -25,6 +32,8 @@ export const diffImages = (
             {
               id: i.id,
               url: i.url,
+              width: i.width,
+              height: i.height,
             },
           ]
         : []

--- a/frontend/src/utils/diff.ts
+++ b/frontend/src/utils/diff.ts
@@ -27,7 +27,7 @@ export const diffImages = (
 ) =>
   diffArray(
     (newImages ?? []).flatMap((i) =>
-      i.id && i.url
+      i.id && i.url && i.height && i.width
         ? [
             {
               id: i.id,


### PR DESCRIPTION
Fixes a bug in my previous version of the Image dimensions display.
Bug was caused because the image dimension was gathered in frontend based on the image that was displayed. But that didn't work with the CDN.

So I fixed it by looking at the data returned by the GraphQL query, which required a few type changes because width/height were not kept for newly uploaded images.

Fixes: https://github.com/stashapp/stash-box/pull/724