### PR TITLE
Fix distance matching in fingerprint lookups

### DIFF
--- a/internal/api/scene_integration_test.go
+++ b/internal/api/scene_integration_test.go
@@ -1007,6 +1007,71 @@ func TestFindScenesBySceneFingerprints(t *testing.T) {
 	pt.testFindScenesBySceneFingerprints()
 }
 
+func (s *sceneTestRunner) testFindScenesBySceneFingerprintsPhashFuzzy() {
+	originalPHashDistance := config.GetPHashDistance()
+	config.C.PHashDistance = 4
+	defer func() {
+		config.C.PHashDistance = originalPHashDistance
+	}()
+
+	// Three scenes whose stored phashes all sit within Hamming distance 4 of the
+	// query hash but at distinct values (1, 2, and 3 bit differences).
+	queryPhash := models.FingerprintHash(0x1122334455667788)
+	storedHashes := []models.FingerprintHash{
+		queryPhash ^ 0x1,  // 1 bit off
+		queryPhash ^ 0x6,  // 2 bits off
+		queryPhash ^ 0x70, // 3 bits off
+	}
+
+	createdIDs := make(map[string]bool, len(storedHashes))
+	for i, h := range storedHashes {
+		title := fmt.Sprintf("Phash fuzzy scene %d", i)
+		input := models.SceneCreateInput{
+			Title: &title,
+			Date:  "2020-03-02",
+			Fingerprints: []models.FingerprintEditInput{
+				{
+					Algorithm: models.FingerprintAlgorithmPhash,
+					Hash:      h,
+					Duration:  1234 + i,
+					UserIds:   []uuid.UUID{},
+				},
+			},
+		}
+		created, err := s.createTestScene(&input)
+		assert.NoError(s.t, err)
+		createdIDs[created.ID] = true
+	}
+
+	queryFingerprints := [][]models.FingerprintQueryInput{
+		{
+			{
+				Algorithm: models.FingerprintAlgorithmPhash,
+				Hash:      queryPhash,
+			},
+		},
+	}
+
+	results, err := s.client.findScenesBySceneFingerprints(queryFingerprints)
+	assert.NoError(s.t, err)
+
+	assert.Equal(s.t, 1, len(results), "Should return one result set")
+	assert.Equal(s.t, len(storedHashes), len(results[0]), "All scenes within phash distance should be returned, none deduped away")
+
+	seen := make(map[string]int)
+	for _, sc := range results[0] {
+		seen[sc.ID]++
+	}
+	for id := range createdIDs {
+		assert.Equal(s.t, 1, seen[id], "Each matching scene should appear exactly once")
+	}
+}
+
+func TestFindScenesBySceneFingerprintsPhashFuzzy(t *testing.T) {
+	pt := createSceneTestRunner(t)
+	pt.testFindScenesBySceneFingerprintsPhashFuzzy()
+}
+
 func (s *sceneTestRunner) testMoveFingerprintSubmissions() {
 	// Create two scenes with fingerprints
 	scene1, err := s.createTestScene(nil)

--- a/internal/queries/scene.sql.go
+++ b/internal/queries/scene.sql.go
@@ -390,13 +390,15 @@ func (q *Queries) FindScenesByFingerprintsExactWithHash(ctx context.Context, has
 const findScenesByFullFingerprintsWithHash = `-- name: FindScenesByFullFingerprintsWithHash :many
 
 SELECT scenes.id, scenes.title, scenes.details, scenes.studio_id, scenes.created_at, scenes.updated_at, scenes.duration, scenes.director, scenes.deleted, scenes.code, scenes.date, scenes.production_date, matches.hash FROM (
-    SELECT SFP.scene_id AS id, FP.hash
+    -- Return the query phash from UNNEST so callers can route results back to
+    -- the input fingerprint when distance > 0 and the stored hash differs.
+    SELECT SFP.scene_id AS id, phash::BIGINT AS hash
     FROM UNNEST($1::BIGINT[]) phash
     JOIN fingerprints FP ON FP.hash <@ (phash, $2::INTEGER)
         AND FP.algorithm = 'PHASH'
     JOIN scene_fingerprints SFP ON SFP.fingerprint_id = FP.id
     WHERE $1::BIGINT[] IS NOT NULL AND array_length($1::BIGINT[], 1) > 0
-    GROUP BY SFP.scene_id, FP.hash
+    GROUP BY SFP.scene_id, phash
 
     UNION
 

--- a/internal/queries/sql/scene.sql
+++ b/internal/queries/sql/scene.sql
@@ -85,13 +85,15 @@ SELECT COUNT(*) FROM scene_performers WHERE performer_id = $1;
 
 -- name: FindScenesByFullFingerprintsWithHash :many
 SELECT sqlc.embed(scenes), matches.hash FROM (
-    SELECT SFP.scene_id AS id, FP.hash
+    -- Return the query phash from UNNEST so callers can route results back to
+    -- the input fingerprint when distance > 0 and the stored hash differs.
+    SELECT SFP.scene_id AS id, phash::BIGINT AS hash
     FROM UNNEST(sqlc.narg('phashes')::BIGINT[]) phash
     JOIN fingerprints FP ON FP.hash <@ (phash, sqlc.arg('distance')::INTEGER)
         AND FP.algorithm = 'PHASH'
     JOIN scene_fingerprints SFP ON SFP.fingerprint_id = FP.id
     WHERE sqlc.narg('phashes')::BIGINT[] IS NOT NULL AND array_length(sqlc.narg('phashes')::BIGINT[], 1) > 0
-    GROUP BY SFP.scene_id, FP.hash
+    GROUP BY SFP.scene_id, phash
 
     UNION
 


### PR DESCRIPTION
Drafted with claude.

Turns out distance matching has been broken ever since the big refactor. Added a test to catch it.