### PR TITLE
Tweak performer alias search scoring

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 57
+	schemaVersion  = 58
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/58_performer_alias_fieldnorms.up.sql
+++ b/internal/database/migrations/postgres/58_performer_alias_fieldnorms.up.sql
@@ -1,0 +1,13 @@
+DROP INDEX performer_search_bm25_idx;
+CREATE INDEX performer_search_bm25_idx ON performer_search
+USING bm25 (
+    performer_id,
+    name,
+    disambiguation,
+    aliases,
+    (gender::pdb.literal)
+)
+WITH (
+    key_field='performer_id',
+    text_fields='{"aliases": {"fieldnorms": false, "record": "basic"}}'
+);


### PR DESCRIPTION
Disables length normalization and frequency tracking for performer aliases, so performers with many aliases aren't penalized in search scoring, or boosted if they have a lot of aliases matching the search term.