### PR TITLE
Implement automatic cleanup of unused images when updating entities

### DIFF
--- a/internal/api/resolver_mutation_performer.go
+++ b/internal/api/resolver_mutation_performer.go
@@ -14,7 +14,7 @@ func (r *mutationResolver) PerformerCreate(ctx context.Context, input models.Per
 }
 
 func (r *mutationResolver) PerformerUpdate(ctx context.Context, input models.PerformerUpdateInput) (*models.Performer, error) {
-	return r.services.Performer().Update(ctx, input)
+	return r.services.Performer().Update(ctx, input, r.services.Image())
 }
 
 func (r *mutationResolver) PerformerDestroy(ctx context.Context, input models.PerformerDestroyInput) (bool, error) {

--- a/internal/api/resolver_mutation_scene.go
+++ b/internal/api/resolver_mutation_scene.go
@@ -13,7 +13,7 @@ func (r *mutationResolver) SceneCreate(ctx context.Context, input models.SceneCr
 
 func (r *mutationResolver) SceneUpdate(ctx context.Context, input models.SceneUpdateInput) (*models.Scene, error) {
 	s := r.services.Scene()
-	return s.Update(ctx, input)
+	return s.Update(ctx, input, r.services.Image())
 }
 
 func (r *mutationResolver) SceneDestroy(ctx context.Context, input models.SceneDestroyInput) (bool, error) {

--- a/internal/api/resolver_mutation_studio.go
+++ b/internal/api/resolver_mutation_studio.go
@@ -13,7 +13,7 @@ func (r *mutationResolver) StudioCreate(ctx context.Context, input models.Studio
 }
 
 func (r *mutationResolver) StudioUpdate(ctx context.Context, input models.StudioUpdateInput) (*models.Studio, error) {
-	return r.services.Studio().Update(ctx, input)
+	return r.services.Studio().Update(ctx, input, r.services.Image())
 }
 
 func (r *mutationResolver) StudioDestroy(ctx context.Context, input models.StudioDestroyInput) (bool, error) {


### PR DESCRIPTION
This change addresses the TODO comments in performer, scene, and studio services to remove unused images after updating image associations.

Changes:
- Modified updateImages() helper functions to capture and return old image IDs before deleting associations
- Updated Performer.Update(), Scene.Update(), and Studio.Update() methods to:
  - Accept an image service parameter
  - Collect old image IDs during the transaction
  - Clean up orphaned images after the transaction commits
- Updated GraphQL mutation resolvers to pass the image service to Update methods
- Added proper error logging for cleanup failures (non-fatal to preserve update success)

The cleanup uses the existing ImageService.DestroyUnusedImage() method which safely checks if an image is still referenced before deletion, preventing accidental removal of images that are re-associated during the update.

This prevents resource leaks where orphaned images accumulate in storage when performers, scenes, or studios have their images updated.