### PR TITLE
Add optional ignore_size to image resize settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `image_max_size` | (none) | Max size of image, if no size is specified. Omit to return full size. |
 | `image_resizing.enabled` | false | Whether to resize images shown in the frontend. |
 | `image_resizing.cache_path` | (none) | Folder in which resized images will be saved for later requests. Recommended when resizing is enabled. |
+| `image_resizing.min_size` | (none) | Only resize images above a certain size |
 | `userLogFile` | (none) | Path to the user log file, which logs user operations. If not set, then these will be output to stderr. |
 | `s3.endpoint` | (none) | Hostname to s3 endpoint used for image storage. |
 | `s3.bucket` | (none) | Name of S3 bucket used to store images. |

--- a/pkg/api/routes_image.go
+++ b/pkg/api/routes_image.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"github.com/stashapp/stash-box/pkg/models"
 	"io"
 	"net/http"
 	"slices"
 	"strconv"
+
+	"github.com/stashapp/stash-box/pkg/models"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gofrs/uuid"
@@ -81,7 +82,7 @@ func (rs imageRoutes) image(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Cache-Control", "max-age=604800000")
 
 	// Resize image
-	if shouldResize(config.GetImageResizeConfig(), databaseImage, maxSize) {
+	if shouldResize(databaseImage, maxSize) {
 		data, err := image.Resize(reader, maxSize, databaseImage, size)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -157,9 +158,10 @@ func getImageSize(r *http.Request) (int, error) {
 // shouldResize returns true if resize config is enabled, the size to resize to is not zero,
 // the image is not below the minimum size to ignore, and the image is larger than the minimum
 // size to resize down to.
-func shouldResize(config *config.ImageResizeConfig, image *models.Image, maxSize int) bool {
-	ignoreSize := config.MinSize
+func shouldResize(image *models.Image, maxSize int) bool {
+	config := config.GetImageResizeConfig()
+	minSize := config.MinSize
 	return config.Enabled && maxSize != 0 &&
-		(image.Width > int64(ignoreSize) || image.Height > int64(ignoreSize)) &&
+		(image.Width > int64(minSize) || image.Height > int64(minSize)) &&
 		(image.Width > int64(maxSize) || image.Height > int64(maxSize))
 }

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -33,6 +33,7 @@ type OTelConfig struct {
 type ImageResizeConfig struct {
 	Enabled   bool   `mapstructure:"enabled"`
 	CachePath string `mapstructure:"cache_path"`
+	MinSize   int    `mapstructure:"min_size"`
 }
 
 type config struct {


### PR DESCRIPTION
This optional setting exempts images under ignore_size from being resized, saving on server CPU.

Not sure if this is fully necessary after the recent changes to add a resize cache, but if there are further CPU usage concerns from resizing then this should help. Defaults to 0, which means when not set all images will be resized as before. 