### PR TITLE
Fix notification page refresh on mark read

### DIFF
--- a/frontend/src/graphql/mutations/index.ts
+++ b/frontend/src/graphql/mutations/index.ts
@@ -1,4 +1,5 @@
 import { type MutationHookOptions, useMutation } from "@apollo/client/react";
+import { isReference, type Reference } from "@apollo/client/utilities";
 
 import MeGql from "../queries/Me.gql";
 import {
@@ -555,7 +556,9 @@ type CachedQueryNotifications = {
 };
 
 const notificationTypenameFromEnum = (type: string) =>
-  type.toLowerCase().replace(/(?:^|_)([a-z])/g, (_, c: string) => c.toUpperCase());
+  type
+    .toLowerCase()
+    .replace(/(?:^|_)([a-z])/g, (_, c: string) => c.toUpperCase());
 
 export const useMarkNotificationsRead = () =>
   useMutation(MarkNotificationsReadDocument, {
@@ -563,8 +566,11 @@ export const useMarkNotificationsRead = () =>
       if (!data?.markNotificationsRead) return;
       cache.modify({
         fields: {
-          queryNotifications(existing: CachedQueryNotifications | undefined) {
-            if (!existing?.notifications) return existing;
+          queryNotifications(
+            existing: CachedQueryNotifications | Reference | undefined,
+          ) {
+            if (!existing || isReference(existing) || !existing.notifications)
+              return existing;
             return {
               ...existing,
               notifications: existing.notifications.map((n) =>
@@ -591,8 +597,11 @@ export const useMarkNotificationRead = (
       const targetTypename = notificationTypenameFromEnum(type);
       cache.modify({
         fields: {
-          queryNotifications(existing: CachedQueryNotifications | undefined) {
-            if (!existing?.notifications) return existing;
+          queryNotifications(
+            existing: CachedQueryNotifications | Reference | undefined,
+          ) {
+            if (!existing || isReference(existing) || !existing.notifications)
+              return existing;
             return {
               ...existing,
               notifications: existing.notifications.map((n) => {
@@ -601,7 +610,7 @@ export const useMarkNotificationRead = (
                   n.data.comment?.__ref ??
                   n.data.edit?.__ref ??
                   n.data.scene?.__ref;
-                if (innerRef && innerRef.endsWith(`:${id}`)) {
+                if (innerRef?.endsWith(`:${id}`)) {
                   return { ...n, read: true };
                 }
                 return n;

--- a/frontend/src/graphql/mutations/index.ts
+++ b/frontend/src/graphql/mutations/index.ts
@@ -539,13 +539,44 @@ export const useUpdateNotificationSubscriptions = (
     ...options,
   });
 
+type CachedNotification = {
+  read: boolean;
+  data: {
+    __typename: string;
+    comment?: { __ref: string };
+    edit?: { __ref: string };
+    scene?: { __ref: string };
+  };
+};
+
+type CachedQueryNotifications = {
+  count: number;
+  notifications: CachedNotification[];
+};
+
+const notificationTypenameFromEnum = (type: string) =>
+  type.toLowerCase().replace(/(?:^|_)([a-z])/g, (_, c: string) => c.toUpperCase());
+
 export const useMarkNotificationsRead = () =>
   useMutation(MarkNotificationsReadDocument, {
     update(cache, { data }) {
-      if (data?.markNotificationsRead) {
-        cache.evict({ fieldName: "queryNotifications" });
-        cache.evict({ fieldName: "getUnreadNotificationCount" });
-      }
+      if (!data?.markNotificationsRead) return;
+      cache.modify({
+        fields: {
+          queryNotifications(existing: CachedQueryNotifications | undefined) {
+            if (!existing?.notifications) return existing;
+            return {
+              ...existing,
+              notifications: existing.notifications.map((n) =>
+                n.read ? n : { ...n, read: true },
+              ),
+            };
+          },
+          getUnreadNotificationCount() {
+            return 0;
+          },
+        },
+      });
     },
   });
 
@@ -555,9 +586,32 @@ export const useMarkNotificationRead = (
   useMutation(MarkNotificationReadDocument, {
     variables,
     update(cache, { data }) {
-      if (data?.markNotificationsRead) {
-        cache.evict({ fieldName: "queryNotifications" });
-        cache.evict({ fieldName: "getUnreadNotificationCount" });
-      }
+      if (!data?.markNotificationsRead) return;
+      const { type, id } = variables.notification;
+      const targetTypename = notificationTypenameFromEnum(type);
+      cache.modify({
+        fields: {
+          queryNotifications(existing: CachedQueryNotifications | undefined) {
+            if (!existing?.notifications) return existing;
+            return {
+              ...existing,
+              notifications: existing.notifications.map((n) => {
+                if (n.read || n.data?.__typename !== targetTypename) return n;
+                const innerRef =
+                  n.data.comment?.__ref ??
+                  n.data.edit?.__ref ??
+                  n.data.scene?.__ref;
+                if (innerRef && innerRef.endsWith(`:${id}`)) {
+                  return { ...n, read: true };
+                }
+                return n;
+              }),
+            };
+          },
+          getUnreadNotificationCount(existing: number | undefined) {
+            return Math.max(0, (existing ?? 0) - 1);
+          },
+        },
+      });
     },
   });


### PR DESCRIPTION
Instead of evicting the whole notification payload we update the cache to mark the notifications as read.