### PR TITLE
Switch image file backend from checksum to id paths

### DIFF
--- a/internal/storage/file.go
+++ b/internal/storage/file.go
@@ -19,15 +19,15 @@ func (s *FileBackend) WriteFile(file []byte, image *models.Image) error {
 
 	fileDir := config.GetImageLocation()
 
-	// check fileDir for the identical file
-	fn := GetImagePath(fileDir, image.Checksum)
-	if exists, _ := utils.FileExists(fn); exists {
-		// file already exists
+	path := GetImagePath(fileDir, image.ID.String())
+	if exists, _ := utils.FileExists(path); exists {
 		return nil
 	}
 
-	// write the file
-	path := GetImagePath(fileDir, image.Checksum)
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+
 	if err := os.WriteFile(path, file, os.FileMode(0644)); err != nil {
 		_ = os.Remove(path)
 		return err
@@ -37,12 +37,12 @@ func (s *FileBackend) WriteFile(file []byte, image *models.Image) error {
 }
 
 func (s *FileBackend) DestroyFile(image *models.Image) error {
-	return os.Remove(GetImagePath(config.GetImageLocation(), image.Checksum))
+	return os.Remove(GetImagePath(config.GetImageLocation(), image.ID.String()))
 }
 
 func (s *FileBackend) ReadFile(image models.Image) (io.ReadCloser, int64, error) {
 	fileDir := config.GetImageLocation()
-	path := GetImagePath(fileDir, image.Checksum)
+	path := GetImagePath(fileDir, image.ID.String())
 	stat, err := os.Stat(path)
 	if err != nil {
 		return nil, 0, err
@@ -52,6 +52,6 @@ func (s *FileBackend) ReadFile(image models.Image) (io.ReadCloser, int64, error)
 	return file, stat.Size(), err
 }
 
-func GetImagePath(imageDir string, checksum string) string {
-	return filepath.Join(imageDir, checksum)
+func GetImagePath(imageDir string, id string) string {
+	return filepath.Join(imageDir, shardedKey(id))
 }

--- a/internal/storage/image_backend.go
+++ b/internal/storage/image_backend.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stashapp/stash-box/internal/models"
 )
 
+func shardedKey(id string) string {
+	return id[0:2] + "/" + id[2:4] + "/" + id
+}
+
 type Backend interface {
 	WriteFile(file []byte, image *models.Image) error
 	DestroyFile(image *models.Image) error

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -45,7 +45,7 @@ func (s *S3Backend) DestroyFile(image *models.Image) error {
 	}
 
 	id := image.ID.String()
-	path := id[0:2] + "/" + id[2:4] + "/" + id
+	path := shardedKey(id)
 	err = minioClient.RemoveObject(context.TODO(), s3config.Bucket, path, minio.RemoveObjectOptions{})
 
 	if err != nil {
@@ -64,7 +64,7 @@ func uploadS3File(client *minio.Client, file []byte, bucket string, id string, h
 		contentType = "image/svg+xml"
 	}
 
-	path := id[0:2] + "/" + id[2:4] + "/" + id
+	path := shardedKey(id)
 	_, err := client.PutObject(
 		ctx,
 		bucket,
@@ -93,7 +93,7 @@ func (s *S3Backend) ReadFile(image models.Image) (io.ReadCloser, int64, error) {
 	}
 
 	id := image.ID.String()
-	path := id[0:2] + "/" + id[2:4] + "/" + id
+	path := shardedKey(id)
 
 	object, err := minioClient.GetObject(
 		ctx,

--- a/scripts/migrate_images_from_checksum_to_id.py
+++ b/scripts/migrate_images_from_checksum_to_id.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S uv run
+# /// script
+# dependencies = ["psycopg2-binary"]
+# ///
+"""
+Migrate image files from flat checksum-based paths to UUID-sharded paths.
+
+Old layout: {image_dir}/{checksum}
+New layout: {image_dir}/{id[0:2]}/{id[2:4]}/{id}
+
+Usage:
+    POSTGRES_DB="postgres://user@localhost/stash-box" ./migrate_images_from_checksum_to_id.py /path/to/images
+"""
+
+import os
+import sys
+import shutil
+import argparse
+import psycopg2
+
+
+def sharded_path(image_dir, image_id):
+    return os.path.join(image_dir, image_id[0:2], image_id[2:4], image_id)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate images from checksum to sharded UUID paths")
+    parser.add_argument("image_dir", help="Path to the image storage directory")
+    args = parser.parse_args()
+
+    image_dir = args.image_dir
+    db_url = os.environ.get("POSTGRES_DB")
+    if not db_url:
+        print("Error: POSTGRES_DB environment variable is not set", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isdir(image_dir):
+        print(f"Error: image directory does not exist: {image_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id, checksum FROM images")
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    moved = 0
+    skipped = 0
+    missing = 0
+
+    for image_id, checksum in rows:
+        image_id = str(image_id)
+        src = os.path.join(image_dir, checksum)
+        dst = sharded_path(image_dir, image_id)
+
+        if not os.path.exists(src):
+            missing += 1
+            continue
+
+        if os.path.exists(dst):
+            skipped += 1
+            continue
+
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.move(src, dst)
+        moved += 1
+
+    print(f"Done: {moved} moved, {skipped} already at destination, {missing} source files not found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stash-box already does checksumming, so storing by checksum doesn't dedupe anything.

Switching to id, same  as s3, makes it easier to switch between the two, and avoids issues with too many files in a single folder.

I've added a script to migrate.