### PR TITLE
Fix oshash not being moved along with linked phash

### DIFF
--- a/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMoveModal.tsx
+++ b/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMoveModal.tsx
@@ -58,12 +58,14 @@ export const ClusterMoveModal: FC<Props> = ({ show, onHide, onMove }) => {
     activeCluster,
     selection.selectedHashes,
   );
+
+  const [target, setTarget] = useState<string | undefined>();
+
   const linkedOshashCount = linkedFingerprintCount(
     activeCluster,
     selection.selectedHashes,
+    target,
   );
-
-  const [target, setTarget] = useState<string | undefined>();
 
   useEffect(() => {
     if (!show || candidates.length === 0) {

--- a/frontend/src/pages/scenes/fingerprintClusters/utils.ts
+++ b/frontend/src/pages/scenes/fingerprintClusters/utils.ts
@@ -32,22 +32,28 @@ export const buildMoveSources = (
   return sources;
 };
 
-/** Count of linked OSHASHes that would be carried along with a selection. */
+/**
+ * Count of distinct linked OSHASHes carried into the target by a selection.
+ * An oshash present on several scenes appears in each scene's
+ * linked_fingerprints, so we dedupe by hash. Oshashes that only exist on the
+ * target scene aren't moving anywhere, so scenes matching `targetSceneId` are
+ * skipped; pass it undefined (no target chosen yet) to count all linked.
+ */
 export const linkedFingerprintCount = (
   cluster: Cluster | undefined,
   selectedHashes: Set<string>,
-): number =>
-  (cluster?.members ?? [])
-    .filter((m) => selectedHashes.has(m.hash))
-    .reduce(
-      (total, m) =>
-        total +
-        m.scene_submissions.reduce(
-          (n, s) => n + s.linked_fingerprints.length,
-          0,
-        ),
-      0,
-    );
+  targetSceneId?: string,
+): number => {
+  const hashes = new Set<string>();
+  for (const m of cluster?.members ?? []) {
+    if (!selectedHashes.has(m.hash)) continue;
+    for (const s of m.scene_submissions) {
+      if (s.scene.id === targetSceneId) continue;
+      for (const o of s.linked_fingerprints) hashes.add(o.hash);
+    }
+  }
+  return hashes.size;
+};
 
 /** Sum of phash user-submission counts on this member across all scenes. */
 export const memberTotalSubmissions = (m: ClusterMember): number =>

--- a/frontend/src/pages/scenes/fingerprintClusters/utils.ts
+++ b/frontend/src/pages/scenes/fingerprintClusters/utils.ts
@@ -34,10 +34,6 @@ export const buildMoveSources = (
 
 /**
  * Count of distinct linked OSHASHes carried into the target by a selection.
- * An oshash present on several scenes appears in each scene's
- * linked_fingerprints, so we dedupe by hash. Oshashes that only exist on the
- * target scene aren't moving anywhere, so scenes matching `targetSceneId` are
- * skipped; pass it undefined (no target chosen yet) to count all linked.
  */
 export const linkedFingerprintCount = (
   cluster: Cluster | undefined,

--- a/internal/service/fingerprint/cluster.go
+++ b/internal/service/fingerprint/cluster.go
@@ -416,20 +416,19 @@ func buildMember(
 	subsByMember map[int][]queries.LoadClusterSubmissionsRow,
 	oshashByPhash map[int][]int,
 ) models.ClusterMember {
-	// Group this member's linked oshashes by their (sole) scene id.
+	// Group this member's linked oshashes by scene id. The same oshash (file
+	// hash) can be submitted against multiple scenes — that's the duplicate
+	// case this tool exists to resolve — so it has one row per scene and must
+	// be attached to each, not just the first.
 	oshashBySceneID := make(map[uuid.UUID][]models.ClusterOshash)
 	for _, oshashID := range oshashByPhash[id] {
-		// OSHASH is user+scene scoped, so each linked oshash has exactly one row.
-		rows := subsByMember[oshashID]
-		if len(rows) == 0 {
-			continue
+		for _, r := range subsByMember[oshashID] {
+			oshashBySceneID[r.SceneID] = append(oshashBySceneID[r.SceneID], models.ClusterOshash{
+				Hash:        hashByID[oshashID],
+				Submissions: r.Submissions,
+				Reports:     r.Reports,
+			})
 		}
-		r := rows[0]
-		oshashBySceneID[r.SceneID] = append(oshashBySceneID[r.SceneID], models.ClusterOshash{
-			Hash:        hashByID[oshashID],
-			Submissions: r.Submissions,
-			Reports:     r.Reports,
-		})
 	}
 	return models.ClusterMember{
 		Hash:             hashByID[id],

--- a/internal/service/fingerprint/cluster.go
+++ b/internal/service/fingerprint/cluster.go
@@ -416,10 +416,7 @@ func buildMember(
 	subsByMember map[int][]queries.LoadClusterSubmissionsRow,
 	oshashByPhash map[int][]int,
 ) models.ClusterMember {
-	// Group this member's linked oshashes by scene id. The same oshash (file
-	// hash) can be submitted against multiple scenes — that's the duplicate
-	// case this tool exists to resolve — so it has one row per scene and must
-	// be attached to each, not just the first.
+	// Group this member's linked oshashes by scene id
 	oshashBySceneID := make(map[uuid.UUID][]models.ClusterOshash)
 	for _, oshashID := range oshashByPhash[id] {
 		for _, r := range subsByMember[oshashID] {

--- a/internal/service/fingerprint/cluster_test.go
+++ b/internal/service/fingerprint/cluster_test.go
@@ -1,0 +1,56 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/stashapp/stash-box/internal/models"
+	"github.com/stashapp/stash-box/internal/queries"
+)
+
+// A linked oshash submitted against more than one scene has one
+// LoadClusterSubmissions row per scene. buildMember must attach it to every
+// scene it appears on; attaching only the first row drops it from the others,
+// which omitted it from the move and left it behind on the source scene.
+func TestBuildMemberLinksOshashAcrossAllScenes(t *testing.T) {
+	const (
+		phashID   = 1
+		oshashID  = 2
+		phashHsh  = models.FingerprintHash(0xAAAA)
+		oshashHsh = models.FingerprintHash(0xBBBB)
+	)
+	sceneA := uuid.FromStringOrNil("019e7850-00e3-719a-b3b0-7dba03d43d43")
+	sceneB := uuid.FromStringOrNil("019e7940-320b-75cc-9430-a21bd9350b24")
+
+	hashByID := map[int]models.FingerprintHash{phashID: phashHsh, oshashID: oshashHsh}
+	oshashByPhash := map[int][]int{phashID: {oshashID}}
+	subsByMember := map[int][]queries.LoadClusterSubmissionsRow{
+		phashID: {
+			{FingerprintID: phashID, SceneID: sceneA, Submissions: 1},
+			{FingerprintID: phashID, SceneID: sceneB, Submissions: 1},
+		},
+		// The same oshash hash on both scenes => one row per scene.
+		oshashID: {
+			{FingerprintID: oshashID, SceneID: sceneA, Submissions: 1},
+			{FingerprintID: oshashID, SceneID: sceneB, Submissions: 1},
+		},
+	}
+
+	member := buildMember(phashID, hashByID, subsByMember, oshashByPhash)
+
+	linkedByScene := make(map[uuid.UUID][]models.ClusterOshash)
+	for _, ss := range member.SceneSubmissions {
+		linkedByScene[ss.SceneID] = ss.LinkedFingerprints
+	}
+
+	for _, sceneID := range []uuid.UUID{sceneA, sceneB} {
+		linked := linkedByScene[sceneID]
+		if len(linked) != 1 {
+			t.Fatalf("scene %s: expected 1 linked oshash, got %d", sceneID, len(linked))
+		}
+		if linked[0].Hash != oshashHsh {
+			t.Errorf("scene %s: expected oshash %x, got %x", sceneID, oshashHsh, linked[0].Hash)
+		}
+	}
+}


### PR DESCRIPTION
Drafted with claude.

When an oshash exists on both source and target, it would randomly pick one of them for the move, sometimes leaving them behind.