### PR TITLE
Add autocert certificate fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,38 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `favicon_path` | (none) | Location where favicons for linked sites should be stored. Leave empty to disable. |
 | `draft_time_limit` | (24h) | Time, in seconds, before a draft is deleted. |
 | `profiler_port` | 0 | Port on which to serve pprof output. Omit to disable entirely. |
+| `port` | 9998 | Port on which the server runs. When using SSL certificates it should be set to `443`. |
 | `postgres.max_open_conns` | (0) | Maximum number of concurrent open connections to the database. |
 | `postgres.max_idle_conns` | (0) | Maximum number of concurrent idle database connections. |
 | `postgres.conn_max_lifetime` | (0) | Maximum lifetime in minutes before a connection is released. |
 | `require_scene_draft` | false | Whether to allow scene creation outside of draft submissions. |
 | `require_tag_role` | false | Whether to require the EditTag role to edit tags. |
 | `csp` | (none) | Contents of the `Content-Security-Policy` header |
+| `autocert.enabled` | (none) | Whether to enable [autocert](#lets-encrypt)|
+| `autocert.cache_dir` | (none) | The directory where autocert certificates are stored. Should be a persisted directory to avoid certificate regeneration on server restart. |
+| `autocert.domain` | (none) | The domain to generate certificates for.|
+| `autocert.email` | (none) | A valid email. Will be submitted to Let's Encrypt, but otherwise not made public. |
 
 ## SSL (HTTPS)
 
-Stash-box is runnable, preferably over HTTPS, for added security, but it requires some setup. You'll need to generate an SSL certificate and key pair to set this up. Or use a TLS terminating proxy of your choice, such as Traefik, Nginx (unsupported), or Caddy Server (unsupported)
+### Let's Encrypt
+
+Stash-box supports automatic certificate generation from Let's Encrypt. If you want to avoid running behind a reverse proxy - which can cause a certain amount of overhead due to image loading - this is the recommended approach.
+
+To use Let's Encrypt, configure the `autocert` config option. As an example:
+```
+autocert:
+    enabled: true
+    cache_dir: /autocert
+    domain: example.org
+    email: email@example.org
+```
+
+To use autocert it needs access to port 80 to respond to Let's Encrypt's challenge. After certificate generation is done, port 80 will redirect to the SSL port.
+
+Stash-box will automatically renew the certificate once it has less than 30 days until expiration.
+
+### Self-signed certificates
 
 Here's an example of how you can do this using OpenSSL:
 

--- a/cmd/stash-box/init.go
+++ b/cmd/stash-box/init.go
@@ -69,6 +69,12 @@ Please ensure this database is created and available, or change the connection s
 	if len(missingEmail) > 0 {
 		fmt.Printf("RequireActivation is set to true, but the following required settings are missing: %s\n", strings.Join(missingEmail, ", "))
 	}
+
+	missingAutocert := config.GetMissingAutocertSettings()
+	if len(missingAutocert) > 0 {
+		fmt.Printf("Autocert is enabled, but the following required settings are missing: %s\n", strings.Join(missingAutocert, ", "))
+		os.Exit(1)
+	}
 }
 
 func parseConfigFilePath(configFilePath string) (string, string) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/riandyrn/otelchi"
 	"github.com/rs/cors"
 	"github.com/stashapp/stash-box/internal/auth"
+	"github.com/stashapp/stash-box/internal/autocert"
 	"github.com/stashapp/stash-box/internal/config"
 	"github.com/stashapp/stash-box/internal/dataloader"
 	"github.com/stashapp/stash-box/internal/models"
@@ -222,6 +223,33 @@ func Start(fac service.Factory, ui embed.FS) {
 	}
 
 	address := config.GetHost() + ":" + strconv.Itoa(config.GetPort())
