### PR TITLE
More search page thumbnail fixes

### DIFF
--- a/frontend/src/pages/search/Search.tsx
+++ b/frontend/src/pages/search/Search.tsx
@@ -49,6 +49,7 @@ const PerformerCard: FC<{ performer: Performer }> = ({ performer }) => (
         orientation="portrait"
         image={getImage(performer.images, "portrait")}
         className={CLASSNAME_PERFORMER_IMAGE}
+        size={150}
       />
       <div className="ms-3">
         <h4>
@@ -91,10 +92,10 @@ const PerformerCard: FC<{ performer: Performer }> = ({ performer }) => (
 const SceneCard: FC<{ scene: Scene }> = ({ scene }) => (
   <Link to={sceneHref(scene)} className={CLASSNAME_SCENE}>
     <Card>
-      <img
-        src={getImage(scene.images, "landscape")}
+      <Thumbnail
+        image={getImage(scene.images, "landscape")}
         className={CLASSNAME_SCENE_IMAGE}
-        alt=""
+        size={200}
       />
       <div className="ms-3 w-100">
         <h5>

--- a/frontend/src/pages/search/search.scss
+++ b/frontend/src/pages/search/search.scss
@@ -27,7 +27,7 @@
 
   &-scene {
     &-image {
-      max-width: 12.44rem;
+      width: 12.44rem;
     }
   }
 

--- a/frontend/src/pages/search/search.scss
+++ b/frontend/src/pages/search/search.scss
@@ -22,17 +22,12 @@
   &-performer {
     &-image {
       max-width: 4.67rem;
-
-      .fa-icon {
-        margin-right: 0 !important;
-      }
     }
   }
 
   &-scene {
     &-image {
-      height: 7rem;
-      width: 12.44rem;
+      max-width: 12.44rem;
     }
   }
 
@@ -63,6 +58,10 @@
 
       &[src=""] {
         visibility: hidden;
+      }
+
+      .fa-icon {
+        margin-right: 0 !important;
       }
     }
   }


### PR DESCRIPTION
- Use `Thumbnail` for scenes too.
- Add sizes, currently uses the full-size images.
	The sizes I chose could be wrong, I just used smaller sizes relative to `SceneCard` and `PerformerCard`, feel free to correct if needed.
	In any case, I believe `srcSet` is not configured correctly ([see blue note on MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset)), **seems** to use the larger source by default.
- Correct style for scenes with no image.
	Minor and not fixed: The removal of the specific `height` made the cards' minimum height determined by the image height.
	This is most noticeable on performer search result cards.

<details>
<summary>Screenshots</summary>

### Before
```html
<img alt="" class="SearchPage-performer-image" src="http://localhost:9998/images/4340ffe1-02af-49d0-a2c6-c22624a55087" srcset="">
<img src="http://localhost:9998/images/ac689cf2-13cb-49cb-8435-f82f560c3797" class="SearchPage-scene-image" alt="">
```
![image](https://github.com/user-attachments/assets/88eebadd-f4b6-404f-9057-bf0de2475277)

### After
```html
<img alt="" class="SearchPage-performer-image" src="http://localhost:9998/images/4340ffe1-02af-49d0-a2c6-c22624a55087?size=150" srcset="http://localhost:9998/images/4340ffe1-02af-49d0-a2c6-c22624a55087?size=300 300w">
<img alt="" class="SearchPage-scene-image" src="http://localhost:9998/images/ac689cf2-13cb-49cb-8435-f82f560c3797?size=200" srcset="http://localhost:9998/images/ac689cf2-13cb-49cb-8435-f82f560c3797?size=400 400w">
```
![image](https://github.com/user-attachments/assets/6198fef3-8552-463f-a5f0-5eaf1511ea6d)


</details>