### PR TITLE
Update docker compose for production

### DIFF
--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -2,7 +2,7 @@
 # ie from top=level stash:
 # docker build -t stash-box/build -f docker/build/x86_64/Dockerfile .
 
-FROM golang:1.22.5 as compiler
+FROM golang:1.22.5 AS compiler
 
 RUN apt-get update && apt-get install -y apt-transport-https
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
@@ -31,7 +31,7 @@ RUN make generate
 RUN make ui 
 RUN make build
 
-FROM ubuntu:22.04 as app
+FROM ubuntu:22.04 AS app
 
 RUN apt-get update && apt-get -y install ca-certificates
 COPY --from=compiler /stash-box/stash-box /usr/bin/

--- a/docker/build/x86_64/Dockerfile
+++ b/docker/build/x86_64/Dockerfile
@@ -2,10 +2,10 @@
 # ie from top=level stash:
 # docker build -t stash-box/build -f docker/build/x86_64/Dockerfile .
 
-FROM golang:1.13.14 as compiler
+FROM golang:1.22.5 as compiler
 
 RUN apt-get update && apt-get install -y apt-transport-https
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
@@ -31,7 +31,7 @@ RUN make generate
 RUN make ui 
 RUN make build
 
-FROM ubuntu:19.10 as app
+FROM ubuntu:22.04 as app
 
 RUN apt-get update && apt-get -y install ca-certificates
 COPY --from=compiler /stash-box/stash-box /usr/bin/

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       - "--entryPoints.web.http.redirections.entryPoint.scheme=https"
       - "--providers.docker=true"
       - "--certificatesResolvers.stash-box.acme.email=<EMAIL>"
-      - "--certificatesResolvers.stash-box.acme.storage=/acme.json"
+      - "--certificatesResolvers.stash-box.acme.storage=/traefik/acme.json"
       - "--certificatesresolvers.stash-box.acme.tlschallenge=true"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /traefik/acme.json:/acme.json
+      - /traefik/acme.json:/traefik

--- a/docker/production/postgres/Dockerfile
+++ b/docker/production/postgres/Dockerfile
@@ -1,11 +1,10 @@
-FROM postgres:14.2
+FROM postgres:15.8
 
-RUN buildDeps='git make gcc postgresql-server-dev-14' \
+RUN buildDeps='git make build-essential postgresql-server-dev-15' \
 		&& apt update && apt install -y $buildDeps --no-install-recommends --reinstall ca-certificates \
-		&& git clone https://github.com/fake-name/pg-spgist_hamming.git \
-		&& make -C pg-spgist_hamming/bktree \
-		&& make -C pg-spgist_hamming/bktree install \
-		&& rm -rf pg-spgist_hamming \
+		&& git clone https://github.com/evirma/pg_bktree.git /usr/local/src/bktree \
+  		&& cd /usr/local/src/bktree \
+		&& make USE_PGXS=1 && make USE_PGXS=1 install \
 		&& apt purge -y --auto-remove $buildDeps
 
 EXPOSE 5432

--- a/frontend/src/components/list/SceneList.tsx
+++ b/frontend/src/components/list/SceneList.tsx
@@ -32,6 +32,7 @@ interface Props {
 
 const sortOptions = [
   { value: SceneSortEnum.DATE, label: "Release Date" },
+  { value: SceneSortEnum.CODE, label: "Code" },
   { value: SceneSortEnum.TITLE, label: "Title" },
   { value: SceneSortEnum.TRENDING, label: "Trending" },
   { value: SceneSortEnum.CREATED_AT, label: "Created At" },

--- a/frontend/src/components/sceneCard/SceneCard.tsx
+++ b/frontend/src/components/sceneCard/SceneCard.tsx
@@ -15,7 +15,7 @@ import { Icon } from "src/components/fragments";
 
 type Performance = Pick<
   Scene,
-  "id" | "title" | "images" | "duration" | "release_date"
+  "id" | "title" | "images" | "duration" | "code" | "release_date"
 > & {
   studio?: Pick<Studio, "id" | "name"> | null;
 };
@@ -39,6 +39,11 @@ const SceneCard: FC<{ scene: Performance }> = ({ scene }) => (
       <div className="d-flex">
         <Link className="text-truncate w-100" to={sceneHref(scene)}>
           <h6 className="text-truncate">{scene.title}</h6>
+        </Link>
+      </div>
+      <div className="d-flex">
+        <Link className="text-truncate w-100" to={sceneHref(scene)}>
+          <h6 className="text-truncate">{scene.code}</h6>
         </Link>
         <span className="text-muted">
           {scene.duration ? formatDuration(scene.duration) : ""}

--- a/frontend/src/components/sceneCard/SceneCard.tsx
+++ b/frontend/src/components/sceneCard/SceneCard.tsx
@@ -41,11 +41,11 @@ const SceneCard: FC<{ scene: Performance }> = ({ scene }) => (
           <h6 className="text-truncate">{scene.title}</h6>
         </Link>
       </div>
-      <div className="d-flex">
+      <div className="text-muted">
         <Link className="text-truncate w-100" to={sceneHref(scene)}>
-          <h6 className="text-truncate">{scene.code}</h6>
+          <strong>{scene.code}</strong>
         </Link>
-        <span className="text-muted">
+        <span className="text-muted float-end">
           {scene.duration ? formatDuration(scene.duration) : ""}
         </span>
       </div>

--- a/frontend/src/graphql/fragments/QuerySceneFragment.gql
+++ b/frontend/src/graphql/fragments/QuerySceneFragment.gql
@@ -5,6 +5,7 @@ fragment QuerySceneFragment on Scene {
   id
   release_date
   title
+  code
   duration
   urls {
     ...URLFragment

--- a/frontend/src/graphql/queries/ScenePairings.gql
+++ b/frontend/src/graphql/queries/ScenePairings.gql
@@ -41,6 +41,7 @@ query ScenePairings(
         title
         date
         duration
+        code
         release_date
         studio {
           id

--- a/frontend/src/graphql/queries/StudioPerformers.gql
+++ b/frontend/src/graphql/queries/StudioPerformers.gql
@@ -39,6 +39,7 @@ query StudioPerformers(
         title
         date
         duration
+        code
         release_date
         studio {
           id

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -180,6 +180,7 @@ type QueryScenesResultType {
 
 enum SceneSortEnum {
   TITLE
+  CODE
   DATE
   TRENDING
   CREATED_AT


### PR DESCRIPTION
Update docker-compose.yml and Dockerfile

* bump postgres to 15.8
* change the bktree repo from [fake-name/pg-spgist_hamming](https://github.com/fake-name/pg-spgist_hamming) to [evirma/pg_bktree](https://github.com/evirma/pg_bktree) and updated build instruction
* * The only difference between the two repo is the Makefile

* Change docker compose so now it mounts /traefik and then look for acme.json in /traefik
** avoid `Are you trying to mount a directory onto a file (or vice-versa)?` error

docker compose up should now run on Ubuntu 22.04 LTS + Docker without manual intervention