### PR TITLE
Change performer image prioritization; use float division for aspect ratios

### DIFF
--- a/internal/image/sort.go
+++ b/internal/image/sort.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stashapp/stash-box/internal/models"
 )
 
+// Sorts by "most" to "least" landscape, i.e. largest to smallest aspect ratio; ties broken by largest --> smallest width.
 func OrderLandscape(p []models.Image) {
 	sort.Slice(p, func(a, b int) bool {
 		if p[a].Height == 0 || p[b].Height == 0 {
 			return false
 		}
-		aspectA := p[a].Width / p[a].Height
-		aspectB := p[b].Width / p[b].Height
+		aspectA := float64(p[a].Width) / float64(p[a].Height)
+		aspectB := float64(p[b].Width) / float64(p[b].Height)
 		if aspectA > aspectB {
 			return true
 		} else if aspectA < aspectB {
@@ -26,7 +27,7 @@ func OrderLandscape(p []models.Image) {
 // Sorts by distance from StashDB's ideal aspect ratio of 2:3; ties broken by largest --> smallest height.
 func OrderPortrait(p []models.Image) {
 	sort.Slice(p, func(a, b int) bool {
-		if p[a].Width == 0 || p[b].Width == 0 {
+		if p[a].Height == 0 || p[b].Height == 0 {
 			return false
 		}
 		aspectA := float64(p[a].Width) / float64(p[a].Height)

--- a/internal/image/sort.go
+++ b/internal/image/sort.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"math"
 	"sort"
 
 	"github.com/stashapp/stash-box/internal/models"
@@ -22,16 +23,20 @@ func OrderLandscape(p []models.Image) {
 	})
 }
 
+// Sorts by distance from StashDB's ideal aspect ratio of 2:3; ties broken by largest --> smallest height.
 func OrderPortrait(p []models.Image) {
 	sort.Slice(p, func(a, b int) bool {
 		if p[a].Width == 0 || p[b].Width == 0 {
 			return false
 		}
-		aspectA := p[a].Height / p[a].Width
-		aspectB := p[b].Height / p[b].Width
-		if aspectA > aspectB {
+		aspectA := float64(p[a].Width) / float64(p[a].Height)
+		aspectB := float64(p[b].Width) / float64(p[b].Height)
+		aspectIdeal := 2.0 / 3.0
+		diffA := math.Abs(aspectA - aspectIdeal)
+		diffB := math.Abs(aspectB - aspectIdeal)
+		if diffA < diffB {
 			return true
-		} else if aspectA < aspectB {
+		} else if diffA > diffB {
 			return false
 		}
 		return p[a].Height > p[b].Height

--- a/internal/image/sort.go
+++ b/internal/image/sort.go
@@ -24,7 +24,7 @@ func OrderLandscape(p []models.Image) {
 	})
 }
 
-// Sorts by distance from StashDB's ideal aspect ratio of 2:3; ties broken by largest --> smallest height.
+// Sorts by distance from ideal aspect ratio of 2:3; ties broken by largest --> smallest height.
 func OrderPortrait(p []models.Image) {
 	sort.Slice(p, func(a, b int) bool {
 		if p[a].Height == 0 || p[b].Height == 0 {

--- a/internal/image/sort_test.go
+++ b/internal/image/sort_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stashapp/stash-box/internal/models"
 )
 
+// TODO: Add tests for OrderLandscape
+
 func TestOrderPortrait(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/image/sort_test.go
+++ b/internal/image/sort_test.go
@@ -1,13 +1,88 @@
 package image
 
 import (
-	"reflect"
+	"fmt"
 	"testing"
 
 	"github.com/stashapp/stash-box/internal/models"
+	"github.com/stretchr/testify/assert"
 )
 
-// TODO: Add tests for OrderLandscape
+func formatDims(images []models.Image) []string {
+	if images == nil {
+		return nil
+	}
+	dims := make([]string, len(images))
+	for i, img := range images {
+		dims[i] = fmt.Sprintf("%dx%d", img.Width, img.Height)
+	}
+	return dims
+}
+
+func TestOrderLandscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		images   []models.Image
+		expected []models.Image
+	}{
+		{
+			name: "Sorts by widest to most narrow aspect ratio",
+			images: []models.Image{
+				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
+				{Width: 640, Height: 480},   // 4:3 (1.333)
+				{Width: 400, Height: 600},   // 2:3 (0.666)
+				{Width: 422, Height: 600},   // 0.703
+				{Width: 1920, Height: 1080}, // 16:9 (1.777)
+				{Width: 600, Height: 400},   // 3:2 (1.5)
+			},
+			expected: []models.Image{
+				{Width: 1920, Height: 1080}, // 16:9 (1.777)
+				{Width: 600, Height: 400},   // 3:2 (1.5)
+				{Width: 640, Height: 480},   // 4:3 (1.333)
+				{Width: 422, Height: 600},   // 0.703
+				{Width: 400, Height: 600},   // 2:3 (0.666)
+				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
+			},
+		},
+		{
+			name: "Fallback to width descending when aspect ratio is identical",
+			images: []models.Image{
+				{Width: 500, Height: 1000},  // Aspect: 2.0, Width: 500
+				{Width: 250, Height: 500},   // Aspect: 2.0, Width: 250
+				{Width: 1000, Height: 2000}, // Aspect: 2.0, Width: 1000
+			},
+			expected: []models.Image{
+				{Width: 1000, Height: 2000},
+				{Width: 500, Height: 1000},
+				{Width: 250, Height: 500},
+			},
+		},
+		{
+			name: "Handles zero dimensions safely",
+			images: []models.Image{
+				{Width: 1000, Height: 2000},
+				{Width: 0, Height: 1000},
+				{Width: 1000, Height: 0},
+				{Width: 0, Height: 0},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Copy the input slice so we don't mutate the test case definition
+			input := make([]models.Image, len(tt.images))
+			copy(input, tt.images)
+
+			OrderLandscape(input)
+
+			if tt.expected != nil {
+				assert.Equal(t, formatDims(tt.expected), formatDims(input))
+			}
+		})
+	}
+}
 
 func TestOrderPortrait(t *testing.T) {
 	tests := []struct {
@@ -18,19 +93,19 @@ func TestOrderPortrait(t *testing.T) {
 		{
 			name: "Sorts by distance from 2:3 ratio",
 			images: []models.Image{
-				{Width: 720, Height: 480}, // 4:3 (1.333)
+				{Width: 640, Height: 480},   // 4:3 (1.333)
 				{Width: 1920, Height: 1080}, // 16:9 (1.777)
 				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
-				{Width: 400, Height: 600}, // 2:3 (0.666) (ideal)
-				{Width: 600, Height: 400}, // 3:2 (1.5)
-				{Width: 422, Height: 600}, // 0.536
+				{Width: 400, Height: 600},   // 2:3 (0.666) (ideal)
+				{Width: 600, Height: 400},   // 3:2 (1.5)
+				{Width: 422, Height: 600},   // 0.703
 			},
 			expected: []models.Image{
-				{Width: 400, Height: 600}, // 2:3 (0.666) (ideal)
-				{Width: 422, Height: 600}, // 0.536
+				{Width: 400, Height: 600},   // 2:3 (0.666) (ideal)
+				{Width: 422, Height: 600},   // 0.703
 				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
-				{Width: 720, Height: 480}, // 4:3 (1.333)
-				{Width: 600, Height: 400}, // 3:2 (1.5)
+				{Width: 640, Height: 480},   // 4:3 (1.333)
+				{Width: 600, Height: 400},   // 3:2 (1.5)
 				{Width: 1920, Height: 1080}, // 16:9 (1.777)
 			},
 		},
@@ -38,7 +113,7 @@ func TestOrderPortrait(t *testing.T) {
 			name: "Fallback to height descending when aspect ratio is identical",
 			images: []models.Image{
 				{Width: 500, Height: 1000},  // Aspect: 2.0, Height: 1000
-				{Width: 250, Height: 500},  // Aspect: 2.0, Height: 500
+				{Width: 250, Height: 500},   // Aspect: 2.0, Height: 500
 				{Width: 1000, Height: 2000}, // Aspect: 2.0, Height: 2000
 			},
 			expected: []models.Image{
@@ -48,17 +123,14 @@ func TestOrderPortrait(t *testing.T) {
 			},
 		},
 		{
-			name: "Handles zero width safely",
+			name: "Handles zero dimensions safely",
 			images: []models.Image{
 				{Width: 0, Height: 1000},
 				{Width: 1000, Height: 2000},
+				{Width: 1000, Height: 0},
+				{Width: 0, Height: 0},
 			},
-			// The current sort logic returns false when a width is 0,
-			// meaning it won't swap them. It preserves the existing order relative to each other.
-			expected: []models.Image{
-				{Width: 0, Height: 1000},
-				{Width: 1000, Height: 2000},
-			},
+			expected: nil,
 		},
 	}
 
@@ -70,8 +142,8 @@ func TestOrderPortrait(t *testing.T) {
 
 			OrderPortrait(input)
 
-			if !reflect.DeepEqual(input, tt.expected) {
-				t.Errorf("OrderPortrait() = %v\nwant %v", input, tt.expected)
+			if tt.expected != nil {
+				assert.Equal(t, formatDims(tt.expected), formatDims(input))
 			}
 		})
 	}

--- a/internal/image/sort_test.go
+++ b/internal/image/sort_test.go
@@ -1,0 +1,76 @@
+package image
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stashapp/stash-box/internal/models"
+)
+
+func TestOrderPortrait(t *testing.T) {
+	tests := []struct {
+		name     string
+		images   []models.Image
+		expected []models.Image
+	}{
+		{
+			name: "Sorts by distance from 2:3 ratio",
+			images: []models.Image{
+				{Width: 720, Height: 480}, // 4:3 (1.333)
+				{Width: 1920, Height: 1080}, // 16:9 (1.777)
+				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
+				{Width: 400, Height: 600}, // 2:3 (0.666) (ideal)
+				{Width: 600, Height: 400}, // 3:2 (1.5)
+				{Width: 422, Height: 600}, // 0.536
+			},
+			expected: []models.Image{
+				{Width: 400, Height: 600}, // 2:3 (0.666) (ideal)
+				{Width: 422, Height: 600}, // 0.536
+				{Width: 1080, Height: 1920}, // 9:16 (0.5625)
+				{Width: 720, Height: 480}, // 4:3 (1.333)
+				{Width: 600, Height: 400}, // 3:2 (1.5)
+				{Width: 1920, Height: 1080}, // 16:9 (1.777)
+			},
+		},
+		{
+			name: "Fallback to height descending when aspect ratio is identical",
+			images: []models.Image{
+				{Width: 500, Height: 1000},  // Aspect: 2.0, Height: 1000
+				{Width: 250, Height: 500},  // Aspect: 2.0, Height: 500
+				{Width: 1000, Height: 2000}, // Aspect: 2.0, Height: 2000
+			},
+			expected: []models.Image{
+				{Width: 1000, Height: 2000},
+				{Width: 500, Height: 1000},
+				{Width: 250, Height: 500},
+			},
+		},
+		{
+			name: "Handles zero width safely",
+			images: []models.Image{
+				{Width: 0, Height: 1000},
+				{Width: 1000, Height: 2000},
+			},
+			// The current sort logic returns false when a width is 0,
+			// meaning it won't swap them. It preserves the existing order relative to each other.
+			expected: []models.Image{
+				{Width: 0, Height: 1000},
+				{Width: 1000, Height: 2000},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Copy the input slice so we don't mutate the test case definition
+			input := make([]models.Image, len(tt.images))
+			copy(input, tt.images)
+
+			OrderPortrait(input)
+
+			if !reflect.DeepEqual(input, tt.expected) {
+				t.Errorf("OrderPortrait() = %v\nwant %v", input, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/image/sort_test.go
+++ b/internal/image/sort_test.go
@@ -47,9 +47,9 @@ func TestOrderLandscape(t *testing.T) {
 		{
 			name: "Fallback to width descending when aspect ratio is identical",
 			images: []models.Image{
-				{Width: 500, Height: 1000},  // Aspect: 2.0, Width: 500
-				{Width: 250, Height: 500},   // Aspect: 2.0, Width: 250
-				{Width: 1000, Height: 2000}, // Aspect: 2.0, Width: 1000
+				{Width: 500, Height: 1000},  // Aspect: 0.5, Width: 500
+				{Width: 250, Height: 500},   // Aspect: 0.5, Width: 250
+				{Width: 1000, Height: 2000}, // Aspect: 0.5, Width: 1000
 			},
 			expected: []models.Image{
 				{Width: 1000, Height: 2000},
@@ -58,10 +58,22 @@ func TestOrderLandscape(t *testing.T) {
 			},
 		},
 		{
-			name: "Handles zero dimensions safely",
+			name: "Zero width images sort last (aspect 0.0)",
 			images: []models.Image{
-				{Width: 1000, Height: 2000},
+				{Width: 1920, Height: 1080}, // aspect 1.778
+				{Width: 0, Height: 1000},    // aspect 0.0
+				{Width: 640, Height: 480},   // aspect 1.333
+			},
+			expected: []models.Image{
+				{Width: 1920, Height: 1080},
+				{Width: 640, Height: 480},
 				{Width: 0, Height: 1000},
+			},
+		},
+		{
+			name: "Zero height images do not panic",
+			images: []models.Image{
+				{Width: 1920, Height: 1080},
 				{Width: 1000, Height: 0},
 				{Width: 0, Height: 0},
 			},
@@ -112,9 +124,9 @@ func TestOrderPortrait(t *testing.T) {
 		{
 			name: "Fallback to height descending when aspect ratio is identical",
 			images: []models.Image{
-				{Width: 500, Height: 1000},  // Aspect: 2.0, Height: 1000
-				{Width: 250, Height: 500},   // Aspect: 2.0, Height: 500
-				{Width: 1000, Height: 2000}, // Aspect: 2.0, Height: 2000
+				{Width: 500, Height: 1000},  // Aspect: 0.5, Height: 1000
+				{Width: 250, Height: 500},   // Aspect: 0.5, Height: 500
+				{Width: 1000, Height: 2000}, // Aspect: 0.5, Height: 2000
 			},
 			expected: []models.Image{
 				{Width: 1000, Height: 2000},
@@ -123,10 +135,22 @@ func TestOrderPortrait(t *testing.T) {
 			},
 		},
 		{
-			name: "Handles zero dimensions safely",
+			name: "Zero width images sort last (aspect 0.0, max distance from ideal)",
 			images: []models.Image{
+				{Width: 400, Height: 600},   // ideal 2:3, diff 0
+				{Width: 0, Height: 1000},    // aspect 0.0, diff 0.667
+				{Width: 1080, Height: 1920}, // 9:16 (0.5625), diff 0.104
+			},
+			expected: []models.Image{
+				{Width: 400, Height: 600},
+				{Width: 1080, Height: 1920},
 				{Width: 0, Height: 1000},
-				{Width: 1000, Height: 2000},
+			},
+		},
+		{
+			name: "Zero height images do not panic",
+			images: []models.Image{
+				{Width: 400, Height: 600},
 				{Width: 1000, Height: 0},
 				{Width: 0, Height: 0},
 			},


### PR DESCRIPTION
### Bug(?) fix: Use float division for aspect ratios
* When sorting landscape (scene) images and portrait (performer) images, integer division was being used to determine aspect ratio. This meant that, e.g., a 4:3 image (1.333) and a 16:9 image (1.777) would be considered to have equal aspect ratios, leaving the "tie" to be broken by prioritizing the image with wider pixel dimensions.
* I *believe* this was a bug, but if it's the intended behavior, that ought to be documented.

### Feature change: Performer image prioritization
* Prioritizes performer images by closeness to [StashDB Guidelines'](https://guidelines.stashdb.org/docs/performers/edit/performer-images/performer-aspect-ratio/) ideal 2:3 aspect ratio, by modifying OrderPortrait (performer images are the only use of this function).
  * I thought I'd heard that this was already the behavior, but that probably either regressed or was something I imagined.
  * Perhaps this isn't the ideal ordering, but it's subjective and seems reasonable to me. Open to alternatives!
* Inspired by my frustration with [this performer](https://stashdb.org/performers/019de86e-b937-7d17-9217-313531edd116)'s images, where I cropped the only face photo to 2:3 aspect ratio, but a photo without the performer's full face was shown as the first image.

### Adds unit tests for image sorting

## Notes
* I'm very new to golang, this is my first time working with the stash-box code, and this code was written with assistance from Antigravity/Gemini 3.1 Pro (though I do understand it, I think, and wrote a lot of it "by hand"). This is all to say: Please take a careful look to see if there's anything dumb in here.
* I have not tested this with a full stash-box instance, only with unit tests.