### PR TITLE
feat: implement modern multi-stage Dockerfile using Go 1.25 and pnpm

### DIFF
--- a/docker/production/stash-box/Dockerfile
+++ b/docker/production/stash-box/Dockerfile
@@ -1,0 +1,43 @@
+# Multi-stage build for stash-box
+# Must be built from the project root:
+#   docker build -f docker/production/stash-box/Dockerfile .
+
+# Stage 1: Build frontend
+FROM node:24-slim AS frontend
+
+RUN corepack enable pnpm
+
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY frontend/ ./
+RUN pnpm build
+
+# Stage 2: Build backend
+FROM golang:1.25 AS backend
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make git ca-certificates libvips-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+COPY --from=frontend /app/frontend/build ./frontend/build
+
+RUN make build
+
+# Stage 3: Runtime
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libvips \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=backend /app/stash-box /usr/bin/stash-box
+
+EXPOSE 9998
+CMD ["stash-box", "--config_file", "/root/.stash-box/stash-box-config.yml"]


### PR DESCRIPTION
## Summary
The current build Dockerfile is outdated (using Go 1.13 and Ubuntu 19.10). This PR introduces a modern, multi-stage Dockerfile to improve build speed, security, and image size.

## Changes
- Created a new multi-stage `Dockerfile` in `docker/production/stash-box/`.
- Upgraded build environment to **Go 1.25** and **Node 24**.
- Switched from yarn/npm to **pnpm** for frontend builds to leverage better caching and speed.
- Used a lean **Ubuntu 24.04** runtime image, significantly reducing the final image footprint.
- Separated frontend and backend build stages for cleaner layer management.

## Why
Modernizing the build pipeline ensures compatibility with the latest Go features and provides a faster, more reliable deployment path for production environments.
