### PR TITLE
[Github Actions] Add apt update to libvips-dev installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Install vips
-      run: sudo apt install -y libvips-dev
+      run: sudo apt-get update && sudo apt-get install -y libvips-dev
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Install vips
-        run: sudo apt install -y libvips-dev
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Currently the github runners fail on apt installing libvips-dev, seems to be a somewhat transient error that Microsoft themselves don't want to fix, so they have added documentation advising people to run `apt-get update` before installing packages. 

Docs:
https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners#installing-software-on-ubuntu-runners

Similar issues:
https://github.com/actions/runner-images/issues/12865
https://stackoverflow.com/questions/74249584/why-did-github-ci-just-start-failing-to-locate-libcurl
https://github.com/actions/runner-images/issues/5105