### PR TITLE
Github Actions: Disable apt caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,8 @@ jobs:
 
     steps:
 
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libvips-dev libhdf5-dev
-        version: 1.0
+    - name: Install vips
+      run: sudo apt install -y libvips-dev
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,10 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libvips-dev
-          version: 1.0
+      - name: Install vips
+        run: sudo apt install -y libvips-dev
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The cache action seems to be buggy, and it doesn't save enough time to warrant figuring out why.