### PR TITLE
Fix activation timer and error messages

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/stashapp/stash-box/internal/config"
 	"github.com/stashapp/stash-box/internal/converter/gen"
 	"github.com/stashapp/stash-box/internal/models"
 	"github.com/stashapp/stash-box/internal/queries"
@@ -542,7 +543,7 @@ func UpdateUserFromUpdateInput(user queries.User, input models.UserUpdateInput, 
 	}
 }
 
-// CreateUserTokenParamsFromData creates a queries.CreateUserTokenParams with token expiring 15 minutes from now
+// CreateUserTokenParamsFromData creates a queries.CreateUserTokenParams with token expiring based on config
 func CreateUserTokenParamsFromData(tokenType string, data any) (queries.CreateUserTokenParams, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
@@ -555,7 +556,7 @@ func CreateUserTokenParamsFromData(tokenType string, data any) (queries.CreateUs
 	}
 
 	now := time.Now()
-	expires := now.Add(15 * time.Minute)
+	expires := now.Add(config.GetActivationExpiry())
 
 	return queries.CreateUserTokenParams{
 		ID:        id,

--- a/internal/service/user/activation.go
+++ b/internal/service/user/activation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/gofrs/uuid"
+	"github.com/stashapp/stash-box/internal/config"
 	"github.com/stashapp/stash-box/internal/converter"
 	"github.com/stashapp/stash-box/internal/models"
 	"github.com/stashapp/stash-box/internal/queries"

--- a/internal/service/user/activation.go
+++ b/internal/service/user/activation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/gofrs/uuid"
-	"github.com/stashapp/stash-box/internal/config"
 	"github.com/stashapp/stash-box/internal/converter"
 	"github.com/stashapp/stash-box/internal/models"
 	"github.com/stashapp/stash-box/internal/queries"

--- a/internal/service/user/invite.go
+++ b/internal/service/user/invite.go
@@ -12,6 +12,7 @@ import (
 )
 
 var ErrNoInviteTokens = errors.New("no invite tokens available")
+var ErrInvalidInviteKey = errors.New("invalid or expired invite key")
 
 type Finder interface {
 	Find(id uuid.UUID) (*models.User, error)

--- a/internal/service/user/service.go
+++ b/internal/service/user/service.go
@@ -337,6 +337,9 @@ func (s *User) ActivateNewUser(ctx context.Context, input models.ActivateNewUser
 	err := s.withTxn(func(tx *queries.Queries) error {
 		token, err := tx.FindUserToken(ctx, input.ActivationKey)
 		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrInvalidActivationKey
+			}
 			return err
 		}
 		if token.Type != models.UserTokenTypeNewUser {
@@ -356,6 +359,9 @@ func (s *User) ActivateNewUser(ctx context.Context, input models.ActivateNewUser
 
 			invite, err := tx.FindInviteKey(ctx, *data.InviteKey)
 			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return ErrInvalidInviteKey
+				}
 				return err
 			}
 


### PR DESCRIPTION
* Activation expiration time was hardcoded to 15m rather than using the config option.
* Fixed error message when invite or activation is expired.