### PR TITLE
Update session.go

### DIFF
--- a/pkg/api/session.go
+++ b/pkg/api/session.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-const cookieName = "session"
+const cookieName = "stashbox"
 const usernameFormKey = "username"
 const passwordFormKey = "password"
 const userIDKey = "userID"


### PR DESCRIPTION
changed cookie name from "session" to "stashbox" to remove browser conflicts with stash instances (stashapp also uses "session"). this will allow users to be logged in to both their Stash app instance and StashBox/Stashdb at the same time in the same browser session.