### PR TITLE
Remove tag redirects from draft tag resolution

### DIFF
--- a/pkg/api/resolver_model_scene_draft.go
+++ b/pkg/api/resolver_model_scene_draft.go
@@ -63,7 +63,7 @@ func (r *sceneDraftResolver) Tags(ctx context.Context, obj *models.SceneDraft) (
 	for _, t := range obj.Tags {
 		var st models.SceneDraftTag
 		if t.ID != nil {
-			tag, err := qb.FindWithRedirect(*t.ID)
+			tag, err := qb.Find(*t.ID)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/api/resolver_mutation_draft.go
+++ b/pkg/api/resolver_mutation_draft.go
@@ -190,19 +190,25 @@ func resolveTags(tags []*models.DraftEntityInput, fac models.Repo) ([]models.Dra
 		res := models.DraftEntity{}
 
 		if tag.ID != nil {
-			res = *translateDraftEntity(tag)
+			dbTag, _ := tqb.Find(*tag.ID)
+			if dbTag.ID == *tag.ID {
+				res = *translateDraftEntity(tag)
+			}
 		} else {
 			foundTag, err := tqb.FindByNameOrAlias(tag.Name)
 			if err != nil {
 				return nil, err
 			}
 
-			res := models.DraftEntity{
-				Name: tag.Name,
-			}
 			if foundTag != nil {
 				res.Name = foundTag.Name
 				res.ID = &foundTag.ID
+			}
+		}
+
+		if res.Name == "" {
+			res = models.DraftEntity{
+				Name: tag.Name,
 			}
 		}
 

--- a/pkg/sqlx/querybuilder_tag.go
+++ b/pkg/sqlx/querybuilder_tag.go
@@ -126,8 +126,10 @@ func (qb *tagQueryBuilder) FindByNameOrAlias(name string) (*models.Tag, error) {
 	query := `
 		SELECT T.* FROM tags T
 		LEFT JOIN tag_aliases TA ON T.id = TA.tag_id
-		WHERE LOWER(TA.alias) = LOWER($1) OR LOWER(T.name) = LOWER($1)
-		ORDER BY T.deleted ASC
+		WHERE (
+		  LOWER(TA.alias) = LOWER($1)
+			OR LOWER(T.name) = LOWER($1)
+		) AND T.deleted = 'F'
 	`
 
 	args := []interface{}{name}


### PR DESCRIPTION
Removes redirects from consideration and only matches on name or alias of active tags.

Resolves #749 