### PR TITLE
Change Image model dimension integer size

### DIFF
--- a/pkg/image/utils.go
+++ b/pkg/image/utils.go
@@ -48,8 +48,8 @@ func populateImageDimensions(imgReader *bytes.Reader, dest *models.Image) error 
 		return fmt.Errorf("unsupported image format: %s", format)
 	}
 
-	dest.Width = int64(img.Bounds().Max.X)
-	dest.Height = int64(img.Bounds().Max.Y)
+	dest.Width = img.Bounds().Max.X
+	dest.Height = img.Bounds().Max.Y
 
 	if dest.Width == 0 || dest.Height == 0 {
 		return ErrImageZeroSize

--- a/pkg/models/generated_exec.go
+++ b/pkg/models/generated_exec.go
@@ -13003,9 +13003,9 @@ func (ec *executionContext) _Image_width(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int64)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_width(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -13047,9 +13047,9 @@ func (ec *executionContext) _Image_height(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int64)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_height(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -52532,21 +52532,6 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalInt(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface{}) (int64, error) {
-	res, err := graphql.UnmarshalInt64(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
-	res := graphql.MarshalInt64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/pkg/models/model_image.go
+++ b/pkg/models/model_image.go
@@ -11,8 +11,8 @@ type Image struct {
 	ID        uuid.UUID      `db:"id" json:"id"`
 	RemoteURL sql.NullString `db:"url" json:"url"`
 	Checksum  string         `db:"checksum" json:"checksum"`
-	Width     int64          `db:"width" json:"width"`
-	Height    int64          `db:"height" json:"height"`
+	Width     int            `db:"width" json:"width"`
+	Height    int            `db:"height" json:"height"`
 }
 
 func (p Image) GetID() uuid.UUID {


### PR DESCRIPTION
Image dimensions are int32 in the db, so pointless to use int64 internally.