### PR TITLE
Drop unique index on pending invites and fix invite key list

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var appSchemaVersion uint = 35
+var appSchemaVersion uint = 36
 
 var databaseProviders map[string]databaseProvider
 

--- a/pkg/database/migrations/postgres/36_drop_unique_invite.up.sql
+++ b/pkg/database/migrations/postgres/36_drop_unique_invite.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "pending_activation_invite_key_idx";

--- a/pkg/sqlx/querybuilder_invite_key.go
+++ b/pkg/sqlx/querybuilder_invite_key.go
@@ -109,8 +109,13 @@ func (qb *inviteKeyQueryBuilder) Find(id uuid.UUID) (*models.InviteKey, error) {
 
 func (qb *inviteKeyQueryBuilder) FindActiveKeysForUser(userID uuid.UUID, expireTime time.Time) (models.InviteKeys, error) {
 	query := `SELECT i.* FROM ` + inviteKeyTable + ` i 
-	 LEFT JOIN ` + pendingActivationTable + ` a ON a.invite_key = i.id AND a.time > ?
-	 WHERE i.generated_by = ? AND a.id IS NULL`
+	 LEFT JOIN (
+	   SELECT invite_key, COUNT(*) as count
+		 FROM pending_activations
+		 WHERE time > ?
+		 GROUP BY invite_key
+	 ) a ON a.invite_key = i.id
+	 WHERE i.generated_by = ? AND (a.invite_key IS NULL OR i.uses IS NULL OR a.count < i.uses)`
 	var args []interface{}
 	args = append(args, expireTime)
 	args = append(args, userID)


### PR DESCRIPTION
Unique index prevents multi-use keys from working properly.