+
+	// Priority 1: Autocert (Let's Encrypt)
+	if tlsConfig := autocert.Init(); tlsConfig != nil {
+		httpsServer := &http.Server{
+			Addr:      address,
+			Handler:   r,
+			TLSConfig: tlsConfig,
+		}
+
+		// Start HTTP server for ACME HTTP-01 challenges on port 80
+		// Non-challenge requests are redirected to HTTPS
+		go func() {
+			logger.Infof("Starting HTTP server on %s:80 for ACME challenges", config.GetHost())
+			if err := http.ListenAndServe(config.GetHost()+":80", autocert.HTTPHandler(http.HandlerFunc(redirect))); err != nil {
+				logger.Errorf("HTTP server error: %v", err)
+			}
+		}()
+
+		go func() {
+			printVersion()
+			logger.Infof("stash-box is running on HTTPS (autocert) at https://%s/", address)
+			logger.Fatal(httpsServer.ListenAndServeTLS("", ""))
+		}()
+		return
+	}
+
+	// Priority 2: File-based TLS
 	if tlsConfig := makeTLSConfig(); tlsConfig != nil {
 		httpsServer := &http.Server{
 			Addr:      address,
@@ -240,18 +268,20 @@ func Start(fac service.Factory, ui embed.FS) {
 			logger.Infof("stash-box is running on HTTPS at https://%s/", address)
 			logger.Fatal(httpsServer.ListenAndServeTLS("", ""))
 		}()
-	} else {
-		server := &http.Server{
-			Addr:    address,
-			Handler: r,
-		}
-
-		go func() {
-			printVersion()
-			logger.Infof("stash-box is running on HTTP at http://%s/", address)
-			logger.Fatal(server.ListenAndServe())
-		}()
+		return
 	}
+
+	// Priority 3: HTTP only
+	server := &http.Server{
+		Addr:    address,
+		Handler: r,
+	}
+
+	go func() {
+		printVersion()
+		logger.Infof("stash-box is running on HTTP at http://%s/", address)
+		logger.Fatal(server.ListenAndServe())
+	}()
 }
 
 func printVersion() {

--- a/internal/autocert/autocert.go
+++ b/internal/autocert/autocert.go
@@ -76,7 +76,6 @@ func checkAndRenew() {
 				case daysUntilExpiry <= 30:
 					logger.Infof("Autocert: certificate for %s expires in %d days, renewing...", domain, daysUntilExpiry)
 				default:
-					logger.Infof("Autocert: certificate for %s is valid (expires %s, %d days remaining)", domain, cert.NotAfter.Format("2006-01-02"), daysUntilExpiry)
 					return
 				}
 			}

