### PR TITLE
Deleted tags

### DIFF
--- a/internal/queries/sql/tag.sql
+++ b/internal/queries/sql/tag.sql
@@ -99,7 +99,7 @@ SELECT T.* FROM scene_tags ST JOIN tags T ON ST.tag_id = T.id WHERE scene_id = $
 -- name: FindTagsBySceneID :many
 SELECT t.* FROM tags t
 INNER JOIN scene_tags st ON st.tag_id = t.id
-WHERE st.scene_id = $1 AND t.deleted = false;
+WHERE st.scene_id = $1;
 
 -- name: UpdateSceneTagsForMerge :exec
 UPDATE scene_tags

--- a/internal/queries/tag.sql.go
+++ b/internal/queries/tag.sql.go
@@ -302,7 +302,7 @@ func (q *Queries) FindTagsByIds(ctx context.Context, dollar_1 []uuid.UUID) ([]Ta
 const findTagsBySceneID = `-- name: FindTagsBySceneID :many
 SELECT t.id, t.name, t.description, t.created_at, t.updated_at, t.deleted, t.category_id FROM tags t
 INNER JOIN scene_tags st ON st.tag_id = t.id
-WHERE st.scene_id = $1 AND t.deleted = false
+WHERE st.scene_id = $1
 `
 
 func (q *Queries) FindTagsBySceneID(ctx context.Context, sceneID uuid.UUID) ([]Tag, error) {

--- a/internal/service/tag/query.go
+++ b/internal/service/tag/query.go
@@ -39,8 +39,6 @@ func (s *Tag) Query(ctx context.Context, input models.TagQueryInput) (*models.Qu
 
 	// Get count
 	countQuery := psql.Select("COUNT(*)").FromSelect(query, "subquery")
-	asd, _ := countQuery.MustSql()
-	fmt.Print(asd)
 	count, err := queryhelper.ExecuteCount(ctx, countQuery, s.queries.DB(), "QueryTagsCount")
 	if err != nil {
 		return nil, err
@@ -51,9 +49,6 @@ func (s *Tag) Query(ctx context.Context, input models.TagQueryInput) (*models.Qu
 
 	// Apply pagination
 	query = queryhelper.ApplyPagination(query, input.Page, input.PerPage)
-
-	asd, _ = query.MustSql()
-	fmt.Print(asd)
 
 	// Execute query
 	tags, err := queryhelper.ExecuteQuery(ctx, query, s.queries.DB(), converter.TagToModel, "QueryTags")

--- a/internal/service/tag/query.go
+++ b/internal/service/tag/query.go
@@ -39,6 +39,8 @@ func (s *Tag) Query(ctx context.Context, input models.TagQueryInput) (*models.Qu
 
 	// Get count
 	countQuery := psql.Select("COUNT(*)").FromSelect(query, "subquery")
+	asd, _ := countQuery.MustSql()
+	fmt.Print(asd)
 	count, err := queryhelper.ExecuteCount(ctx, countQuery, s.queries.DB(), "QueryTagsCount")
 	if err != nil {
 		return nil, err
@@ -49,6 +51,9 @@ func (s *Tag) Query(ctx context.Context, input models.TagQueryInput) (*models.Qu
 
 	// Apply pagination
 	query = queryhelper.ApplyPagination(query, input.Page, input.PerPage)
+
+	asd, _ = query.MustSql()
+	fmt.Print(asd)
 
 	// Execute query
 	tags, err := queryhelper.ExecuteQuery(ctx, query, s.queries.DB(), converter.TagToModel, "QueryTags")


### PR DESCRIPTION
Filtering out deleted tags from `FindTagsBySceneID` isn't very useful. If a tag is attached, it's attached.