### PR TITLE
Fix moving fingerprints when they exist on both source and target

### DIFF
--- a/internal/api/scene_integration_test.go
+++ b/internal/api/scene_integration_test.go
@@ -1145,9 +1145,76 @@ func (s *sceneTestRunner) testDeleteFingerprintSubmissions() {
 	assert.Equal(s.t, initialCount-2, len(updatedScene.Fingerprints), "Should have 2 fewer fingerprints")
 }
 
+func (s *sceneTestRunner) testMoveFingerprintSubmissionsWithDuplicates() {
+	// Reproduces the bug where the same user submitted the same fingerprint to
+	// both source and target — the move must not violate the unique constraint.
+	scene1, err := s.createTestScene(nil)
+	assert.Nil(s.t, err)
+	scene2, err := s.createTestScene(nil)
+	assert.Nil(s.t, err)
+
+	fp := s.generateSceneFingerprintWithAlgorithm(models.FingerprintAlgorithmPhash, nil)
+
+	// Same user submits the same fingerprint to both scenes.
+	_, err = s.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: scene1.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      fp.Hash,
+			Algorithm: fp.Algorithm,
+			Duration:  fp.Duration,
+		},
+	})
+	assert.Nil(s.t, err)
+
+	_, err = s.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: scene2.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      fp.Hash,
+			Algorithm: fp.Algorithm,
+			Duration:  fp.Duration,
+		},
+	})
+	assert.Nil(s.t, err)
+
+	moderateUser, err := s.createTestUser(nil, []models.RoleEnum{models.RoleEnumModerate})
+	assert.Nil(s.t, err)
+	moderateRunner := createTestRunner(s.t, moderateUser, []models.RoleEnum{models.RoleEnumModerate})
+
+	_, err = moderateRunner.client.sceneMoveFingerprintSubmissions(models.MoveFingerprintSubmissionsInput{
+		Fingerprints: []models.FingerprintQueryInput{
+			{Hash: fp.Hash, Algorithm: fp.Algorithm},
+		},
+		SourceSceneID: scene1.UUID(),
+		TargetSceneID: scene2.UUID(),
+	})
+	assert.Nil(s.t, err)
+
+	updatedScene1, err := s.client.findScene(scene1.UUID())
+	assert.Nil(s.t, err)
+	for _, sceneFP := range updatedScene1.Fingerprints {
+		assert.False(s.t, sceneFP.FingerprintHash() == fp.Hash && sceneFP.Algorithm == fp.Algorithm,
+			"Fingerprint should no longer be on source scene")
+	}
+
+	updatedScene2, err := s.client.findScene(scene2.UUID())
+	assert.Nil(s.t, err)
+	found := false
+	for _, sceneFP := range updatedScene2.Fingerprints {
+		if sceneFP.FingerprintHash() == fp.Hash && sceneFP.Algorithm == fp.Algorithm {
+			found = true
+		}
+	}
+	assert.True(s.t, found, "Fingerprint should remain on target scene")
+}
+
 func TestMoveFingerprintSubmissions(t *testing.T) {
 	pt := createSceneTestRunner(t)
 	pt.testMoveFingerprintSubmissions()
+}
+
+func TestMoveFingerprintSubmissionsWithDuplicates(t *testing.T) {
+	pt := createSceneTestRunner(t)
+	pt.testMoveFingerprintSubmissionsWithDuplicates()
 }
 
 func TestDeleteFingerprintSubmissions(t *testing.T) {

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -90,6 +90,43 @@ func (q *Queries) DeleteAllSceneFingerprintSubmissions(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
+const deleteDuplicateSceneFingerprintSubmissions = `-- name: DeleteDuplicateSceneFingerprintSubmissions :execrows
+DELETE FROM scene_fingerprints SFP
+USING fingerprints FP
+WHERE SFP.fingerprint_id = FP.id
+  AND FP.hash = $1
+  AND FP.algorithm = $2
+  AND SFP.scene_id = $3
+  AND EXISTS (
+    SELECT 1 FROM scene_fingerprints SFP2
+    WHERE SFP2.scene_id = $4
+      AND SFP2.fingerprint_id = SFP.fingerprint_id
+      AND SFP2.user_id = SFP.user_id
+  )
+`
+
+type DeleteDuplicateSceneFingerprintSubmissionsParams struct {
+	Hash          int64     `db:"hash" json:"hash"`
+	Algorithm     string    `db:"algorithm" json:"algorithm"`
+	SourceSceneID uuid.UUID `db:"source_scene_id" json:"source_scene_id"`
+	TargetSceneID uuid.UUID `db:"target_scene_id" json:"target_scene_id"`
+}
+
+// Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
+// so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
+func (q *Queries) DeleteDuplicateSceneFingerprintSubmissions(ctx context.Context, arg DeleteDuplicateSceneFingerprintSubmissionsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDuplicateSceneFingerprintSubmissions,
+		arg.Hash,
+		arg.Algorithm,
+		arg.SourceSceneID,
+		arg.TargetSceneID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteSceneFingerprint = `-- name: DeleteSceneFingerprint :exec
 DELETE FROM scene_fingerprints SFP
 USING fingerprints FP
@@ -260,19 +297,6 @@ func (q *Queries) GetFingerprint(ctx context.Context, arg GetFingerprintParams) 
 }
 
 const moveSceneFingerprintSubmissions = `-- name: MoveSceneFingerprintSubmissions :execrows
-WITH to_move AS (
-  SELECT SFP.fingerprint_id, SFP.user_id
-  FROM scene_fingerprints SFP
-  JOIN fingerprints FP ON SFP.fingerprint_id = FP.id
-  WHERE FP.hash = $2
-    AND FP.algorithm = $3
-    AND SFP.scene_id = $4
-),
-deleted AS (
-  DELETE FROM scene_fingerprints
-  WHERE scene_id = $1
-    AND (fingerprint_id, user_id) IN (SELECT fingerprint_id, user_id FROM to_move)
-)
 UPDATE scene_fingerprints SFP
 SET scene_id = $1
 FROM fingerprints FP

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -92,6 +92,9 @@ type Querier interface {
 	CreateUserToken(ctx context.Context, arg CreateUserTokenParams) (UserToken, error)
 	DeleteAllSceneFingerprintSubmissions(ctx context.Context, arg DeleteAllSceneFingerprintSubmissionsParams) (int64, error)
 	DeleteDraft(ctx context.Context, id uuid.UUID) error
+	// Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
+	// so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
+	DeleteDuplicateSceneFingerprintSubmissions(ctx context.Context, arg DeleteDuplicateSceneFingerprintSubmissionsParams) (int64, error)
 	DeleteEdit(ctx context.Context, id uuid.UUID) error
 	DeleteExpiredDrafts(ctx context.Context, dollar_1 interface{}) error
 	DeleteExpiredModAudits(ctx context.Context, dollar_1 interface{}) error

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -69,20 +69,23 @@ WHERE SFP.scene_id = ANY(sqlc.arg(scene_ids)::UUID[])
 GROUP BY SFP.scene_id, FP.algorithm, FP.hash
 ORDER BY net_submissions DESC;
 
+-- name: DeleteDuplicateSceneFingerprintSubmissions :execrows
+-- Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
+-- so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
+DELETE FROM scene_fingerprints SFP
+USING fingerprints FP
+WHERE SFP.fingerprint_id = FP.id
+  AND FP.hash = sqlc.arg(hash)
+  AND FP.algorithm = sqlc.arg(algorithm)
+  AND SFP.scene_id = sqlc.arg(source_scene_id)
+  AND EXISTS (
+    SELECT 1 FROM scene_fingerprints SFP2
+    WHERE SFP2.scene_id = sqlc.arg(target_scene_id)
+      AND SFP2.fingerprint_id = SFP.fingerprint_id
+      AND SFP2.user_id = SFP.user_id
+  );
+
 -- name: MoveSceneFingerprintSubmissions :execrows
-WITH to_move AS (
-  SELECT SFP.fingerprint_id, SFP.user_id
-  FROM scene_fingerprints SFP
-  JOIN fingerprints FP ON SFP.fingerprint_id = FP.id
-  WHERE FP.hash = sqlc.arg(hash)
-    AND FP.algorithm = sqlc.arg(algorithm)
-    AND SFP.scene_id = sqlc.arg(source_scene_id)
-),
-deleted AS (
-  DELETE FROM scene_fingerprints
-  WHERE scene_id = sqlc.arg(target_scene_id)
-    AND (fingerprint_id, user_id) IN (SELECT fingerprint_id, user_id FROM to_move)
-)
 UPDATE scene_fingerprints SFP
 SET scene_id = sqlc.arg(target_scene_id)
 FROM fingerprints FP

--- a/internal/service/scene/service.go
+++ b/internal/service/scene/service.go
@@ -676,7 +676,18 @@ func (s *Scene) MoveFingerprintSubmissions(ctx context.Context, input models.Mov
 
 		// Move each fingerprint
 		for _, fp := range input.Fingerprints {
-			rowsAffected, err := txnQueries.MoveSceneFingerprintSubmissions(ctx, queries.MoveSceneFingerprintSubmissionsParams{
+			// Drop source rows that would collide with an existing target submission
+			deduped, err := txnQueries.DeleteDuplicateSceneFingerprintSubmissions(ctx, queries.DeleteDuplicateSceneFingerprintSubmissionsParams{
+				Hash:          fp.Hash.Int64(),
+				Algorithm:     fp.Algorithm.String(),
+				SourceSceneID: input.SourceSceneID,
+				TargetSceneID: input.TargetSceneID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to deduplicate fingerprint %s (%s): %w", fp.Hash.Hex(), fp.Algorithm, err)
+			}
+
+			moved, err := txnQueries.MoveSceneFingerprintSubmissions(ctx, queries.MoveSceneFingerprintSubmissionsParams{
 				Hash:          fp.Hash.Int64(),
 				Algorithm:     fp.Algorithm.String(),
 				TargetSceneID: input.TargetSceneID,
@@ -685,7 +696,7 @@ func (s *Scene) MoveFingerprintSubmissions(ctx context.Context, input models.Mov
 			if err != nil {
 				return fmt.Errorf("failed to move fingerprint %s (%s): %w", fp.Hash.Hex(), fp.Algorithm, err)
 			}
-			if rowsAffected == 0 {
+			if deduped+moved == 0 {
 				return fmt.Errorf("fingerprint %s (%s) not found on source scene", fp.Hash.Hex(), fp.Algorithm)
 			}
 		}


### PR DESCRIPTION
Drafted with claude.

Updated move fingerprint to delete dupe fingerprints before moving. Deleting as part of query in CTE does not satisfy constraint resolver.