### PR TITLE
Treat unmatched URLs as studio even if more than one URL was sent

### DIFF
--- a/frontend/src/pages/drafts/parse.ts
+++ b/frontend/src/pages/drafts/parse.ts
@@ -99,9 +99,12 @@ const parseSceneUrls = (
   const [matches, remainder] = parseUrls(urls, type, sites);
 
   // Fall back to studio URL if there's only one unmatched URL
-  if (matches.length === 0 && remainder.length === 1) {
+  if (remainder.length === 1) {
     const studio = sites.find((site) => site.name === "Studio");
-    if (studio) return [[{ url: remainder[0], site: studio }], []];
+    if (studio) {
+      matches.push({ url: remainder[0], site: studio });
+      return [matches, []];
+    }
   }
 
   return [matches, remainder];


### PR DESCRIPTION
Now that Stash supports sending more than one URL at a time (https://github.com/stashapp/stash/pull/5894), this code treats unmatched URLs as a studio URL even if multiple URLs were submitted.

This allows, for example, submitting a Clips4Sale URL and a studio URL and having both matched.