### PR TITLE
Allow "Read" Role to Edit Favorite Notifications

### DIFF
--- a/frontend/src/pages/users/UserNotificationPreferences.tsx
+++ b/frontend/src/pages/users/UserNotificationPreferences.tsx
@@ -6,7 +6,8 @@ import {
   NotificationEnum,
   useUpdateNotificationSubscriptions,
 } from "src/graphql";
-import { NotificationType, ensureEnum } from "src/utils";
+import {NotificationType, ensureEnum, FavoriteNotificationType} from "src/utils";
+import {useCurrentUser} from "../../hooks";
 
 interface Props {
   user: {
@@ -16,6 +17,11 @@ interface Props {
 }
 
 export const UserNotificationPreferences: FC<Props> = ({ user }) => {
+    const { isEditor } = useCurrentUser();
+    const subscribableNotificationTypes = Object.entries(
+        isEditor ? NotificationType : FavoriteNotificationType
+    )
+
   const [updateSubscriptions, { loading: submitting }] =
     useUpdateNotificationSubscriptions();
   const activeNotifications: string[] = user.notification_subscriptions.map(
@@ -41,7 +47,7 @@ export const UserNotificationPreferences: FC<Props> = ({ user }) => {
       <hr />
 
       <Form onSubmit={handleSubmit}>
-        {Object.entries(NotificationType).map(([key, value]) => (
+        {subscribableNotificationTypes.map(([key, value]) => (
           <Form.Check
             value={key}
             defaultChecked={activeNotifications.includes(key)}

--- a/frontend/src/pages/users/UserNotificationPreferences.tsx
+++ b/frontend/src/pages/users/UserNotificationPreferences.tsx
@@ -6,8 +6,12 @@ import {
   NotificationEnum,
   useUpdateNotificationSubscriptions,
 } from "src/graphql";
-import {NotificationType, ensureEnum, FavoriteNotificationType} from "src/utils";
-import {useCurrentUser} from "../../hooks";
+import {
+  NotificationType,
+  ensureEnum,
+  FavoriteNotificationType,
+} from "src/utils";
+import { useCurrentUser } from "../../hooks";
 
 interface Props {
   user: {
@@ -17,10 +21,10 @@ interface Props {
 }
 
 export const UserNotificationPreferences: FC<Props> = ({ user }) => {
-    const { isEditor } = useCurrentUser();
-    const subscribableNotificationTypes = Object.entries(
-        isEditor ? NotificationType : FavoriteNotificationType
-    )
+  const { isEditor } = useCurrentUser();
+  const subscribableNotificationTypes = Object.entries(
+    isEditor ? NotificationType : FavoriteNotificationType,
+  );
 
   const [updateSubscriptions, { loading: submitting }] =
     useUpdateNotificationSubscriptions();

--- a/frontend/src/utils/enum.ts
+++ b/frontend/src/utils/enum.ts
@@ -89,7 +89,17 @@ export const resolveEnum = <T>(
     ? (value.toUpperCase() as unknown as T)
     : defaultValue;
 
-type NotificationEnumMap = { [key in NotificationEnum]: string };
+type NotificationEnumMap = { [key: string]: string };
+export const FavoriteNotificationType: NotificationEnumMap = {
+  [NotificationEnum.FAVORITE_PERFORMER_EDIT]:
+      "An edit to a performer you have favorited, or a scene involving them.",
+  [NotificationEnum.FAVORITE_STUDIO_EDIT]:
+      "An edit to a studio you have favorited, or a scene from that studio.",
+  [NotificationEnum.FAVORITE_STUDIO_SCENE]:
+      "A new scene from a studio you have favorited.",
+  [NotificationEnum.FAVORITE_PERFORMER_SCENE]:
+      "A new scene involving a performer you have favorited.",
+};
 export const NotificationType: NotificationEnumMap = {
   [NotificationEnum.UPDATED_EDIT]: "Updates to an edit you have voted on.",
   [NotificationEnum.COMMENT_OWN_EDIT]: "Comments on one of your edits",
@@ -98,14 +108,7 @@ export const NotificationType: NotificationEnumMap = {
   [NotificationEnum.COMMENT_COMMENTED_EDIT]:
     "Comments on edits you have commented on",
   [NotificationEnum.COMMENT_VOTED_EDIT]: "Comments on edits you have voted on",
-  [NotificationEnum.FAVORITE_PERFORMER_EDIT]:
-    "An edit to a performer you have favorited, or a scene involving them.",
-  [NotificationEnum.FAVORITE_STUDIO_EDIT]:
-    "An edit to a studio you have favorited, or a scene from that studio.",
-  [NotificationEnum.FAVORITE_STUDIO_SCENE]:
-    "A new scene from a studio you have favorited.",
-  [NotificationEnum.FAVORITE_PERFORMER_SCENE]:
-    "A new scene involving a performer you have favorited.",
   [NotificationEnum.FINGERPRINTED_SCENE_EDIT]:
     "An edit to a scene you have submitted fingerprints for.",
+  ...FavoriteNotificationType,
 };

--- a/frontend/src/utils/enum.ts
+++ b/frontend/src/utils/enum.ts
@@ -89,18 +89,17 @@ export const resolveEnum = <T>(
     ? (value.toUpperCase() as unknown as T)
     : defaultValue;
 
-type NotificationEnumMap = { [key: string]: string };
-export const FavoriteNotificationType: NotificationEnumMap = {
+export const FavoriteNotificationType = {
   [NotificationEnum.FAVORITE_PERFORMER_EDIT]:
-      "An edit to a performer you have favorited, or a scene involving them.",
+    "An edit to a performer you have favorited, or a scene involving them.",
   [NotificationEnum.FAVORITE_STUDIO_EDIT]:
-      "An edit to a studio you have favorited, or a scene from that studio.",
+    "An edit to a studio you have favorited, or a scene from that studio.",
   [NotificationEnum.FAVORITE_STUDIO_SCENE]:
-      "A new scene from a studio you have favorited.",
+    "A new scene from a studio you have favorited.",
   [NotificationEnum.FAVORITE_PERFORMER_SCENE]:
-      "A new scene involving a performer you have favorited.",
-};
-export const NotificationType: NotificationEnumMap = {
+    "A new scene involving a performer you have favorited.",
+} as const;
+export const NotificationType = {
   [NotificationEnum.UPDATED_EDIT]: "Updates to an edit you have voted on.",
   [NotificationEnum.COMMENT_OWN_EDIT]: "Comments on one of your edits",
   [NotificationEnum.DOWNVOTE_OWN_EDIT]: "Downvotes on one of your edits",
@@ -111,4 +110,4 @@ export const NotificationType: NotificationEnumMap = {
   [NotificationEnum.FINGERPRINTED_SCENE_EDIT]:
     "An edit to a scene you have submitted fingerprints for.",
   ...FavoriteNotificationType,
-};
+} as const;

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -190,7 +190,7 @@ type Mutation {
   """Mark all of the current users notifications as read."""
   markNotificationsRead(notification: MarkNotificationReadInput): Boolean! @hasRole(role: READ)
   """Update notification subscriptions for current user."""
-  updateNotificationSubscriptions(subscriptions: [NotificationEnum!]!): Boolean! @hasRole(role: EDIT)
+  updateNotificationSubscriptions(subscriptions: [NotificationEnum!]!): Boolean! @hasRole(role: READ)
 }
 
 schema {

--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -958,3 +958,23 @@ func (c *graphqlClient) markNotificationsRead(notification *models.MarkNotificat
 
 	return resp.MarkNotificationsRead, nil
 }
+
+func (c *graphqlClient) getNotificationSubscriptions() ([]models.NotificationEnum, error) {
+	q := `
+	query Me {
+		me {
+			notification_subscriptions
+		}
+	}`
+
+	var resp struct {
+		Me struct {
+			NotificationSubscriptions []models.NotificationEnum `json:"notification_subscriptions"`
+		}
+	}
+	if err := c.Post(q, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Me.NotificationSubscriptions, nil
+}

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -1088,3 +1088,7 @@ func assertBodyMods(t *testing.T, input []models.BodyModificationInput, bodyMods
 	// Use ElementsMatch for order-independent comparison
 	assert.ElementsMatch(t, inputStrs, bodyModStrs, text)
 }
+
+func (s *testRunner) getUserNotificationSubscriptions() ([]models.NotificationEnum, error) {
+	return s.client.getNotificationSubscriptions()
+}

--- a/internal/models/generated_exec.go
+++ b/internal/models/generated_exec.go
@@ -6410,7 +6410,7 @@ type Mutation {
   """Mark all of the current users notifications as read."""
   markNotificationsRead(notification: MarkNotificationReadInput): Boolean! @hasRole(role: READ)
   """Update notification subscriptions for current user."""
-  updateNotificationSubscriptions(subscriptions: [NotificationEnum!]!): Boolean! @hasRole(role: EDIT)
+  updateNotificationSubscriptions(subscriptions: [NotificationEnum!]!): Boolean! @hasRole(role: READ)
 }
 
 schema {
@@ -16411,7 +16411,7 @@ func (ec *executionContext) _Mutation_updateNotificationSubscriptions(ctx contex
 		}
 
 		directive1 := func(ctx context.Context) (any, error) {
-			role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "EDIT")
+			role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "READ")
 			if err != nil {
 				var zeroVal bool
 				return zeroVal, err


### PR DESCRIPTION
As mentioned in issue https://github.com/stashapp/stash-box/issues/927, normal users cannot set notifications for their favorite studios and performers. This PR remedies the issue by allowing the API endpoint `updateNotificationSubscriptions` to be called by `READ` role.

In the backend, the `UpdateNotificationSubscriptions` mutation resolver enforces, that if the user is role `EDIT`, all notification types may be subscribed. Otherwise, only a pre-defined set of "favorite" notification types may be subscribed.

In the frontend, all notification types are displayed in case the user is role `EDIT`. Otherwise, only a pre-defined set of "favorite" notification types is displayed.

This PR is a second draft after a discussion about a [first PR](https://github.com/stashapp/stash-box/pull/982).