### PR TITLE
Add configurable edit update limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `voting_period` | `345600` | Time, in seconds, before a voting period is closed. |
 | `min_destructive_voting_period` | `172800` | Minimum time, in seconds, that needs to pass before a destructive edit can be immediately applied with sufficient positive votes. |
 | `vote_cron_interval` | `5m` | Time between runs to close edits whose voting periods have ended. |
+| `edit_update_limit` | `1` | Number of times an edit can be updated by the creator. |
 | `email_host` | (none) | Address of the SMTP server. Required to send emails for activation and recovery purposes. |
 | `email_port` | `25` | Port of the SMTP server. Only STARTTLS is supported. Direct TLS connections are not supported. |
 | `email_user` | (none) | Username for the SMTP server. Optional. |

--- a/frontend/src/components/editCard/EditCard.tsx
+++ b/frontend/src/components/editCard/EditCard.tsx
@@ -7,7 +7,7 @@ import { Icon, Tooltip } from "src/components/fragments";
 
 import { OperationEnum, EditFragment } from "src/graphql";
 
-import { formatDateTime, editHref, userHref } from "src/utils";
+import { formatDateTime, editHref, userHref, formatOrdinals } from "src/utils";
 import ModifyEdit from "./ModifyEdit";
 import EditComment from "./EditComment";
 import EditHeader from "./EditHeader";
@@ -78,6 +78,7 @@ const EditCardComponent: FC<Props> = ({ edit, showVotes = false }) => {
             <div>
               <b className="me-2">Updated:</b>
               <span>{formatDateTime(edit.updated)}</span>
+              <small className="text-muted align-text-top ms-2">{`${formatOrdinals(edit.update_count)} revision`}</small>
             </div>
           )}
         </div>

