### PR TITLE
Remove orphan fingerprints

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 61
+	schemaVersion  = 62
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/62_cleanup_orphan_fingerprints.up.sql
+++ b/internal/database/migrations/postgres/62_cleanup_orphan_fingerprints.up.sql
@@ -1,0 +1,22 @@
+-- Remove existing orphaned fingerprints (no scene_fingerprints reference them).
+DELETE FROM fingerprints F
+WHERE NOT EXISTS (
+    SELECT 1 FROM scene_fingerprints SFP WHERE SFP.fingerprint_id = F.id
+);
+
+CREATE OR REPLACE FUNCTION delete_orphan_fingerprints() RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM fingerprints F
+    WHERE F.id IN (SELECT DISTINCT fingerprint_id FROM deleted_rows)
+      AND NOT EXISTS (
+          SELECT 1 FROM scene_fingerprints SFP WHERE SFP.fingerprint_id = F.id
+      );
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER scene_fingerprints_cleanup_orphans
+AFTER DELETE ON scene_fingerprints
+REFERENCING OLD TABLE AS deleted_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION delete_orphan_fingerprints();


### PR DESCRIPTION
We've not cleaned up the `fingerprints` table after deleting fingerprint submissions. Not a huge issue, but it clutters the index, and shows empty nodes in the cluster view.