### PR TITLE
Fix draft images being deleted while they're still in use

### DIFF
--- a/pkg/draft/draft.go
+++ b/pkg/draft/draft.go
@@ -36,12 +36,15 @@ func Destroy(fac models.Repo, id uuid.UUID) error {
 		return fmt.Errorf("Unsupported type: %s", draft.Type)
 	}
 
+	if err = dqb.Destroy(id); err != nil {
+		return err
+	}
+
 	if imageID != nil {
 		imageService := image.GetService(fac.Image())
 		if err := imageService.DestroyUnusedImage(*imageID); err != nil {
 			return err
 		}
 	}
-
-	return dqb.Destroy(id)
+	return nil
 }


### PR DESCRIPTION
Drafts were not taken into consideration when checking for image usage, so in some cases drafts could end up with a dead image.