### PR TITLE
Fix typos and normalize British->American English spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `s3.endpoint` | (none) | Hostname to s3 endpoint used for image storage. |
 | `s3.bucket` | (none) | Name of S3 bucket used to store images. |
 | `s3.access_key` | (none) | Access key used for authentication. |
-| `s3.secret ` | (none) | Secret Access key used for authentication. |
+| `s3.secret` | (none) | Secret Access key used for authentication. |
 | `s3.max_dimension` | (none) | If set, a resized copy will be created for any image whose dimensions exceed this number. This copy will be served in place of the original. |
 | `s3.upload_headers` | (none) | A map of headers to send with each upload request. For example, DigitalOcean requires the `x-amz-acl` header to be set to `public-read` or it does not make the uploaded images available. |
-| `phash_distance` | 0 | Determines what binary distance is considered a match when querying with a pHash fingeprint. Using more than 8 is not recommended and may lead to large amounts of false positives. **Note**: The [pg-spgist_hamming extension](#phash-distance-matching) must be installed to use distance matching, otherwise you will get errors. |
+| `phash_distance` | 0 | Determines what binary distance is considered a match when querying with a pHash fingerprint. Using more than 8 is not recommended and may lead to large amounts of false positives. **Note**: The [pg-spgist_hamming extension](#phash-distance-matching) must be installed to use distance matching, otherwise you will get errors. |
 | `favicon_path` | (none) | Location where favicons for linked sites should be stored. Leave empty to disable. |
 | `draft_time_limit` | (24h) | Time, in seconds, before a draft is deleted. |
 | `profiler_port` | 0 | Port on which to serve pprof output. Omit to disable entirely. |

--- a/e2e/support/helpers/seed.ts
+++ b/e2e/support/helpers/seed.ts
@@ -196,7 +196,7 @@ export const randomHex = (len: number) =>
  * IMPORTANT: defaults to OSHASH/16-char hash. The server's
  * FingerprintHash scalar is int64-backed; MD5 (32 hex chars) overflows and
  * is silently dropped (commit 8d45dad3 made this explicit). Tests that need
- * MD5-specific behaviour should pass a 16-char hash anyway — the API will
+ * MD5-specific behavior should pass a 16-char hash anyway — the API will
  * happily round-trip it as MD5.
  */
 export async function submitFingerprint(

--- a/e2e/support/helpers/workflow.ts
+++ b/e2e/support/helpers/workflow.ts
@@ -60,7 +60,7 @@ export async function voteOnEdit(
   vote: "Yes" | "No" | "Abstain",
 ) {
   await page.goto(`/edits/${editId}`);
-  // VoteBar renders three radios labelled Yes / No / Abstain inside a form
+  // VoteBar renders three radios labeled Yes / No / Abstain inside a form
   // group with the edit id in the controlId. A "Save" button appears once a
   // new vote is selected.
   await page.getByText(vote, { exact: true }).first().click();

--- a/e2e/tests/auth/account.spec.ts
+++ b/e2e/tests/auth/account.spec.ts
@@ -68,7 +68,7 @@ test("change own password, log in with new password", async ({ browser }) => {
 test("regenerate API key issues a new key and invalidates the old one", async () => {
   // Drive via GraphQL — `regenerateAPIKey` is a single mutation; testing the
   // UI button click on top would only validate the click handler. The
-  // behavioural check (old key stops working, new key works) is what matters.
+  // behavioral check (old key stops working, new key works) is what matters.
   const api = await graphqlAs("e2e_read");
 
   // Fetch current key.

--- a/e2e/tests/entities/scene-fingerprints.spec.ts
+++ b/e2e/tests/entities/scene-fingerprints.spec.ts
@@ -109,7 +109,7 @@ test("moderator can delete a fingerprint via the UI", async ({ adminPage }) => {
   const row = adminPage.locator("tr").filter({ hasText: hash });
   await row.getByRole("checkbox").check();
 
-  // The toolbar button is labelled "Move Selected (N)" / "Delete Selected (N)";
+  // The toolbar button is labeled "Move Selected (N)" / "Delete Selected (N)";
   // use a regex so we don't care about the count number.
   await adminPage.getByRole("button", { name: /Delete Selected/i }).click();
   // Modal: red "Delete" button. The page also has a top-level "Delete" link
@@ -173,7 +173,7 @@ test("user can unmatch their own fingerprint submission", async ({}) => {
   // The "user_submitted" check controls visibility of the unmatch icon. Drive
   // submission + unmatch as the same user, then verify via the unmatch
   // mutation directly (the UI uses an icon-only button which is brittle to
-  // address through the DOM). This keeps the test as a behavioural assertion
+  // address through the DOM). This keeps the test as a behavioral assertion
   // on the mutation rather than the icon click.
   const admin = await adminApi();
   const studio = await createStudio(admin);

--- a/e2e/tests/search-and-list.spec.ts
+++ b/e2e/tests/search-and-list.spec.ts
@@ -1,4 +1,4 @@
-// Tier 4 — search + list-page behaviour. Search and pagination are
+// Tier 4 — search + list-page behavior. Search and pagination are
 // load-bearing for users browsing the catalogue; keep this small but cover
 // the smoke shape.
 
@@ -37,7 +37,7 @@ test("/edits status filter persists in URL", async ({ adminPage }) => {
 test("studios list paginates: page=2 URL stays on /studios", async ({
   adminPage,
 }) => {
-  // Cheaply assert the pagination URL pattern works. Real pagination behaviour
+  // Cheaply assert the pagination URL pattern works. Real pagination behavior
   // (clicking next, page=2) depends on having >40 studios; instead we hit
   // page=2 directly and assert the page renders without errors.
   await adminPage.goto("/studios?page=2");

--- a/frontend/src/components/editCard/EditStatus.tsx
+++ b/frontend/src/components/editCard/EditStatus.tsx
@@ -31,10 +31,10 @@ const EditStatus: FC<Props> = ({ closed, status }) => {
       tooltip = "Edit did not get sufficient votes to pass.";
       break;
     case VoteStatusEnum.CANCELED:
-      tooltip = "Edit was cancelled by the editor.";
+      tooltip = "Edit was canceled by the editor.";
       break;
     case VoteStatusEnum.IMMEDIATE_REJECTED:
-      tooltip = "Edit was cancelled by an admin.";
+      tooltip = "Edit was canceled by an admin.";
       break;
     case VoteStatusEnum.FAILED:
       tooltip =

--- a/frontend/src/pages/edits/Edit.tsx
+++ b/frontend/src/pages/edits/Edit.tsx
@@ -36,7 +36,7 @@ const EditComponent: FC = () => {
   const [showCancel, setShowCancel] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
   const { data, loading } = useEdit({ id: id ?? "" }, !id);
-  const [cancelEdit, { loading: cancelling }] = useCancelEdit();
+  const [cancelEdit, { loading: canceling }] = useCancelEdit();
   const [approveEdit, { loading: applying }] = useApproveEdit();
 
   if (loading) return <LoadingIndicator message="Loading..." />;
@@ -79,7 +79,7 @@ const EditComponent: FC = () => {
     />
   );
 
-  const mutating = cancelling || applying;
+  const mutating = canceling || applying;
 
   // Update Edit is owner-only (and admin via implies). Cancel Edit is
   // available to the owner, any moderator, or admin (see Edit.Cancel in

--- a/internal/api/edit_integration_test.go
+++ b/internal/api/edit_integration_test.go
@@ -341,7 +341,7 @@ func (s *editTestRunner) testQueryEdits() {
 	appliedEdit, err := s.approveEdit(tagEdit1.ID)
 	assert.NoError(s.t, err)
 
-	// Cancel one edit to have a cancelled edit
+	// Cancel one edit to have a canceled edit
 	_, err = s.resolver.Mutation().CancelEdit(s.ctx, models.CancelEditInput{
 		ID: studioEdit1.ID,
 	})
@@ -547,7 +547,7 @@ func (s *editTestRunner) testQueryEdits() {
 		}
 	}
 
-	// Test 11: Query cancelled edits
+	// Test 11: Query canceled edits
 	result, err = s.resolver.Query().QueryEdits(s.ctx, models.EditQueryInput{
 		Status:    &[]models.VoteStatusEnum{models.VoteStatusEnumCanceled}[0],
 		Page:      1,
@@ -560,9 +560,9 @@ func (s *editTestRunner) testQueryEdits() {
 	editsResult, err = s.resolver.QueryEditsResultType().Edits(s.ctx, result)
 	assert.NoError(s.t, err)
 
-	assert.True(s.t, len(editsResult) >= 1, "Should have at least 1 cancelled edit")
+	assert.True(s.t, len(editsResult) >= 1, "Should have at least 1 canceled edit")
 	for _, edit := range editsResult {
-		assert.Equal(s.t, edit.Status, models.VoteStatusEnumCanceled.String(), "All returned edits should be cancelled")
+		assert.Equal(s.t, edit.Status, models.VoteStatusEnumCanceled.String(), "All returned edits should be canceled")
 	}
 }
 

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // we need to create some users to test the api with, otherwise all calls
-// will be unauthorised
+// will be unauthorized
 type userPopulator struct {
 	none          *models.User
 	read          *models.User

--- a/internal/api/performer_edit_integration_test.go
+++ b/internal/api/performer_edit_integration_test.go
@@ -1142,7 +1142,7 @@ func (s *performerEditTestRunner) testQueryExistingPerformer() {
 			}
 		}
 	`, testURL), &resp3)
-	assert.True(s.t, len(resp3.QueryExistingPerformer.Edits) == 0, "Should not find cancelled edit")
+	assert.True(s.t, len(resp3.QueryExistingPerformer.Edits) == 0, "Should not find canceled edit")
 
 	// Test 4: Create an actual performer (without disambiguation) and verify it appears in results
 	performerName2 := "Test Performer Name 2"

--- a/internal/api/performer_integration_test.go
+++ b/internal/api/performer_integration_test.go
@@ -227,7 +227,7 @@ func (s *performerTestRunner) testUpdatePerformer() {
 		},
 	}
 
-	// need some mocking of the context to make the field ignore behaviour work
+	// need some mocking of the context to make the field ignore behavior work
 	ctx := s.updateContext([]string{
 		"aliases",
 		"urls",

--- a/internal/api/studio_integration_test.go
+++ b/internal/api/studio_integration_test.go
@@ -91,7 +91,7 @@ func (s *studioTestRunner) testUpdateStudioName() {
 		Name: &updatedName,
 	}
 
-	// need some mocking of the context to make the field ignore behaviour work
+	// need some mocking of the context to make the field ignore behavior work
 	ctx := s.updateContext([]string{
 		"name",
 	})

--- a/internal/api/user_integration_test.go
+++ b/internal/api/user_integration_test.go
@@ -124,7 +124,7 @@ func (s *userTestRunner) testUpdateUserName() {
 		Name: &updatedName,
 	}
 
-	// need some mocking of the context to make the field ignore behaviour work
+	// need some mocking of the context to make the field ignore behavior work
 	ctx := s.updateContext([]string{
 		"name",
 	})
@@ -155,7 +155,7 @@ func (s *userTestRunner) testUpdatePassword() {
 		Password: &updatedPassword,
 	}
 
-	// need some mocking of the context to make the field ignore behaviour work
+	// need some mocking of the context to make the field ignore behavior work
 	ctx := s.updateContext([]string{
 		"password",
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,8 +257,8 @@ func GetEmailFrom() string {
 }
 
 // GetEmailTLSMode returns the configured STARTTLS policy for the SMTP client.
-// Recognised values: "mandatory" (default), "opportunistic", "none". Anything
-// else falls back to "mandatory" to preserve secure-by-default behaviour.
+// Recognized values: "mandatory" (default), "opportunistic", "none". Anything
+// else falls back to "mandatory" to preserve secure-by-default behavior.
 func GetEmailTLSMode() string {
 	switch C.EmailTLSMode {
 	case "opportunistic", "none":


### PR DESCRIPTION
Fixes various typos and British English spellings across the codebase to match the project's American English convention.

### Changes
- fingeprint -> fingerprint (README.md)
- s3.secret trailing space removed (README.md)
- behaviour -> behavior (10 instances)
- behavioural -> behavioral (2 instances)
- cancelled -> canceled (7 instances)
- cancelling -> canceling (2 instances, variable rename)
- labelled -> labeled (2 instances)
- unauthorised -> unauthorized
- Recognised -> Recognized