### PR TITLE
Fix missing orientation in performer card `Thumbnail`

### DIFF
--- a/frontend/src/components/performerCard/PerformerCard.tsx
+++ b/frontend/src/components/performerCard/PerformerCard.tsx
@@ -35,6 +35,7 @@ const PerformerCard: FC<PerformerCardProps> = ({ className, performer }) => (
           image={getImage(performer.images, "portrait")}
           alt={performer.name}
           size={350}
+          orientation="portrait"
         />
         <FavoriteStar
           entity={performer}


### PR DESCRIPTION
Noticed the issue on the performer merge form.
Left is before, right is after.

![image](https://github.com/user-attachments/assets/a8e0f87a-1595-49a4-ba46-fae1f25a9198)
