### PR TITLE
Update postgres extension documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ Stash-box is an open-source video indexing and metadata API server for adult con
 - `make stash-box` - Full build: dependencies, generation, UI, linting, and binary
 
 ### Database Setup
-The application requires PostgreSQL with specific extensions:
-- Run `CREATE EXTENSION pg_trgm; CREATE EXTENSION pgcrypto;` as superuser before first run
+The application uses PostgreSQL extensions, created automatically by migrations (superuser required):
+- `CREATE EXTENSION IF NOT EXISTS bktree;` — pHash distance search (optional, only if installed on system)
+- `CREATE EXTENSION IF NOT EXISTS pg_search;` — ParadeDB full-text search (optional, only if installed on system)
 - Database schema migrations run automatically on startup
 - **Migrations**: Located in `internal/database/migrations/postgres/` and executed sequentially by filename
 - Default connection string: `postgres@localhost/stash-box?sslmode=disable`
@@ -118,4 +119,4 @@ The application requires PostgreSQL with specific extensions:
 - Default admin user (`root`) is created on first run with random password printed to stdout
 - Frontend development can use API key in `.env.development.local` to bypass login
 - Integration tests require PostgreSQL (default: `postgres@localhost/stash-box-test?sslmode=disable`)
-- pHash distance matching requires `pg-spgist_hamming` PostgreSQL extension
+- pHash distance matching requires the `bktree` extension (built from the `pg-spgist_hamming` repo), installed via the production Dockerfile

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build stash-box on linux [libvips](https://www.libvips.org/) must be installe
 
 1. Run `make` to build the application.
 2. Stash-box requires access to a PostgreSQL database server. Suppose stash-box doesn't find a configuration file (defaults to `stash-box-config.yml` in the current directory). In that case, it will generate a default configuration file with a default PostgreSQL connection string (`postgres@localhost/stash-box?sslmode=disable`). You can adjust the connection string as needed.
-3. The database must be created and available. If the PostgreSQL user is not a superuser, run `CREATE EXTENSION pg_trgm; CREATE EXTENSION pgcrypto;` by a superuser before rerunning Stash-box. If the schema is not present, it will be created within the database.
+3. The database must be created and available. If the PostgreSQL user is not a superuser, run `CREATE EXTENSION pg_search; CREATE EXTENSION bktree;` by a superuser before rerunning Stash-box. If the schema is not present, it will be created within the database.
 4. The `sslmode` parameter is documented [here](https://godoc.org/github.com/lib/pq). Use `sslmode=disable` to not use SSL for the database connection. The default is `require`.
 5. After ensuring the database connection and availability, rerun Stash-box.
 #### Schema migrations and initial Admin user
@@ -148,7 +148,7 @@ Once you've generated the certificate and key pair, make sure they're named `sta
 
 ## pHash Distance Matching
 
-If you want to enable distance matching for pHashes in stash-box, you'll need to install the [pg-spgist_hamming](https://github.com/fake-name/pg-spgist_hamming) Postgres extension.
+If you want to enable distance matching for pHashes in stash-box, you'll need to install the [pg-spgist_hamming](https://github.com/infinitestash/pg-spgist_hamming) Postgres extension.
 
 The recommended way to do this is to use the [docker image](docker/production/postgres/Dockerfile). Still, you can also install it manually by following the build instructions in the pg-spgist_hamming repository.
 

--- a/docker/production/postgres/Dockerfile
+++ b/docker/production/postgres/Dockerfile
@@ -3,9 +3,9 @@ FROM postgres:18
 # Build and install pg-spgist_hamming (pHash matching)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends make gcc postgresql-server-dev-18 git ca-certificates \
-    && git clone --depth 1 https://github.com/fake-name/pg-spgist_hamming.git /tmp/pg-spgist_hamming \
-    && make -C /tmp/pg-spgist_hamming/bktree \
-    && make -C /tmp/pg-spgist_hamming/bktree install \
+    && git clone --depth 1 https://github.com/InfiniteStash/pg-spgist_hamming.git /tmp/pg-spgist_hamming \
+    && make -C /tmp/pg-spgist_hamming \
+    && make -C /tmp/pg-spgist_hamming install \
     && rm -rf /tmp/pg-spgist_hamming /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove make gcc postgresql-server-dev-18 git
 

--- a/internal/database/migrations/postgres/02_create_search.up.sql
+++ b/internal/database/migrations/postgres/02_create_search.up.sql
@@ -5,7 +5,7 @@ BEGIN
   END IF;
 END$$;
 
-CREATE TABLE scene_search AS 
+CREATE TABLE scene_search AS
 SELECT
 	S.id as scene_id,
 	REGEXP_REPLACE(S.title, '[^a-zA-Z0-9 ]+', '', 'g') AS scene_title,
@@ -19,7 +19,12 @@ LEFT JOIN studios T ON T.id = S.studio_id
 LEFT JOIN studios TP ON T.parent_studio_id = TP.id
 GROUP BY S.id, S.title, T.name, TP.name;
 
-CREATE INDEX name_trgm_idx ON performers USING GIN (name gin_trgm_ops);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+    CREATE INDEX name_trgm_idx ON performers USING GIN (name gin_trgm_ops);
+  END IF;
+END$$;
 CREATE INDEX ts_idx ON scene_search USING gist (
 	(
         to_tsvector('simple', COALESCE(scene_date, '')) ||

--- a/internal/database/migrations/postgres/18_fingerprint_user.up.sql
+++ b/internal/database/migrations/postgres/18_fingerprint_user.up.sql
@@ -1,10 +1,3 @@
-DO $$
-BEGIN
-  IF current_setting('is_superuser') = 'on' THEN
-    CREATE EXTENSION IF NOT EXISTS pgcrypto;
-  END IF;
-END$$;
-
 ALTER TABLE "scene_fingerprints" ADD COLUMN user_id uuid references "users"("id") ON DELETE CASCADE;
 
 -- if there are existing fingerprints, create a user to assign them to it

--- a/internal/database/migrations/postgres/22_performer_search_indexes.up.sql
+++ b/internal/database/migrations/postgres/22_performer_search_indexes.up.sql
@@ -1,2 +1,7 @@
-CREATE INDEX disambiguation_trgm_idx ON "performers" USING GIN ("disambiguation" gin_trgm_ops);
-CREATE INDEX performer_alias_trgm_idx ON "performer_aliases" USING GIN ("alias" gin_trgm_ops);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+    CREATE INDEX disambiguation_trgm_idx ON "performers" USING GIN ("disambiguation" gin_trgm_ops);
+    CREATE INDEX performer_alias_trgm_idx ON "performer_aliases" USING GIN ("alias" gin_trgm_ops);
+  END IF;
+END$$;


### PR DESCRIPTION
Removes mention of pgcrypto and pg_trgm since they're not used in current versions.