### PR TITLE
Fix CheckboxSelect state persistence

### DIFF
--- a/frontend/src/components/checkboxSelect/CheckboxSelect.tsx
+++ b/frontend/src/components/checkboxSelect/CheckboxSelect.tsx
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/correctness/noNestedComponentDefinitions: Necessary for react-select
-import { type FC, useState } from "react";
+import type { FC } from "react";
 import Select, { type OnChangeValue } from "react-select";
 import { Form } from "react-bootstrap";
 import { uniq } from "lodash-es";
@@ -9,7 +9,7 @@ interface MultiSelectProps {
   onChange: (values: string[]) => void;
   placeholder?: string;
   plural?: string;
-  initialSelected?: string[];
+  selected?: string[];
 }
 
 interface IOptionType {
@@ -23,17 +23,10 @@ const CheckboxSelect: FC<MultiSelectProps> = ({
   onChange,
   placeholder = "Select...",
   plural = "values",
-  initialSelected = [],
+  selected = [],
 }) => {
-  const [unselected, setUnselected] = useState<string[]>(initialSelected);
-
   const handleChange = (vals: OnChangeValue<IOptionType, true>) => {
-    const selected = uniq(
-      vals.flatMap((v) => [v.value, ...(v.subValues ?? [])]),
-    );
-
-    setUnselected(selected);
-    onChange(selected);
+    onChange(uniq(vals.flatMap((v) => [v.value, ...(v.subValues ?? [])])));
   };
 
   const formatLabel = (
@@ -45,7 +38,7 @@ const CheckboxSelect: FC<MultiSelectProps> = ({
         <div className="d-flex ms-3">
           <Form.Check
             className="me-2"
-            checked={unselected.includes(option.value)}
+            checked={selected.includes(option.value)}
           />
           {option.label}
         </div>
@@ -53,23 +46,21 @@ const CheckboxSelect: FC<MultiSelectProps> = ({
         <div className="d-flex">
           <Form.Check
             className="me-2"
-            checked={unselected.includes(option.value)}
+            checked={selected.includes(option.value)}
           />
           <span className="text-muted">{option.label}</span>
         </div>
       );
     return `${
-      unselected.length === 0 ? "All" : unselected.length
+      selected.length === 0 ? "All" : selected.length
     } ${plural} selected`;
   };
 
-  const defaultValue = values.filter((val) =>
-    initialSelected.includes(val.value),
-  );
+  const selectedOptions = values.filter((val) => selected.includes(val.value));
 
   return (
     <Select
-      defaultValue={defaultValue}
+      value={selectedOptions}
       isMulti
       classNamePrefix="react-select"
       className="react-select CheckboxSelect"
@@ -90,9 +81,9 @@ const CheckboxSelect: FC<MultiSelectProps> = ({
         DropdownIndicator: () => null,
         IndicatorSeparator: () => null,
         MultiValue: (e) =>
-          e.data.value === unselected[0] ? (
+          e.data.value === selected[0] ? (
             <span className="text-secondary">
-              {unselected.length} {plural} selected
+              {selected.length} {plural} selected
             </span>
           ) : null,
       }}

--- a/frontend/src/pages/performers/Performer.tsx
+++ b/frontend/src/pages/performers/Performer.tsx
@@ -101,7 +101,7 @@ const PerformerComponent: FC<Props> = ({ performer }) => {
             placeholder="Filter by studios"
             plural="studios"
             key={`performer-${performer.id}-studio-select`}
-            initialSelected={studioFilter}
+            selected={studioFilter}
           />
           <SceneList
             perPage={40}


### PR DESCRIPTION
Removes internal `CheckboxSelect` state and just use url param state, ensuring that dropdown state always matches filter state.