### PR TITLE
Remove fingerprints/images from deleted scenes

### DIFF
--- a/internal/api/scene_edit_integration_test.go
+++ b/internal/api/scene_edit_integration_test.go
@@ -351,7 +351,19 @@ func (s *sceneEditTestRunner) testApplyModifyUnsetSceneEdit() {
 }
 
 func (s *sceneEditTestRunner) testApplyDestroySceneEdit() {
-	createdScene, err := s.createTestScene(nil)
+	// Create a scene with an image and a fingerprint
+	imgURL := "http://example.org/image.jpg"
+	image, err := s.resolver.Mutation().ImageCreate(s.ctx, models.ImageCreateInput{URL: &imgURL})
+	assert.NoError(s.t, err)
+
+	sceneInput := &models.SceneCreateInput{
+		Date:     "2020-03-02",
+		ImageIds: []uuid.UUID{image.ID},
+		Fingerprints: []models.FingerprintEditInput{
+			s.generateSceneFingerprint(nil),
+		},
+	}
+	createdScene, err := s.createTestScene(sceneInput)
 	assert.NoError(s.t, err)
 
 	sceneID := createdScene.UUID()
@@ -364,6 +376,7 @@ func (s *sceneEditTestRunner) testApplyDestroySceneEdit() {
 	destroyEdit, err := s.createTestSceneEdit(models.OperationEnumDestroy, &sceneEditDetailsInput, &editInput)
 	assert.NoError(s.t, err)
 	appliedEdit, err := s.approveEdit(destroyEdit.ID)
+	assert.NoError(s.t, err)
 
 	destroyedScene, _ := s.resolver.Query().FindScene(s.ctx, sceneID)
 	s.verifyApplyDestroySceneEdit(destroyedScene, appliedEdit)
@@ -376,6 +389,14 @@ func (s *sceneEditTestRunner) verifyApplyDestroySceneEdit(destroyedScene *models
 	s.verifyEditApplication(true, edit)
 
 	assert.Equal(s.t, destroyedScene.Deleted, true)
+
+	images, err := s.resolver.Scene().Images(s.ctx, destroyedScene)
+	assert.NoError(s.t, err)
+	assert.Empty(s.t, images, "destroyed scene should have no images")
+
+	fingerprints, err := s.resolver.Scene().Fingerprints(s.ctx, destroyedScene, nil)
+	assert.NoError(s.t, err)
+	assert.Empty(s.t, fingerprints, "destroyed scene should have no fingerprints")
 }
 
 func (s *sceneEditTestRunner) testApplyMergeSceneEdit() {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 58
+	schemaVersion  = 59
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/59_cleanup_deleted_scene_relationships.up.sql
+++ b/internal/database/migrations/postgres/59_cleanup_deleted_scene_relationships.up.sql
@@ -1,0 +1,2 @@
+DELETE FROM scene_images WHERE scene_id IN (SELECT id FROM scenes WHERE deleted = true);
+DELETE FROM scene_fingerprints WHERE scene_id IN (SELECT id FROM scenes WHERE deleted = true);

--- a/internal/service/edit/scene.go
+++ b/internal/service/edit/scene.go
@@ -421,7 +421,15 @@ func (m *SceneEditProcessor) applyDestroy(scene *models.Scene) error {
 		return err
 	}
 
-	return err
+	if err = m.queries.DeleteSceneImages(m.context, scene.ID); err != nil {
+		return err
+	}
+
+	if err = m.queries.DeleteSceneFingerprintsByScene(m.context, scene.ID); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *SceneEditProcessor) applyMerge(scene *models.Scene, data *models.SceneEditData) error {

--- a/internal/service/edit/scene.go
+++ b/internal/service/edit/scene.go
@@ -425,11 +425,7 @@ func (m *SceneEditProcessor) applyDestroy(scene *models.Scene) error {
 		return err
 	}
 
-	if err = m.queries.DeleteSceneFingerprintsByScene(m.context, scene.ID); err != nil {
-		return err
-	}
-
-	return nil
+	return m.queries.DeleteSceneFingerprintsByScene(m.context, scene.ID)
 }
 
 func (m *SceneEditProcessor) applyMerge(scene *models.Scene, data *models.SceneEditData) error {


### PR DESCRIPTION
Fingerprint/image deletion was accidentally broken in the big refactor. Reinstated, along with a migration to delete any leftovers.