### PR TITLE
Remove reported fingerprints on fp move

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -23,12 +23,14 @@ type performerAppearance struct {
 }
 
 type fingerprint struct {
-	Hash        string                      `json:"hash"`
-	Algorithm   models.FingerprintAlgorithm `json:"algorithm"`
-	Duration    int                         `json:"duration"`
-	Submissions int                         `json:"submissions"`
-	Created     string                      `json:"created"`
-	Updated     string                      `json:"updated"`
+	Hash         string                      `json:"hash"`
+	Algorithm    models.FingerprintAlgorithm `json:"algorithm"`
+	Duration     int                         `json:"duration"`
+	Submissions  int                         `json:"submissions"`
+	Reports      int                         `json:"reports"`
+	UserReported bool                        `json:"user_reported"`
+	Created      string                      `json:"created"`
+	Updated      string                      `json:"updated"`
 }
 
 // FingerprintHash returns the Hash as a models.FingerprintHash

--- a/internal/api/scene_integration_test.go
+++ b/internal/api/scene_integration_test.go
@@ -1217,6 +1217,84 @@ func TestMoveFingerprintSubmissionsWithDuplicates(t *testing.T) {
 	pt.testMoveFingerprintSubmissionsWithDuplicates()
 }
 
+func TestMoveFingerprintSubmissionsClearsReports(t *testing.T) {
+	pt := createSceneTestRunner(t)
+	pt.testMoveFingerprintSubmissionsClearsReports()
+}
+
+func (s *sceneTestRunner) testMoveFingerprintSubmissionsClearsReports() {
+	// Reports against a fingerprint reflect a mismatch on the source scene, so
+	// once a moderator moves the fingerprint to its correct scene the report no
+	// longer applies and must not follow the fingerprint.
+	scene1, err := s.createTestScene(nil)
+	assert.Nil(s.t, err)
+	scene2, err := s.createTestScene(nil)
+	assert.Nil(s.t, err)
+
+	fp := s.generateSceneFingerprintWithAlgorithm(models.FingerprintAlgorithmOshash, nil)
+
+	// Admin submits the fingerprint so there is something to report against.
+	_, err = s.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: scene1.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      fp.Hash,
+			Algorithm: fp.Algorithm,
+			Duration:  fp.Duration,
+		},
+	})
+	assert.Nil(s.t, err)
+
+	// A second user reports it as a bad match.
+	reporter, err := s.createTestUser(nil, []models.RoleEnum{models.RoleEnumEdit})
+	assert.Nil(s.t, err)
+	reporterRunner := createTestRunner(s.t, reporter, []models.RoleEnum{models.RoleEnumEdit})
+	reportVote := models.FingerprintSubmissionTypeInvalid
+	_, err = reporterRunner.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: scene1.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      fp.Hash,
+			Algorithm: fp.Algorithm,
+			Duration:  fp.Duration,
+		},
+		Vote: &reportVote,
+	})
+	assert.Nil(s.t, err)
+
+	preMove, err := s.client.findScene(scene1.UUID())
+	assert.Nil(s.t, err)
+	var reportsBefore int
+	for _, sceneFP := range preMove.Fingerprints {
+		if sceneFP.FingerprintHash() == fp.Hash && sceneFP.Algorithm == fp.Algorithm {
+			reportsBefore = sceneFP.Reports
+		}
+	}
+	assert.Equal(s.t, 1, reportsBefore, "scene1 should have one report before the move")
+
+	moderateUser, err := s.createTestUser(nil, []models.RoleEnum{models.RoleEnumModerate})
+	assert.Nil(s.t, err)
+	moderateRunner := createTestRunner(s.t, moderateUser, []models.RoleEnum{models.RoleEnumModerate})
+
+	_, err = moderateRunner.client.sceneMoveFingerprintSubmissions(models.MoveFingerprintSubmissionsInput{
+		Fingerprints: []models.FingerprintQueryInput{
+			{Hash: fp.Hash, Algorithm: fp.Algorithm},
+		},
+		SourceSceneID: scene1.UUID(),
+		TargetSceneID: scene2.UUID(),
+	})
+	assert.Nil(s.t, err)
+
+	updatedScene2, err := s.client.findScene(scene2.UUID())
+	assert.Nil(s.t, err)
+	found := false
+	for _, sceneFP := range updatedScene2.Fingerprints {
+		if sceneFP.FingerprintHash() == fp.Hash && sceneFP.Algorithm == fp.Algorithm {
+			found = true
+			assert.Equal(s.t, 0, sceneFP.Reports, "report should not follow the moved fingerprint")
+		}
+	}
+	assert.True(s.t, found, "moved fingerprint should appear on the target scene")
+}
+
 func TestDeleteFingerprintSubmissions(t *testing.T) {
 	pt := createSceneTestRunner(t)
 	pt.testDeleteFingerprintSubmissions()

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -90,43 +90,6 @@ func (q *Queries) DeleteAllSceneFingerprintSubmissions(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
-const deleteDuplicateSceneFingerprintSubmissions = `-- name: DeleteDuplicateSceneFingerprintSubmissions :execrows
-DELETE FROM scene_fingerprints SFP
-USING fingerprints FP
-WHERE SFP.fingerprint_id = FP.id
-  AND FP.hash = $1
-  AND FP.algorithm = $2
-  AND SFP.scene_id = $3
-  AND EXISTS (
-    SELECT 1 FROM scene_fingerprints SFP2
-    WHERE SFP2.scene_id = $4
-      AND SFP2.fingerprint_id = SFP.fingerprint_id
-      AND SFP2.user_id = SFP.user_id
-  )
-`
-
-type DeleteDuplicateSceneFingerprintSubmissionsParams struct {
-	Hash          int64     `db:"hash" json:"hash"`
-	Algorithm     string    `db:"algorithm" json:"algorithm"`
-	SourceSceneID uuid.UUID `db:"source_scene_id" json:"source_scene_id"`
-	TargetSceneID uuid.UUID `db:"target_scene_id" json:"target_scene_id"`
-}
-
-// Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
-// so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
-func (q *Queries) DeleteDuplicateSceneFingerprintSubmissions(ctx context.Context, arg DeleteDuplicateSceneFingerprintSubmissionsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, deleteDuplicateSceneFingerprintSubmissions,
-		arg.Hash,
-		arg.Algorithm,
-		arg.SourceSceneID,
-		arg.TargetSceneID,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const deleteSceneFingerprint = `-- name: DeleteSceneFingerprint :exec
 DELETE FROM scene_fingerprints SFP
 USING fingerprints FP
@@ -319,6 +282,48 @@ func (q *Queries) MoveSceneFingerprintSubmissions(ctx context.Context, arg MoveS
 		arg.Hash,
 		arg.Algorithm,
 		arg.SourceSceneID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const pruneSceneFingerprintsForMove = `-- name: PruneSceneFingerprintsForMove :execrows
+DELETE FROM scene_fingerprints SFP
+USING fingerprints FP
+WHERE SFP.fingerprint_id = FP.id
+  AND FP.hash = $1
+  AND FP.algorithm = $2
+  AND SFP.scene_id = $3
+  AND (
+    SFP.vote = -1
+    OR EXISTS (
+      SELECT 1 FROM scene_fingerprints SFP2
+      WHERE SFP2.scene_id = $4
+        AND SFP2.fingerprint_id = SFP.fingerprint_id
+        AND SFP2.user_id = SFP.user_id
+    )
+  )
+`
+
+type PruneSceneFingerprintsForMoveParams struct {
+	Hash          int64     `db:"hash" json:"hash"`
+	Algorithm     string    `db:"algorithm" json:"algorithm"`
+	SourceSceneID uuid.UUID `db:"source_scene_id" json:"source_scene_id"`
+	TargetSceneID uuid.UUID `db:"target_scene_id" json:"target_scene_id"`
+}
+
+// Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
+//   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
+//   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
+//     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
+func (q *Queries) PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) (int64, error) {
+	result, err := q.db.Exec(ctx, pruneSceneFingerprintsForMove,
+		arg.Hash,
+		arg.Algorithm,
+		arg.SourceSceneID,
+		arg.TargetSceneID,
 	)
 	if err != nil {
 		return 0, err

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -314,10 +314,7 @@ type PruneSceneFingerprintsForMoveParams struct {
 	TargetSceneID uuid.UUID `db:"target_scene_id" json:"target_scene_id"`
 }
 
-// Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
-//   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
-//   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
-//     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
+// Prepare a fingerprint move by dropping reports and dupe fingerprint submissions
 func (q *Queries) PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) (int64, error) {
 	result, err := q.db.Exec(ctx, pruneSceneFingerprintsForMove,
 		arg.Hash,

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -92,9 +92,6 @@ type Querier interface {
 	CreateUserToken(ctx context.Context, arg CreateUserTokenParams) (UserToken, error)
 	DeleteAllSceneFingerprintSubmissions(ctx context.Context, arg DeleteAllSceneFingerprintSubmissionsParams) (int64, error)
 	DeleteDraft(ctx context.Context, id uuid.UUID) error
-	// Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
-	// so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
-	DeleteDuplicateSceneFingerprintSubmissions(ctx context.Context, arg DeleteDuplicateSceneFingerprintSubmissionsParams) (int64, error)
 	DeleteEdit(ctx context.Context, id uuid.UUID) error
 	DeleteExpiredDrafts(ctx context.Context, dollar_1 interface{}) error
 	DeleteExpiredModAudits(ctx context.Context, dollar_1 interface{}) error
@@ -285,6 +282,11 @@ type Querier interface {
 	MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID) error
 	MarkNotificationRead(ctx context.Context, arg MarkNotificationReadParams) error
 	MoveSceneFingerprintSubmissions(ctx context.Context, arg MoveSceneFingerprintSubmissionsParams) (int64, error)
+	// Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
+	//   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
+	//   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
+	//     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
+	PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) (int64, error)
 	QueryModAudits(ctx context.Context, arg QueryModAuditsParams) ([]ModAudit, error)
 	ReassignPerformerAliases(ctx context.Context, arg ReassignPerformerAliasesParams) error
 	ReassignPerformerFavorites(ctx context.Context, arg ReassignPerformerFavoritesParams) error

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -282,10 +282,7 @@ type Querier interface {
 	MarkAllNotificationsRead(ctx context.Context, userID uuid.UUID) error
 	MarkNotificationRead(ctx context.Context, arg MarkNotificationReadParams) error
 	MoveSceneFingerprintSubmissions(ctx context.Context, arg MoveSceneFingerprintSubmissionsParams) (int64, error)
-	// Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
-	//   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
-	//   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
-	//     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
+	// Prepare a fingerprint move by dropping reports and dupe fingerprint submissions
 	PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) (int64, error)
 	QueryModAudits(ctx context.Context, arg QueryModAuditsParams) ([]ModAudit, error)
 	ReassignPerformerAliases(ctx context.Context, arg ReassignPerformerAliasesParams) error

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -70,10 +70,7 @@ GROUP BY SFP.scene_id, FP.algorithm, FP.hash
 ORDER BY net_submissions DESC;
 
 -- name: PruneSceneFingerprintsForMove :execrows
--- Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
---   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
---   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
---     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
+-- Prepare a fingerprint move by dropping reports and dupe fingerprint submissions
 DELETE FROM scene_fingerprints SFP
 USING fingerprints FP
 WHERE SFP.fingerprint_id = FP.id

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -69,20 +69,25 @@ WHERE SFP.scene_id = ANY(sqlc.arg(scene_ids)::UUID[])
 GROUP BY SFP.scene_id, FP.algorithm, FP.hash
 ORDER BY net_submissions DESC;
 
--- name: DeleteDuplicateSceneFingerprintSubmissions :execrows
--- Delete source-scene submissions whose (fingerprint, user) already exists on the target scene,
--- so MoveSceneFingerprintSubmissions can move the remainder without tripping the unique constraint.
+-- name: PruneSceneFingerprintsForMove :execrows
+-- Prepare a fingerprint move by dropping source-scene rows that should not be carried over:
+--   - reports (vote = -1): a moderator-confirmed move means the report no longer applies.
+--   - submissions whose (fingerprint, user) already exists on the target: avoids tripping
+--     the unique constraint when MoveSceneFingerprintSubmissions shifts the remainder.
 DELETE FROM scene_fingerprints SFP
 USING fingerprints FP
 WHERE SFP.fingerprint_id = FP.id
   AND FP.hash = sqlc.arg(hash)
   AND FP.algorithm = sqlc.arg(algorithm)
   AND SFP.scene_id = sqlc.arg(source_scene_id)
-  AND EXISTS (
-    SELECT 1 FROM scene_fingerprints SFP2
-    WHERE SFP2.scene_id = sqlc.arg(target_scene_id)
-      AND SFP2.fingerprint_id = SFP.fingerprint_id
-      AND SFP2.user_id = SFP.user_id
+  AND (
+    SFP.vote = -1
+    OR EXISTS (
+      SELECT 1 FROM scene_fingerprints SFP2
+      WHERE SFP2.scene_id = sqlc.arg(target_scene_id)
+        AND SFP2.fingerprint_id = SFP.fingerprint_id
+        AND SFP2.user_id = SFP.user_id
+    )
   );
 
 -- name: MoveSceneFingerprintSubmissions :execrows

--- a/internal/service/scene/service.go
+++ b/internal/service/scene/service.go
@@ -676,15 +676,15 @@ func (s *Scene) MoveFingerprintSubmissions(ctx context.Context, input models.Mov
 
 		// Move each fingerprint
 		for _, fp := range input.Fingerprints {
-			// Drop source rows that would collide with an existing target submission
-			deduped, err := txnQueries.DeleteDuplicateSceneFingerprintSubmissions(ctx, queries.DeleteDuplicateSceneFingerprintSubmissionsParams{
+			// Drop reports and any source rows that would collide with an existing target submission.
+			pruned, err := txnQueries.PruneSceneFingerprintsForMove(ctx, queries.PruneSceneFingerprintsForMoveParams{
 				Hash:          fp.Hash.Int64(),
 				Algorithm:     fp.Algorithm.String(),
 				SourceSceneID: input.SourceSceneID,
 				TargetSceneID: input.TargetSceneID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to deduplicate fingerprint %s (%s): %w", fp.Hash.Hex(), fp.Algorithm, err)
+				return fmt.Errorf("failed to prune fingerprint %s (%s): %w", fp.Hash.Hex(), fp.Algorithm, err)
 			}
 
 			moved, err := txnQueries.MoveSceneFingerprintSubmissions(ctx, queries.MoveSceneFingerprintSubmissionsParams{
@@ -696,7 +696,7 @@ func (s *Scene) MoveFingerprintSubmissions(ctx context.Context, input models.Mov
 			if err != nil {
 				return fmt.Errorf("failed to move fingerprint %s (%s): %w", fp.Hash.Hex(), fp.Algorithm, err)
 			}
-			if deduped+moved == 0 {
+			if pruned+moved == 0 {
 				return fmt.Errorf("fingerprint %s (%s) not found on source scene", fp.Hash.Hex(), fp.Algorithm)
 			}
 		}


### PR DESCRIPTION
Drafted with claude.

Deletes fingerprint reports when a fingerprint is moved to another scene.