### PR TITLE
Add ability to sort performers by updated_at

### DIFF
--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -36,6 +36,7 @@ const sortOptions = [
   { value: PerformerSortEnum.DEBUT, label: "Scene Debut" },
   { value: PerformerSortEnum.LAST_SCENE, label: "Latest Scene" },
   { value: PerformerSortEnum.CREATED_AT, label: "Created At" },
+  { value: PerformerSortEnum.UPDATED_AT, label: "Updated At" },
 ];
 
 const PerformersComponent: FC = () => {


### PR DESCRIPTION
Resolves #830 

Quick one line change since the backend infrastructure is already there. Not sure how performant the underlying query will be on a big stashbox, or if it needs an index, but it looks like the other sort options don't currently have indexes other than `name`. 