### PR TITLE
Allow jpeg & jfif for Image Uploads

### DIFF
--- a/frontend/src/components/editImages/editImages.tsx
+++ b/frontend/src/components/editImages/editImages.tsx
@@ -125,6 +125,7 @@ const EditImages: FC<EditImagesProps> = ({
                     ".jpg",
                     ".jpeg",
                     ".webp",
+                    ".jfif",
                     ...(allowLossless ? [".svg", ".png"] : []),
                   ].join(",")}
                 />

--- a/frontend/src/components/editImages/editImages.tsx
+++ b/frontend/src/components/editImages/editImages.tsx
@@ -123,6 +123,7 @@ const EditImages: FC<EditImagesProps> = ({
                   onChange={onFileChange}
                   accept={[
                     ".jpg",
+                    ".jpeg",
                     ".webp",
                     ...(allowLossless ? [".svg", ".png"] : []),
                   ].join(",")}


### PR DESCRIPTION
Minor change, but will make life so much easier.

Uploading images (for performers, as an example) now allows using JPEG extension files (already supported, but missing in the filter)