### PR TITLE
trim `PerformerQueryInput` to filters that are currently implemented

### DIFF
--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1088,25 +1088,12 @@ export type PerformerEditOptionsInput = {
 
 export type PerformerQueryInput = {
   age?: InputMaybe<IntCriterionInput>;
-  /** Search aliases only - assumes like query unless quoted */
-  alias?: InputMaybe<Scalars["String"]["input"]>;
-  band_size?: InputMaybe<IntCriterionInput>;
   birth_year?: InputMaybe<IntCriterionInput>;
-  birthdate?: InputMaybe<DateCriterionInput>;
-  breast_type?: InputMaybe<BreastTypeCriterionInput>;
-  career_end_year?: InputMaybe<IntCriterionInput>;
-  career_start_year?: InputMaybe<IntCriterionInput>;
   country?: InputMaybe<StringCriterionInput>;
-  cup_size?: InputMaybe<StringCriterionInput>;
-  deathdate?: InputMaybe<DateCriterionInput>;
   direction?: SortDirectionEnum;
   disambiguation?: InputMaybe<StringCriterionInput>;
   ethnicity?: InputMaybe<EthnicityFilterEnum>;
-  eye_color?: InputMaybe<EyeColorCriterionInput>;
   gender?: InputMaybe<GenderFilterEnum>;
-  hair_color?: InputMaybe<HairColorCriterionInput>;
-  height?: InputMaybe<IntCriterionInput>;
-  hip_size?: InputMaybe<IntCriterionInput>;
   /** Filter by performerfavorite status for the current user */
   is_favorite?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Searches name only - assumes like query unless quoted */
@@ -1117,14 +1104,11 @@ export type PerformerQueryInput = {
   per_page?: Scalars["Int"]["input"];
   /** Filter by a performer they have performed in scenes with */
   performed_with?: InputMaybe<Scalars["ID"]["input"]>;
-  piercings?: InputMaybe<BodyModificationCriterionInput>;
   sort?: PerformerSortEnum;
   /** Filter by a studio */
   studio_id?: InputMaybe<Scalars["ID"]["input"]>;
-  tattoos?: InputMaybe<BodyModificationCriterionInput>;
   /** Filter to search urls - assumes like query unless quoted */
   url?: InputMaybe<Scalars["String"]["input"]>;
-  waist_size?: InputMaybe<IntCriterionInput>;
 };
 
 export type PerformerScenesInput = {

--- a/graphql/schema/types/performer.graphql
+++ b/graphql/schema/types/performer.graphql
@@ -329,8 +329,8 @@ input PerformerQueryInput {
   """Searches name only - assumes like query unless quoted"""
   name: String
 
-  """Search aliases only - assumes like query unless quoted"""
-  alias: String
+  # """Search aliases only - assumes like query unless quoted"""
+  # alias: String
 
   disambiguation: StringCriterionInput
 
@@ -339,28 +339,29 @@ input PerformerQueryInput {
   """Filter to search urls - assumes like query unless quoted"""
   url: String
 
-  birthdate: DateCriterionInput
-  deathdate: DateCriterionInput
+  # birthdate: DateCriterionInput
+  # deathdate: DateCriterionInput
   birth_year: IntCriterionInput
   age: IntCriterionInput
 
   ethnicity: EthnicityFilterEnum
   country: StringCriterionInput
-  eye_color: EyeColorCriterionInput
-  hair_color: HairColorCriterionInput
-  height: IntCriterionInput
+  # eye_color: EyeColorCriterionInput
+  # hair_color: HairColorCriterionInput
+  # height: IntCriterionInput
 
-  cup_size: StringCriterionInput
-  band_size: IntCriterionInput
-  waist_size: IntCriterionInput
-  hip_size: IntCriterionInput
+  # cup_size: StringCriterionInput
+  # band_size: IntCriterionInput
+  # waist_size: IntCriterionInput
+  # hip_size: IntCriterionInput
 
-  breast_type: BreastTypeCriterionInput
+  # breast_type: BreastTypeCriterionInput
 
-  career_start_year: IntCriterionInput
-  career_end_year: IntCriterionInput
-  tattoos: BodyModificationCriterionInput
-  piercings: BodyModificationCriterionInput
+  # career_start_year: IntCriterionInput
+  # career_end_year: IntCriterionInput
+  # tattoos: BodyModificationCriterionInput
+  # piercings: BodyModificationCriterionInput
+
   """Filter by performerfavorite status for the current user"""
   is_favorite: Boolean
 

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -5370,8 +5370,8 @@ input PerformerQueryInput {
   """Searches name only - assumes like query unless quoted"""
   name: String
 
-  """Search aliases only - assumes like query unless quoted"""
-  alias: String
+  # """Search aliases only - assumes like query unless quoted"""
+  # alias: String
 
   disambiguation: StringCriterionInput
 
@@ -5380,28 +5380,29 @@ input PerformerQueryInput {
   """Filter to search urls - assumes like query unless quoted"""
   url: String
 
-  birthdate: DateCriterionInput
-  deathdate: DateCriterionInput
+  # birthdate: DateCriterionInput
+  # deathdate: DateCriterionInput
   birth_year: IntCriterionInput
   age: IntCriterionInput
 
   ethnicity: EthnicityFilterEnum
   country: StringCriterionInput
-  eye_color: EyeColorCriterionInput
-  hair_color: HairColorCriterionInput
-  height: IntCriterionInput
+  # eye_color: EyeColorCriterionInput
+  # hair_color: HairColorCriterionInput
+  # height: IntCriterionInput
 
-  cup_size: StringCriterionInput
-  band_size: IntCriterionInput
-  waist_size: IntCriterionInput
-  hip_size: IntCriterionInput
+  # cup_size: StringCriterionInput
+  # band_size: IntCriterionInput
+  # waist_size: IntCriterionInput
+  # hip_size: IntCriterionInput
 
-  breast_type: BreastTypeCriterionInput
+  # breast_type: BreastTypeCriterionInput
 
-  career_start_year: IntCriterionInput
-  career_end_year: IntCriterionInput
-  tattoos: BodyModificationCriterionInput
-  piercings: BodyModificationCriterionInput
+  # career_start_year: IntCriterionInput
+  # career_end_year: IntCriterionInput
+  # tattoos: BodyModificationCriterionInput
+  # piercings: BodyModificationCriterionInput
+
   """Filter by performerfavorite status for the current user"""
   is_favorite: Boolean
 
@@ -38813,7 +38814,7 @@ func (ec *executionContext) unmarshalInputPerformerQueryInput(ctx context.Contex
 		asMap["sort"] = "CREATED_AT"
 	}
 
-	fieldsInOrder := [...]string{"names", "name", "alias", "disambiguation", "gender", "url", "birthdate", "deathdate", "birth_year", "age", "ethnicity", "country", "eye_color", "hair_color", "height", "cup_size", "band_size", "waist_size", "hip_size", "breast_type", "career_start_year", "career_end_year", "tattoos", "piercings", "is_favorite", "performed_with", "studio_id", "page", "per_page", "direction", "sort"}
+	fieldsInOrder := [...]string{"names", "name", "disambiguation", "gender", "url", "birth_year", "age", "ethnicity", "country", "is_favorite", "performed_with", "studio_id", "page", "per_page", "direction", "sort"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -38834,13 +38835,6 @@ func (ec *executionContext) unmarshalInputPerformerQueryInput(ctx context.Contex
 				return it, err
 			}
 			it.Name = data
-		case "alias":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("alias"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Alias = data
 		case "disambiguation":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disambiguation"))
 			data, err := ec.unmarshalOStringCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐStringCriterionInput(ctx, v)
@@ -38862,20 +38856,6 @@ func (ec *executionContext) unmarshalInputPerformerQueryInput(ctx context.Contex
 				return it, err
 			}
 			it.URL = data
-		case "birthdate":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("birthdate"))
-			data, err := ec.unmarshalODateCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐDateCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Birthdate = data
-		case "deathdate":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deathdate"))
-			data, err := ec.unmarshalODateCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐDateCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Deathdate = data
 		case "birth_year":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("birth_year"))
 			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
@@ -38904,90 +38884,6 @@ func (ec *executionContext) unmarshalInputPerformerQueryInput(ctx context.Contex
 				return it, err
 			}
 			it.Country = data
-		case "eye_color":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("eye_color"))
-			data, err := ec.unmarshalOEyeColorCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐEyeColorCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.EyeColor = data
-		case "hair_color":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hair_color"))
-			data, err := ec.unmarshalOHairColorCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐHairColorCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.HairColor = data
-		case "height":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("height"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Height = data
-		case "cup_size":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cup_size"))
-			data, err := ec.unmarshalOStringCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐStringCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CupSize = data
-		case "band_size":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("band_size"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.BandSize = data
-		case "waist_size":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("waist_size"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.WaistSize = data
-		case "hip_size":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hip_size"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.HipSize = data
-		case "breast_type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("breast_type"))
-			data, err := ec.unmarshalOBreastTypeCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBreastTypeCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.BreastType = data
-		case "career_start_year":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("career_start_year"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CareerStartYear = data
-		case "career_end_year":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("career_end_year"))
-			data, err := ec.unmarshalOIntCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐIntCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CareerEndYear = data
-		case "tattoos":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tattoos"))
-			data, err := ec.unmarshalOBodyModificationCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBodyModificationCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Tattoos = data
-		case "piercings":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("piercings"))
-			data, err := ec.unmarshalOBodyModificationCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBodyModificationCriterionInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Piercings = data
 		case "is_favorite":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("is_favorite"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -54117,14 +54013,6 @@ func (ec *executionContext) marshalOBodyModification2ᚕᚖgithubᚗcomᚋstasha
 	return ret
 }
 
-func (ec *executionContext) unmarshalOBodyModificationCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBodyModificationCriterionInput(ctx context.Context, v interface{}) (*BodyModificationCriterionInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputBodyModificationCriterionInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) unmarshalOBodyModificationInput2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBodyModificationᚄ(ctx context.Context, v interface{}) ([]*BodyModification, error) {
 	if v == nil {
 		return nil, nil
@@ -54169,14 +54057,6 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	}
 	res := graphql.MarshalBoolean(*v)
 	return res
-}
-
-func (ec *executionContext) unmarshalOBreastTypeCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBreastTypeCriterionInput(ctx context.Context, v interface{}) (*BreastTypeCriterionInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputBreastTypeCriterionInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOBreastTypeEnum2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐBreastTypeEnum(ctx context.Context, v interface{}) (*BreastTypeEnum, error) {
@@ -54289,14 +54169,6 @@ func (ec *executionContext) marshalOEthnicityFilterEnum2ᚖgithubᚗcomᚋstasha
 		return graphql.Null
 	}
 	return v
-}
-
-func (ec *executionContext) unmarshalOEyeColorCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐEyeColorCriterionInput(ctx context.Context, v interface{}) (*EyeColorCriterionInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputEyeColorCriterionInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOEyeColorEnum2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐEyeColorEnum(ctx context.Context, v interface{}) (*EyeColorEnum, error) {
@@ -54478,14 +54350,6 @@ func (ec *executionContext) unmarshalOGenerateInviteCodeInput2ᚖgithubᚗcomᚋ
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputGenerateInviteCodeInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalOHairColorCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋpkgᚋmodelsᚐHairColorCriterionInput(ctx context.Context, v interface{}) (*HairColorCriterionInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputHairColorCriterionInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/pkg/models/generated_models.go
+++ b/pkg/models/generated_models.go
@@ -427,31 +427,15 @@ type PerformerQueryInput struct {
 	// Searches name and disambiguation - assumes like query unless quoted
 	Names *string `json:"names,omitempty"`
 	// Searches name only - assumes like query unless quoted
-	Name *string `json:"name,omitempty"`
-	// Search aliases only - assumes like query unless quoted
-	Alias          *string               `json:"alias,omitempty"`
+	Name           *string               `json:"name,omitempty"`
 	Disambiguation *StringCriterionInput `json:"disambiguation,omitempty"`
 	Gender         *GenderFilterEnum     `json:"gender,omitempty"`
 	// Filter to search urls - assumes like query unless quoted
-	URL             *string                         `json:"url,omitempty"`
-	Birthdate       *DateCriterionInput             `json:"birthdate,omitempty"`
-	Deathdate       *DateCriterionInput             `json:"deathdate,omitempty"`
-	BirthYear       *IntCriterionInput              `json:"birth_year,omitempty"`
-	Age             *IntCriterionInput              `json:"age,omitempty"`
-	Ethnicity       *EthnicityFilterEnum            `json:"ethnicity,omitempty"`
-	Country         *StringCriterionInput           `json:"country,omitempty"`
-	EyeColor        *EyeColorCriterionInput         `json:"eye_color,omitempty"`
-	HairColor       *HairColorCriterionInput        `json:"hair_color,omitempty"`
-	Height          *IntCriterionInput              `json:"height,omitempty"`
-	CupSize         *StringCriterionInput           `json:"cup_size,omitempty"`
-	BandSize        *IntCriterionInput              `json:"band_size,omitempty"`
-	WaistSize       *IntCriterionInput              `json:"waist_size,omitempty"`
-	HipSize         *IntCriterionInput              `json:"hip_size,omitempty"`
-	BreastType      *BreastTypeCriterionInput       `json:"breast_type,omitempty"`
-	CareerStartYear *IntCriterionInput              `json:"career_start_year,omitempty"`
-	CareerEndYear   *IntCriterionInput              `json:"career_end_year,omitempty"`
-	Tattoos         *BodyModificationCriterionInput `json:"tattoos,omitempty"`
-	Piercings       *BodyModificationCriterionInput `json:"piercings,omitempty"`
+	URL       *string               `json:"url,omitempty"`
+	BirthYear *IntCriterionInput    `json:"birth_year,omitempty"`
+	Age       *IntCriterionInput    `json:"age,omitempty"`
+	Ethnicity *EthnicityFilterEnum  `json:"ethnicity,omitempty"`
+	Country   *StringCriterionInput `json:"country,omitempty"`
 	// Filter by performerfavorite status for the current user
 	IsFavorite *bool `json:"is_favorite,omitempty"`
 	// Filter by a performer they have performed in scenes with


### PR DESCRIPTION
closes #1003

someone was trying to filter performers by tattoos (a filter which is not implemented)
trim the graphql schema and keep only the filters that are currently implemented,
based on buildQuery https://github.com/stashapp/stash-box/blob/c9fc7ecd3d8031a15070e6a3d5f263ece65b1cc0/pkg/sqlx/querybuilder_performer.go#L192