### PR TITLE
Add support for sorting scenes by duration

### DIFF
--- a/frontend/src/components/list/SceneList.tsx
+++ b/frontend/src/components/list/SceneList.tsx
@@ -36,6 +36,7 @@ const sortOptions = [
   { value: SceneSortEnum.POPULARITY, label: "Popularity" },
   { value: SceneSortEnum.CREATED_AT, label: "Created At" },
   { value: SceneSortEnum.UPDATED_AT, label: "Updated At" },
+  { value: SceneSortEnum.DURATION, label: "Duration" },
 ];
 
 const favoriteOptions = [

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1973,6 +1973,7 @@ export type SceneQueryInput = {
 export enum SceneSortEnum {
   CREATED_AT = 'CREATED_AT',
   DATE = 'DATE',
+  DURATION = 'DURATION',
   POPULARITY = 'POPULARITY',
   TITLE = 'TITLE',
   TRENDING = 'TRENDING',

--- a/frontend/src/pages/users/UserFingerprintsList/UserFingerprintsList.tsx
+++ b/frontend/src/pages/users/UserFingerprintsList/UserFingerprintsList.tsx
@@ -34,6 +34,7 @@ const sortOptions = [
   { value: SceneSortEnum.TRENDING, label: "Trending" },
   { value: SceneSortEnum.CREATED_AT, label: "Created At" },
   { value: SceneSortEnum.UPDATED_AT, label: "Updated At" },
+  { value: SceneSortEnum.DURATION, label: "Duration" },
 ];
 
 export const UserFingerprintsList: FC<Props> = ({

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -229,6 +229,7 @@ type QueryScenesResultType {
 enum SceneSortEnum {
   TITLE
   DATE
+  DURATION
   TRENDING
   POPULARITY
   CREATED_AT

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 68
+	schemaVersion  = 69
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/69_scene_deleted_sort_duration_index.up.sql
+++ b/internal/database/migrations/postgres/69_scene_deleted_sort_duration_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX scenes_deleted_duration_id_idx ON scenes (duration DESC, id DESC) WHERE deleted = false;

--- a/internal/database/migrations/postgres/69_scene_deleted_sort_duration_index.up.sql
+++ b/internal/database/migrations/postgres/69_scene_deleted_sort_duration_index.up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX scenes_deleted_duration_id_idx ON scenes (duration DESC, id DESC) WHERE deleted = false;
+CREATE INDEX scenes_deleted_duration_id_idx ON scenes (duration DESC NULLS LAST, id DESC) WHERE deleted = false;

--- a/internal/models/generated_exec.go
+++ b/internal/models/generated_exec.go
@@ -5915,6 +5915,7 @@ type QueryScenesResultType {
 enum SceneSortEnum {
   TITLE
   DATE
+  DURATION
   TRENDING
   POPULARITY
   CREATED_AT

--- a/internal/models/generated_models.go
+++ b/internal/models/generated_models.go
@@ -2224,6 +2224,7 @@ type SceneSortEnum string
 const (
 	SceneSortEnumTitle      SceneSortEnum = "TITLE"
 	SceneSortEnumDate       SceneSortEnum = "DATE"
+	SceneSortEnumDuration   SceneSortEnum = "DURATION"
 	SceneSortEnumTrending   SceneSortEnum = "TRENDING"
 	SceneSortEnumPopularity SceneSortEnum = "POPULARITY"
 	SceneSortEnumCreatedAt  SceneSortEnum = "CREATED_AT"
@@ -2233,6 +2234,7 @@ const (
 var AllSceneSortEnum = []SceneSortEnum{
 	SceneSortEnumTitle,
 	SceneSortEnumDate,
+	SceneSortEnumDuration,
 	SceneSortEnumTrending,
 	SceneSortEnumPopularity,
 	SceneSortEnumCreatedAt,
@@ -2241,7 +2243,7 @@ var AllSceneSortEnum = []SceneSortEnum{
 
 func (e SceneSortEnum) IsValid() bool {
 	switch e {
-	case SceneSortEnumTitle, SceneSortEnumDate, SceneSortEnumTrending, SceneSortEnumPopularity, SceneSortEnumCreatedAt, SceneSortEnumUpdatedAt:
+	case SceneSortEnumTitle, SceneSortEnumDate, SceneSortEnumDuration, SceneSortEnumTrending, SceneSortEnumPopularity, SceneSortEnumCreatedAt, SceneSortEnumUpdatedAt:
 		return true
 	}
 	return false

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -262,7 +262,11 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 			if input.Sort != models.SceneSortEnumTitle {
 				secondary = "id"
 			}
-			query = query.OrderBy(fmt.Sprintf("scenes.%s %s, scenes.%s %s", sortField, sortDir, secondary, sortDir))
+			nullsClause := ""
+			if input.Sort == models.SceneSortEnumDuration {
+				nullsClause = " NULLS LAST"
+			}
+			query = query.OrderBy(fmt.Sprintf("scenes.%s %s%s, scenes.%s %s", sortField, sortDir, nullsClause, secondary, sortDir))
 			query = queryhelper.ApplyPagination(query, input.Page, input.PerPage)
 		}
 	}


### PR DESCRIPTION
Implements feature request from #930 to support sorting a performer's scenes by duration, as well as in other scene list views.

Tested manually on a local `stash-box` instance, and with an [integration test](https://github.com/stashapp/stash-box/commit/0e0553c3bd32573c1d3409bf2ae91562e18396b5). I've chosen to not include that test in this PR under the questionable logic of "if sorting was something that ought to be tested, there would already be tests for it". If it's appropriate to test scene sorting, I'd be happy to add tests for all sort options.

LLM use (Antigravity/Gemini): Implemented "by hand"... kind of. Used LLM-based tab completion. Above test was written entirely by LLM.