--- a/internal/autocert/autocert.go
+++ b/internal/autocert/autocert.go
@@ -1,0 +1,102 @@
+package autocert
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/stashapp/stash-box/internal/config"
+	"github.com/stashapp/stash-box/pkg/logger"
+)
+
+var manager *autocert.Manager
+var domain string
+
+// Init initializes autocert if configured and returns the TLS config.
+// Returns nil if autocert is not enabled.
+func Init() *tls.Config {
+	cfg := config.GetAutocertConfig()
+	if cfg == nil {
+		return nil
+	}
+
+	cache := autocert.DirCache(cfg.CacheDir)
+	domain = cfg.Domain
+
+	manager = &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(domain),
+		Cache:      cache,
+		Email:      cfg.Email,
+	}
+
+	// Obtain certificate on startup
+	go checkAndRenew()
+
+	tlsConfig := manager.TLSConfig()
+	tlsConfig.MinVersion = tls.VersionTLS12
+
+	return tlsConfig
+}
+
+// HTTPHandler returns the autocert HTTP handler for ACME challenges.
+// The fallback handler is used for non-ACME requests.
+func HTTPHandler(fallback http.Handler) http.Handler {
+	if manager == nil {
+		return fallback
+	}
+	return manager.HTTPHandler(fallback)
+}
+
+// CheckAndRenew checks the certificate and renews if needed.
+// Called by cron job.
+func CheckAndRenew() {
+	if manager == nil {
+		return
+	}
+	checkAndRenew()
+}
+
+func checkAndRenew() {
+	// Check cache first
+	if data, err := manager.Cache.Get(context.Background(), domain); err == nil {
+		if block, _ := pem.Decode(data); block != nil {
+			if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+				now := time.Now()
+				daysUntilExpiry := int(cert.NotAfter.Sub(now).Hours() / 24)
+
+				switch {
+				case now.After(cert.NotAfter):
+					logger.Warnf("Autocert: certificate for %s has expired, renewing...", domain)
+				case daysUntilExpiry <= 30:
+					logger.Infof("Autocert: certificate for %s expires in %d days, renewing...", domain, daysUntilExpiry)
+				default:
+					logger.Infof("Autocert: certificate for %s is valid (expires %s, %d days remaining)", domain, cert.NotAfter.Format("2006-01-02"), daysUntilExpiry)
+					return
+				}
+			}
+		}
+	} else {
+		logger.Infof("Autocert: obtaining certificate for %s from Let's Encrypt...", domain)
+	}
+
+	// Trigger certificate acquisition/renewal
+	hello := &tls.ClientHelloInfo{ServerName: domain}
+	cert, err := manager.GetCertificate(hello)
+	if err != nil {
+		logger.Errorf("Autocert: failed to obtain certificate for %s: %v", domain, err)
+		return
+	}
+
+	if cert != nil && len(cert.Certificate) > 0 {
+		if x509Cert, parseErr := x509.ParseCertificate(cert.Certificate[0]); parseErr == nil {
+			daysUntilExpiry := int(time.Until(x509Cert.NotAfter).Hours() / 24)
+			logger.Infof("Autocert: obtained certificate for %s (expires %s, %d days remaining)", domain, x509Cert.NotAfter.Format("2006-01-02"), daysUntilExpiry)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,13 @@ type ImageResizeConfig struct {
 	MinSize   int    `mapstructure:"min_size"`
 }
 
+type AutocertConfig struct {
+	Enabled  bool   `mapstructure:"enabled"`
+	Domain   string `mapstructure:"domain"`
+	Email    string `mapstructure:"email"`
+	CacheDir string `mapstructure:"cache_dir"`
+}
+
 type config struct {
 	Host         string `mapstructure:"host"`
 	Port         int    `mapstructure:"port"`
@@ -111,6 +118,10 @@ type config struct {
 	// revive:disable-next-line
 	Image_Resizing struct {
 		ImageResizeConfig `mapstructure:",squash"`
+	}
+
+	Autocert struct {
+		AutocertConfig `mapstructure:",squash"`
 	}
 
 	PHashDistance int `mapstructure:"phash_distance"`
@@ -271,6 +282,32 @@ func GetOTelConfig() *OTelConfig {
 		return &C.OTel.OTelConfig
 	}
 	return nil
+}
+
+func GetAutocertConfig() *AutocertConfig {
+	if C.Autocert.Enabled {
+		return &C.Autocert.AutocertConfig
+	}
+	return nil
+}
+
+func GetMissingAutocertSettings() []string {
+	if !C.Autocert.Enabled {
+		return nil
+	}
+
+	missing := []string{}
+	if C.Autocert.Domain == "" {
+		missing = append(missing, "domain")
+	}
+	if C.Autocert.Email == "" {
+		missing = append(missing, "email")
+	}
+	if C.Autocert.CacheDir == "" {
+		missing = append(missing, "cache_dir")
+	}
+
+	return missing
 }
 
 // ValidateImageLocation returns an error is image_location is not set.

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -100,9 +100,11 @@ func Init(fac service.Factory) {
 		panic(err.Error())
 	}
 
-	_, err = c.AddFunc("@daily", autocert.CheckAndRenew)
-	if err != nil {
-		panic(err.Error())
+	if config.GetAutocertConfig() != nil {
+		_, err = c.AddFunc("@daily", autocert.CheckAndRenew)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 
 	interval := config.GetVoteCronInterval()

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -6,6 +6,7 @@ import (
 	"github.com/robfig/cron/v3"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/stashapp/stash-box/internal/autocert"
 	"github.com/stashapp/stash-box/internal/config"
 	"github.com/stashapp/stash-box/internal/service"
 	"github.com/stashapp/stash-box/pkg/logger"
@@ -95,6 +96,11 @@ func Init(fac service.Factory) {
 	}
 
 	_, err = c.AddFunc("@every 60m", cronJobs.cleanInvites)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = c.AddFunc("@daily", autocert.CheckAndRenew)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
Using autocert avoids having to use traefik just to get tls, which can be a resource hog.