### PR TITLE
fix: configuration initialization order and priority

### DIFF
--- a/cmd/stash-box/init.go
+++ b/cmd/stash-box/init.go
@@ -38,18 +38,18 @@ func initConfig(configFilePath *string) {
 		}
 	}
 
+	initEnvs()
+
+	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+		logger.Infof("failed to bind flags: %s", err.Error())
+	}
+
 	if err = config.InitializeDefaults(); err != nil {
 		panic(err)
 	}
 
-	initEnvs()
-
 	if err = viper.ReadInConfig(); err != nil {
 		panic(err)
-	}
-
-	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		logger.Infof("failed to bind flags: %s", err.Error())
 	}
 
 	if err = config.Initialize(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -395,9 +395,7 @@ func InitializeDefaults() error {
 		viper.Set(SessionStoreKey, sessionStoreKey)
 	}
 
-	if viper.GetString(Database) == "" {
-		viper.Set(Database, GetDefaultDatabaseFilePath())
-	}
+	viper.SetDefault(Database, GetDefaultDatabaseFilePath())
 
 	return viper.WriteConfig()
 }


### PR DESCRIPTION
## Problem
On the first run, `InitializeDefaults` would call `viper.Set("database", ...)` before environment variables were bound via `initEnvs`. Since `viper.Set` has a higher priority than environment variables in Viper, any `STASH_BOX_DATABASE` env var provided by the user would be permanently ignored in subsequent runs because the hardcoded default was already baked into the configuration with top priority.

## Solution
1. Reordered the initialization in `cmd/stash-box/init.go` to ensure `initEnvs()` and `BindPFlags` are called before `InitializeDefaults()`.
2. Changed `viper.Set` to `viper.SetDefault` in `internal/config/config.go` for the database connection string. This ensures the hardcoded default has the lowest priority and can be correctly overridden by config files or environment variables.

## Impact
Users can now correctly configure the database connection string via the `STASH_BOX_DATABASE` environment variable even on the very first run.