### PR TITLE
New: Move Vote Bar Below Comments

### DIFF
--- a/frontend/src/components/editCard/EditCard.tsx
+++ b/frontend/src/components/editCard/EditCard.tsx
@@ -94,7 +94,6 @@ const EditCardComponent: FC<Props> = ({
             <b className="me-2">Status:</b>
             <EditStatus {...edit} />
             <EditExpiration edit={edit} />
-            {showVoteBar && <VoteBar edit={edit} />}
           </div>
         </div>
       </Card.Header>
@@ -110,6 +109,7 @@ const EditCardComponent: FC<Props> = ({
                 {showVotes && <Votes edit={edit} />}
                 {comments}
                 <AddComment editID={edit.id} />
+                {showVoteBar && <VoteBar edit={edit} />}
               </Col>
             </Row>
           </>


### PR DESCRIPTION
This was initially noticed in Discourse, https://discourse.stashapp.cc/t/move-voting-controls-below-comments-to-encourage-informed-voting/6961 

This was a small addition that was brought up to me in hopes of helping reduce voters from just automatically clicking +1. 

UI: 

<img width="1281" height="662" alt="Screenshot 2026-04-27 at 14 49 07" src="https://github.com/user-attachments/assets/bca159d2-097d-4908-a294-6b91d6d5cf34" />
<img width="1359" height="789" alt="Screenshot 2026-04-27 at 14 48 10" src="https://github.com/user-attachments/assets/20dcaed0-5304-4ce9-9824-34ead9789acb" />
