### PR TITLE
fix(notifications): Allow multiple notifications for scene edits

### DIFF
--- a/internal/queries/sql/notification.sql
+++ b/internal/queries/sql/notification.sql
@@ -88,7 +88,7 @@ WHERE E.id = $1;
 
 -- name: TriggerSceneEditNotifications :exec
 INSERT INTO notifications (user_id, type, id)
-SELECT DISTINCT ON (user_id) user_id, type, $1 FROM (
+SELECT user_id, type, $1 FROM (
     SELECT N.user_id, N.type
     FROM edits E JOIN studio_favorites SF ON (E.data->'new_data'->>'studio_id')::uuid = SF.studio_id
     JOIN user_notifications N ON SF.user_id = N.user_id AND N.type = 'FAVORITE_STUDIO_EDIT' AND N.user_id != E.user_id


### PR DESCRIPTION
## Summary

Fixes a bug where `FINGERPRINTED_SCENE_EDIT` notifications were suppressed by `FAVORITE_PERFORMER_EDIT` or `FAVORITE_STUDIO_EDIT` notifications. The `TriggerSceneEditNotifications` query used `DISTINCT ON (user_id)`, which only allowed one notification per user for a single edit. This has been removed to allow multiple notifications of different types to be created for the same user and edit.

## Changes

- **internal/queries/sql/notification.sql**: Removed `DISTINCT ON (user_id)` from the `TriggerSceneEditNotifications` query. This allows multiple notifications of different types to be created for a single user and scene edit, fixing the bug where some notification types were being suppressed.

## Related Issue

Closes #1060