--- a/frontend/src/graphql/fragments/EditFragment.gql
+++ b/frontend/src/graphql/fragments/EditFragment.gql
@@ -17,6 +17,8 @@ fragment EditFragment on Edit {
   updated
   closed
   expires
+  update_count
+  updatable
   vote_count
   destructive
   comments {

--- a/frontend/src/graphql/queries/EditUpdate.gql
+++ b/frontend/src/graphql/queries/EditUpdate.gql
@@ -12,6 +12,8 @@ query EditUpdate($id: ID!) {
     applied
     created
     updated
+    updatable
+    update_count
     vote_count
     merge_sources {
       ... on Tag {

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -160,6 +160,8 @@ export type Edit = {
   /** Object being edited - null if creating a new object */
   target?: Maybe<EditTarget>;
   target_type: TargetTypeEnum;
+  updatable: Scalars["Boolean"]["output"];
+  update_count: Scalars["Int"]["output"];
   updated?: Maybe<Scalars["Time"]["output"]>;
   user?: Maybe<User>;
   /**  = Accepted - Rejected */
@@ -1960,6 +1962,8 @@ export type EditFragment = {
   updated?: string | null;
   closed?: string | null;
   expires?: string | null;
+  update_count: number;
+  updatable: boolean;
   vote_count: number;
   destructive: boolean;
   comments: Array<{
@@ -3290,6 +3294,8 @@ export type ApplyEditMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -4515,6 +4521,8 @@ export type PerformerEditMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -5550,6 +5558,8 @@ export type PerformerEditUpdateMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -6629,6 +6639,8 @@ export type SceneEditMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -7664,6 +7676,8 @@ export type SceneEditUpdateMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -8698,6 +8712,8 @@ export type StudioEditMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -9733,6 +9749,8 @@ export type StudioEditUpdateMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -10767,6 +10785,8 @@ export type TagEditMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -11802,6 +11822,8 @@ export type TagEditUpdateMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -12980,6 +13002,8 @@ export type VoteMutation = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -14274,6 +14298,8 @@ export type EditQuery = {
     updated?: string | null;
     closed?: string | null;
     expires?: string | null;
+    update_count: number;
+    updatable: boolean;
     vote_count: number;
     destructive: boolean;
     comments: Array<{
@@ -15305,6 +15331,8 @@ export type EditUpdateQuery = {
     applied: boolean;
     created: string;
     updated?: string | null;
+    updatable: boolean;
+    update_count: number;
     vote_count: number;
     merge_sources: Array<
       | { __typename: "Performer"; id: string }
@@ -15747,6 +15775,8 @@ export type EditsQuery = {
       updated?: string | null;
       closed?: string | null;
       expires?: string | null;
+      update_count: number;
+      updatable: boolean;
       vote_count: number;
       destructive: boolean;
       comments: Array<{
@@ -17098,6 +17128,8 @@ export type QueryExistingSceneQuery = {
       updated?: string | null;
       closed?: string | null;
       expires?: string | null;
+      update_count: number;
+      updatable: boolean;
       vote_count: number;
       destructive: boolean;
       comments: Array<{
@@ -19372,6 +19404,8 @@ export const EditFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -22152,6 +22186,8 @@ export const ApplyEditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -24633,6 +24669,8 @@ export const PerformerEditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -26242,6 +26280,8 @@ export const PerformerEditUpdateDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -28037,6 +28077,8 @@ export const SceneEditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -29643,6 +29685,8 @@ export const SceneEditUpdateDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -31236,6 +31280,8 @@ export const StudioEditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -32842,6 +32888,8 @@ export const StudioEditUpdateDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -34435,6 +34483,8 @@ export const TagEditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -36041,6 +36091,8 @@ export const TagEditUpdateDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -38310,6 +38362,8 @@ export const VoteDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -40755,6 +40809,8 @@ export const EditDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -41910,6 +41966,11 @@ export const EditUpdateDocument = {
                 { kind: "Field", name: { kind: "Name", value: "applied" } },
                 { kind: "Field", name: { kind: "Name", value: "created" } },
                 { kind: "Field", name: { kind: "Name", value: "updated" } },
+                { kind: "Field", name: { kind: "Name", value: "updatable" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "update_count" },
+                },
                 { kind: "Field", name: { kind: "Name", value: "vote_count" } },
                 {
                   kind: "Field",
@@ -43389,6 +43450,8 @@ export const EditsDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {
@@ -45862,6 +45925,8 @@ export const QueryExistingSceneDocument = {
           { kind: "Field", name: { kind: "Name", value: "updated" } },
           { kind: "Field", name: { kind: "Name", value: "closed" } },
           { kind: "Field", name: { kind: "Name", value: "expires" } },
+          { kind: "Field", name: { kind: "Name", value: "update_count" } },
+          { kind: "Field", name: { kind: "Name", value: "updatable" } },
           { kind: "Field", name: { kind: "Name", value: "vote_count" } },
           { kind: "Field", name: { kind: "Name", value: "destructive" } },
           {

--- a/frontend/src/pages/edits/Edit.tsx
+++ b/frontend/src/pages/edits/Edit.tsx
@@ -81,15 +81,13 @@ const EditComponent: FC = () => {
   const buttons = (isAdmin(auth.user) || auth.user?.id === edit.user?.id) &&
     edit.status === VoteStatusEnum.PENDING && (
       <div className="d-flex justify-content-end">
-        {auth.user?.id === edit.user?.id &&
-          edit.operation !== OperationEnum.DESTROY &&
-          !edit.updated && (
-            <Link to={createHref(ROUTE_EDIT_UPDATE, edit)} className="me-2">
-              <Button variant="primary" disabled={mutating}>
-                Update Edit
-              </Button>
-            </Link>
-          )}
+        {edit.updatable && (
+          <Link to={createHref(ROUTE_EDIT_UPDATE, edit)} className="me-2">
+            <Button variant="primary" disabled={mutating}>
+              Update Edit
+            </Button>
+          </Link>
+        )}
         <Button
           variant="danger"
           className="me-2"

--- a/frontend/src/pages/edits/EditUpdate.tsx
+++ b/frontend/src/pages/edits/EditUpdate.tsx
@@ -1,8 +1,7 @@
-import { FC, useContext } from "react";
+import { FC } from "react";
 import { useParams } from "react-router-dom";
 
-import { useEditUpdate, TargetTypeEnum, OperationEnum } from "src/graphql";
-import AuthContext from "src/AuthContext";
+import { useEditUpdate, TargetTypeEnum } from "src/graphql";
 import { ErrorMessage, LoadingIndicator } from "src/components/fragments";
 import { SceneEditUpdate } from "src/pages/scenes/SceneEditUpdate";
 import { PerformerEditUpdate } from "src/pages/performers/PerformerEditUpdate";
@@ -10,7 +9,6 @@ import { TagEditUpdate } from "src/pages/tags/TagEditUpdate";
 import { StudioEditUpdate } from "src/pages/studios/StudioEditUpdate";
 
 const EditUpdateComponent: FC = () => {
-  const auth = useContext(AuthContext);
   const { id } = useParams();
   const { data, loading } = useEditUpdate({ id: id ?? "" }, !id);
 
@@ -18,12 +16,7 @@ const EditUpdateComponent: FC = () => {
 
   const edit = data?.findEdit;
   if (!edit) return <ErrorMessage error="Failed to load edit." />;
-  if (edit.user?.id != auth.user?.id)
-    return <ErrorMessage error="Only the creator can update edits." />;
-  if (edit.updated)
-    return <ErrorMessage error="Edits can only be updated once." />;
-  if (edit.operation === OperationEnum.DESTROY)
-    return <ErrorMessage error="Destroy edits can't be edited." />;
+  if (!edit.updatable) return <ErrorMessage error="Unable to update edit" />;
 
   switch (edit.target_type) {
     case TargetTypeEnum.SCENE:

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from "./enum";
 export * from "./user";
 export * from "./diff";
 export * from "./data";
+export * from "./intl";

--- a/frontend/src/utils/intl.ts
+++ b/frontend/src/utils/intl.ts
@@ -1,0 +1,14 @@
+const enOrdinalRules = new Intl.PluralRules("en-US", { type: "ordinal" });
+
+const suffixes = new Map([
+  ["one", "st"],
+  ["two", "nd"],
+  ["few", "rd"],
+  ["other", "th"],
+]);
+
+export const formatOrdinals = (num: number) => {
+  const rule = enOrdinalRules.select(num);
+  const suffix = suffixes.get(rule);
+  return `${num}${suffix}`;
+};

--- a/graphql/schema/types/edit.graphql
+++ b/graphql/schema/types/edit.graphql
@@ -72,6 +72,8 @@ type Edit {
     destructive: Boolean!
     status: VoteStatusEnum!
     applied: Boolean!
+    update_count: Int!
+    updatable: Boolean!
     created: Time!
     updated: Time
     closed: Time

--- a/pkg/api/resolver_model_edit.go
+++ b/pkg/api/resolver_model_edit.go
@@ -361,3 +361,21 @@ func (r *editResolver) Options(ctx context.Context, obj *models.Edit) (*models.P
 func (r *editResolver) Destructive(ctx context.Context, obj *models.Edit) (bool, error) {
 	return obj.IsDestructive(), nil
 }
+
+func (r *editResolver) Updatable(ctx context.Context, obj *models.Edit) (bool, error) {
+	user := getCurrentUser(ctx)
+
+	if user.ID != obj.UserID.UUID {
+		return false, nil
+	}
+
+	if obj.UpdateCount >= config.GetEditUpdateLimit() {
+		return false, nil
+	}
+
+	if obj.Operation == models.OperationEnumDestroy.String() {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var appSchemaVersion uint = 38
+var appSchemaVersion uint = 39
 
 var databaseProviders map[string]databaseProvider
 

--- a/pkg/database/migrations/postgres/39_edits_updates.up.sql
+++ b/pkg/database/migrations/postgres/39_edits_updates.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "edits"
+ADD COLUMN "update_count" integer NOT NULL DEFAULT 0;
+

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -59,6 +59,8 @@ type config struct {
 	MinDestructiveVotingPeriod int `mapstructure:"min_destructive_voting_period"`
 	// Interval between checks for completed voting periods
 	VoteCronInterval string `mapstructure:"vote_cron_interval"`
+	// Number of times an edit can be updated by the creator
+	EditUpdateLimit int `mapstructure:"edit_update_limit"`
 
 	// Email settings
 	EmailHost string `mapstructure:"email_host"`
@@ -120,6 +122,7 @@ var C = &config{
 	VotingPeriod:               345600,
 	MinDestructiveVotingPeriod: 172800,
 	DraftTimeLimit:             86400,
+	EditUpdateLimit:            1,
 }
 
 func GetDatabasePath() string {
@@ -358,6 +361,10 @@ func GetMinDestructiveVotingPeriod() int {
 
 func GetVoteCronInterval() string {
 	return C.VoteCronInterval
+}
+
+func GetEditUpdateLimit() int {
+	return C.EditUpdateLimit
 }
 
 func GetTitle() string {

--- a/pkg/manager/edit/edit.go
+++ b/pkg/manager/edit/edit.go
@@ -50,9 +50,14 @@ func (m *mutator) CreateEdit() (*models.Edit, error) {
 }
 
 func (m *mutator) UpdateEdit() (*models.Edit, error) {
+	m.edit.UpdateCount++
 	m.edit.UpdatedAt = sql.NullTime{Time: time.Now(), Valid: true}
 	updated, err := m.fac.Edit().Update(*m.edit)
 	if err != nil {
+		return nil, err
+	}
+
+	if err = m.fac.Edit().ResetVotes(m.edit.ID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/models/edit.go
+++ b/pkg/models/edit.go
@@ -29,4 +29,5 @@ type EditRepo interface {
 	FindCompletedEdits(int, int, int) ([]*Edit, error)
 	FindPendingSceneCreation(input QueryExistingSceneInput) ([]*Edit, error)
 	CancelUserEdits(userID uuid.UUID) error
+	ResetVotes(id uuid.UUID) error
 }

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -116,6 +116,8 @@ type ComplexityRoot struct {
 		Status       func(childComplexity int) int
 		Target       func(childComplexity int) int
 		TargetType   func(childComplexity int) int
+		Updatable    func(childComplexity int) int
+		UpdateCount  func(childComplexity int) int
 		Updated      func(childComplexity int) int
 		User         func(childComplexity int) int
 		VoteCount    func(childComplexity int) int
@@ -622,6 +624,7 @@ type EditResolver interface {
 	Destructive(ctx context.Context, obj *Edit) (bool, error)
 	Status(ctx context.Context, obj *Edit) (VoteStatusEnum, error)
 
+	Updatable(ctx context.Context, obj *Edit) (bool, error)
 	Created(ctx context.Context, obj *Edit) (*time.Time, error)
 	Updated(ctx context.Context, obj *Edit) (*time.Time, error)
 	Closed(ctx context.Context, obj *Edit) (*time.Time, error)
@@ -1121,6 +1124,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Edit.TargetType(childComplexity), true
+
+	case "Edit.updatable":
+		if e.complexity.Edit.Updatable == nil {
+			break
+		}
+
+		return e.complexity.Edit.Updatable(childComplexity), true
+
+	case "Edit.update_count":
+		if e.complexity.Edit.UpdateCount == nil {
+			break
+		}
+
+		return e.complexity.Edit.UpdateCount(childComplexity), true
 
 	case "Edit.updated":
 		if e.complexity.Edit.Updated == nil {
@@ -4361,6 +4378,8 @@ type Edit {
     destructive: Boolean!
     status: VoteStatusEnum!
     applied: Boolean!
+    update_count: Int!
+    updatable: Boolean!
     created: Time!
     updated: Time
     closed: Time
@@ -10126,6 +10145,94 @@ func (ec *executionContext) fieldContext_Edit_applied(_ context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Edit_update_count(ctx context.Context, field graphql.CollectedField, obj *Edit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Edit_update_count(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdateCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Edit_update_count(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Edit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Edit_updatable(ctx context.Context, field graphql.CollectedField, obj *Edit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Edit_updatable(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Edit().Updatable(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Edit_updatable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Edit",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Edit_created(ctx context.Context, field graphql.CollectedField, obj *Edit) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Edit_created(ctx, field)
 	if err != nil {
@@ -14669,6 +14776,10 @@ func (ec *executionContext) fieldContext_Mutation_sceneEdit(ctx context.Context,
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -14793,6 +14904,10 @@ func (ec *executionContext) fieldContext_Mutation_performerEdit(ctx context.Cont
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -14917,6 +15032,10 @@ func (ec *executionContext) fieldContext_Mutation_studioEdit(ctx context.Context
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15041,6 +15160,10 @@ func (ec *executionContext) fieldContext_Mutation_tagEdit(ctx context.Context, f
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15165,6 +15288,10 @@ func (ec *executionContext) fieldContext_Mutation_sceneEditUpdate(ctx context.Co
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15289,6 +15416,10 @@ func (ec *executionContext) fieldContext_Mutation_performerEditUpdate(ctx contex
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15413,6 +15544,10 @@ func (ec *executionContext) fieldContext_Mutation_studioEditUpdate(ctx context.C
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15537,6 +15672,10 @@ func (ec *executionContext) fieldContext_Mutation_tagEditUpdate(ctx context.Cont
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15661,6 +15800,10 @@ func (ec *executionContext) fieldContext_Mutation_editVote(ctx context.Context, 
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15785,6 +15928,10 @@ func (ec *executionContext) fieldContext_Mutation_editComment(ctx context.Contex
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -15909,6 +16056,10 @@ func (ec *executionContext) fieldContext_Mutation_applyEdit(ctx context.Context,
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -16033,6 +16184,10 @@ func (ec *executionContext) fieldContext_Mutation_cancelEdit(ctx context.Context
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -17763,6 +17918,10 @@ func (ec *executionContext) fieldContext_Performer_edits(_ context.Context, fiel
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -22586,6 +22745,10 @@ func (ec *executionContext) fieldContext_Query_findEdit(ctx context.Context, fie
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -23983,6 +24146,10 @@ func (ec *executionContext) fieldContext_QueryEditsResultType_edits(_ context.Co
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -24069,6 +24236,10 @@ func (ec *executionContext) fieldContext_QueryExistingSceneResult_edits(_ contex
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -25794,6 +25965,10 @@ func (ec *executionContext) fieldContext_Scene_edits(_ context.Context, field gr
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -29627,6 +29802,10 @@ func (ec *executionContext) fieldContext_Tag_edits(_ context.Context, field grap
 				return ec.fieldContext_Edit_status(ctx, field)
 			case "applied":
 				return ec.fieldContext_Edit_applied(ctx, field)
+			case "update_count":
+				return ec.fieldContext_Edit_update_count(ctx, field)
+			case "updatable":
+				return ec.fieldContext_Edit_updatable(ctx, field)
 			case "created":
 				return ec.fieldContext_Edit_created(ctx, field)
 			case "updated":
@@ -38799,6 +38978,47 @@ func (ec *executionContext) _Edit(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "update_count":
+			out.Values[i] = ec._Edit_update_count(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatable":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Edit_updatable(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "created":
 			field := field
 

--- a/pkg/models/model_edit.go
+++ b/pkg/models/model_edit.go
@@ -12,18 +12,19 @@ import (
 )
 
 type Edit struct {
-	ID         uuid.UUID      `db:"id" json:"id"`
-	UserID     uuid.NullUUID  `db:"user_id" json:"user_id"`
-	TargetType string         `db:"target_type" json:"target_type"`
-	Operation  string         `db:"operation" json:"operation"`
-	VoteCount  int            `db:"votes" json:"votes"`
-	Status     string         `db:"status" json:"status"`
-	Applied    bool           `db:"applied" json:"applied"`
-	Data       types.JSONText `db:"data" json:"data"`
-	Bot        bool           `db:"bot" json:"bot"`
-	CreatedAt  time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt  sql.NullTime   `db:"updated_at" json:"updated_at"`
-	ClosedAt   sql.NullTime   `db:"closed_at" json:"closed_at"`
+	ID          uuid.UUID      `db:"id" json:"id"`
+	UserID      uuid.NullUUID  `db:"user_id" json:"user_id"`
+	TargetType  string         `db:"target_type" json:"target_type"`
+	Operation   string         `db:"operation" json:"operation"`
+	VoteCount   int            `db:"votes" json:"votes"`
+	Status      string         `db:"status" json:"status"`
+	Applied     bool           `db:"applied" json:"applied"`
+	Data        types.JSONText `db:"data" json:"data"`
+	Bot         bool           `db:"bot" json:"bot"`
+	CreatedAt   time.Time      `db:"created_at" json:"created_at"`
+	UpdateCount int            `db:"update_count" json:"update_count"`
+	UpdatedAt   sql.NullTime   `db:"updated_at" json:"updated_at"`
+	ClosedAt    sql.NullTime   `db:"closed_at" json:"closed_at"`
 }
 
 type EditComment struct {

--- a/pkg/sqlx/querybuilder_edit.go
+++ b/pkg/sqlx/querybuilder_edit.go
@@ -472,3 +472,12 @@ func (qb *editQueryBuilder) CancelUserEdits(userID uuid.UUID) error {
 	err := qb.dbi.RawQuery(editDBTable, query, args, nil)
 	return err
 }
+
+func (qb *editQueryBuilder) ResetVotes(id uuid.UUID) error {
+	args := []any{id}
+	query := `
+	  UPDATE edit_votes
+		SET vote = 'ABSTAIN'
+		WHERE edit_id = ?`
+	return qb.dbi.RawQuery(editDBTable, query, args, nil)
+}


### PR DESCRIPTION
Alternative approach to https://github.com/stashapp/stash-box/pull/597 

Logs the number of times an edit has been updated, and adds a configurable limit. Default is 1 time, but something like 3 is probably sufficient.

Also adds vote resetting whenever an edit is updated. The expiration was already reset on update, so nothing changes on that part.

Resolves #593 