### PR TITLE
Fix slow cluster queries

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 63
+	schemaVersion  = 64
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/64_scene_fingerprints_user_id_statistics.up.sql
+++ b/internal/database/migrations/postgres/64_scene_fingerprints_user_id_statistics.up.sql
@@ -1,0 +1,4 @@
+-- Some users have significant numbers of fingerprint submissions.
+-- Raise the analyze target so these users are correctly taken into account.
+ALTER TABLE scene_fingerprints ALTER COLUMN user_id SET STATISTICS 1000;
+ANALYZE scene_fingerprints;


### PR DESCRIPTION
Cluster queries were slow on prod since the scene_fingerprints table was misanalyzed, and config nuances meant the planner didn't use the correct index.