### PR TITLE
add native beforeUnload handlers

### DIFF
--- a/frontend/src/hooks/useBeforeUnload.ts
+++ b/frontend/src/hooks/useBeforeUnload.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-export const NativeBeforeUnload = () => {
+export const useBeforeUnload = () => {
   const unloadListener = (event: BeforeUnloadEvent) => {
     event.preventDefault();
     event.returnValue = true

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -38,7 +38,7 @@ import URLInput from "src/components/urlInput";
 import DiffPerformer from "./diff";
 import { PerformerSchema, PerformerFormData } from "./schema";
 import { InitialPerformer } from "./types";
-import { NativeBeforeUnload } from "src/utils/beforeUnload";
+import { useBeforeUnload } from "src/hooks/useBeforeUnload";
 
 import { GenderTypes } from "src/constants";
 
@@ -135,7 +135,7 @@ const PerformerForm: FC<PerformerProps> = ({
   saving,
   options,
 }) => {
-  NativeBeforeUnload();
+  useBeforeUnload();
   const initialAliases = initial?.aliases ?? performer?.aliases ?? [];
   const {
     register,

--- a/frontend/src/pages/performers/performerForm/PerformerForm.tsx
+++ b/frontend/src/pages/performers/performerForm/PerformerForm.tsx
@@ -38,6 +38,7 @@ import URLInput from "src/components/urlInput";
 import DiffPerformer from "./diff";
 import { PerformerSchema, PerformerFormData } from "./schema";
 import { InitialPerformer } from "./types";
+import { NativeBeforeUnload } from "src/utils/beforeUnload";
 
 import { GenderTypes } from "src/constants";
 
@@ -134,6 +135,7 @@ const PerformerForm: FC<PerformerProps> = ({
   saving,
   options,
 }) => {
+  NativeBeforeUnload();
   const initialAliases = initial?.aliases ?? performer?.aliases ?? [];
   const {
     register,

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -34,6 +34,7 @@ import DiffScene from "./diff";
 import { SceneSchema, SceneFormData } from "./schema";
 import { InitialScene } from "./types";
 import ExistingSceneAlert from "./ExistingSceneAlert";
+import { NativeBeforeUnload } from "src/utils/beforeUnload";
 
 const CLASS_NAME = "SceneForm";
 const CLASS_NAME_PERFORMER_CHANGE = `${CLASS_NAME}-performer-change`;
@@ -59,6 +60,7 @@ const SceneForm: FC<SceneProps> = ({
   isCreate = false,
   draftFingerprints,
 }) => {
+  NativeBeforeUnload
   const {
     register,
     control,

--- a/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
+++ b/frontend/src/pages/scenes/sceneForm/SceneForm.tsx
@@ -33,8 +33,8 @@ import URLInput from "src/components/urlInput";
 import DiffScene from "./diff";
 import { SceneSchema, SceneFormData } from "./schema";
 import { InitialScene } from "./types";
+import { useBeforeUnload } from "src/hooks/useBeforeUnload";
 import ExistingSceneAlert from "./ExistingSceneAlert";
-import { NativeBeforeUnload } from "src/utils/beforeUnload";
 
 const CLASS_NAME = "SceneForm";
 const CLASS_NAME_PERFORMER_CHANGE = `${CLASS_NAME}-performer-change`;
@@ -60,7 +60,7 @@ const SceneForm: FC<SceneProps> = ({
   isCreate = false,
   draftFingerprints,
 }) => {
-  NativeBeforeUnload
+  useBeforeUnload();
   const {
     register,
     control,

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -21,7 +21,7 @@ import { renderStudioDetails } from "src/components/editCard/ModifyEdit";
 import { StudioSchema, StudioFormData } from "./schema";
 import { InitialStudio } from "./types";
 import DiffStudio from "./diff";
-import { NativeBeforeUnload } from "src/utils/beforeUnload";
+import { useBeforeUnload } from "src/hooks/useBeforeUnload";
 
 interface StudioProps {
   studio?: Studio | null;
@@ -38,7 +38,7 @@ const StudioForm: FC<StudioProps> = ({
   initial,
   saving,
 }) => {
-  NativeBeforeUnload();
+  useBeforeUnload();
   const {
     register,
     control,

--- a/frontend/src/pages/studios/studioForm/StudioForm.tsx
+++ b/frontend/src/pages/studios/studioForm/StudioForm.tsx
@@ -21,6 +21,7 @@ import { renderStudioDetails } from "src/components/editCard/ModifyEdit";
 import { StudioSchema, StudioFormData } from "./schema";
 import { InitialStudio } from "./types";
 import DiffStudio from "./diff";
+import { NativeBeforeUnload } from "src/utils/beforeUnload";
 
 interface StudioProps {
   studio?: Studio | null;
@@ -37,6 +38,7 @@ const StudioForm: FC<StudioProps> = ({
   initial,
   saving,
 }) => {
+  NativeBeforeUnload();
   const {
     register,
     control,

--- a/frontend/src/pages/tags/tagForm/TagForm.tsx
+++ b/frontend/src/pages/tags/tagForm/TagForm.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react";
-import { useNavigate } from "react-router-dom";
 import { useForm, Controller, FieldError } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import cx from "classnames";
@@ -19,7 +18,7 @@ import MultiSelect from "src/components/multiSelect";
 
 import { TagSchema, TagFormData } from "./schema";
 import { InitialTag } from "./types";
-import { NativeBeforeUnload } from "src/utils/beforeUnload";
+import { useBeforeUnload } from "src/hooks/useBeforeUnload";
 
 interface TagProps {
   tag?: Tag | null;
@@ -29,8 +28,7 @@ interface TagProps {
 }
 
 const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
-  NativeBeforeUnload();
-  const navigate = useNavigate();
+  useBeforeUnload();
   const initialAliases = initial?.aliases ?? tag?.aliases ?? [];
   const {
     register,
@@ -144,7 +142,7 @@ const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
         <Button type="reset" className="ms-auto me-2">
           Reset
         </Button>
-        <Button variant="danger" onClick={() => navigate(-1)}>
+        <Button variant="danger" onClick={() => history.back()}>
           Cancel
         </Button>
       </Form.Group>

--- a/frontend/src/pages/tags/tagForm/TagForm.tsx
+++ b/frontend/src/pages/tags/tagForm/TagForm.tsx
@@ -19,6 +19,7 @@ import MultiSelect from "src/components/multiSelect";
 
 import { TagSchema, TagFormData } from "./schema";
 import { InitialTag } from "./types";
+import { NativeBeforeUnload } from "src/utils/beforeUnload";
 
 interface TagProps {
   tag?: Tag | null;
@@ -28,6 +29,7 @@ interface TagProps {
 }
 
 const TagForm: FC<TagProps> = ({ tag, callback, initial, saving }) => {
+  NativeBeforeUnload();
   const navigate = useNavigate();
   const initialAliases = initial?.aliases ?? tag?.aliases ?? [];
   const {

--- a/frontend/src/utils/beforeUnload.ts
+++ b/frontend/src/utils/beforeUnload.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export const NativeBeforeUnload = () => {
+  const unloadListener = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = true
+  }
+  useEffect(() => {
+    window.addEventListener("beforeunload", unloadListener);
+  }, []);
+  return () => window.removeEventListener("beforeunload", unloadListener)
+}


### PR DESCRIPTION
partially addresses #594 

doesn't work with SPA navigation because

[it's "unstable"](https://www.github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx#L1796-L1828), reactrouter [does not intercept it](https://reactrouter.com/en/main/hooks/use-before-unload), it [does not work on SPAs](https://www.github.com/remix-run/react-router/issues/10894), the [PR](https://www.github.com/remix-run/react-router/pull/4359) ([s](https://www.github.com/remix-run/react-router/pull/4372)) are dead, is [still unstable](https://www.github.com/remix-run/react-router/issues/8139)

If someone else who is more versed and has more patience for SPAs and React wants to improve, it they are more than welcome to. In the meantime I will just [intercept navigate events](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event)