### PR TITLE
Fix clearing fields in merge edits

### DIFF
--- a/pkg/manager/edit/performer.go
+++ b/pkg/manager/edit/performer.go
@@ -123,7 +123,8 @@ func (m *PerformerEditProcessor) mergeEdit(input models.PerformerEditInput, inpu
 	}
 
 	// perform a diff against the input and the current object
-	performerEdit, err := input.Details.PerformerEditFromMerge(*performer, mergeSources, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	performerEdit, err := input.Details.PerformerEditFromMerge(*performer, mergeSources, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/scene.go
+++ b/pkg/manager/edit/scene.go
@@ -277,7 +277,8 @@ func (m *SceneEditProcessor) mergeEdit(input models.SceneEditInput, inputArgs ut
 	}
 
 	// perform a diff against the input and the current object
-	sceneEdit, err := input.Details.SceneEditFromMerge(*scene, mergeSources, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	sceneEdit, err := input.Details.SceneEditFromMerge(*scene, mergeSources, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/studio.go
+++ b/pkg/manager/edit/studio.go
@@ -154,7 +154,8 @@ func (m *StudioEditProcessor) mergeEdit(input models.StudioEditInput, inputArgs 
 	}
 
 	// perform a diff against the input and the current object
-	studioEdit, err := input.Details.StudioEditFromMerge(*studio, mergeSources, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	studioEdit, err := input.Details.StudioEditFromMerge(*studio, mergeSources, detailArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/manager/edit/tag.go
+++ b/pkg/manager/edit/tag.go
@@ -115,7 +115,8 @@ func (m *TagEditProcessor) mergeEdit(input models.TagEditInput, inputArgs utils.
 	}
 
 	// perform a diff against the input and the current object
-	tagEdit := input.Details.TagEditFromMerge(*tag, mergeSources, inputArgs)
+	detailArgs := inputArgs.Field("details")
+	tagEdit := input.Details.TagEditFromMerge(*tag, mergeSources, detailArgs)
 
 	aliases, err := tqb.GetAliases(tagID)
 


### PR DESCRIPTION
Fixes #903, by applying the same fix to `MERGE` edits, as #677 did for `MODIFY` edits.

- [x] Tested only on performers merges, trying to remove disambiguation from the merge target.
- [ ] ~~Need to look into adding tests, like in #677?~~
		it seems I don't have any patience to do this