### PR TITLE
Split popularity and trending matviews

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -90,17 +90,27 @@ func (c Cron) cleanNotifications() {
 	}
 }
 
-func (c Cron) refreshPopularity() {
-	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "cron.refreshPopularity")
+func (c Cron) refreshPopularityTrending() {
+	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "cron.refreshPopularityTrending")
 	defer span.End()
 
-	if err := c.fac.Scene().RefreshPopularity(ctx); err != nil {
+	if err := c.fac.Scene().RefreshPopularityTrending(ctx); err != nil {
 		tracing.RecordError(span, err)
-		logger.Errorf("Error refreshing scene popularity: %s", err)
+		logger.Errorf("Error refreshing scene popularity trending: %s", err)
 	}
-	if err := c.fac.Performer().RefreshPopularity(ctx); err != nil {
+}
+
+func (c Cron) refreshPopularityAlltime() {
+	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "cron.refreshPopularityAlltime")
+	defer span.End()
+
+	if err := c.fac.Scene().RefreshPopularityAlltime(ctx); err != nil {
 		tracing.RecordError(span, err)
-		logger.Errorf("Error refreshing performer popularity: %s", err)
+		logger.Errorf("Error refreshing scene popularity alltime: %s", err)
+	}
+	if err := c.fac.Performer().RefreshPopularityAlltime(ctx); err != nil {
+		tracing.RecordError(span, err)
+		logger.Errorf("Error refreshing performer popularity alltime: %s", err)
 	}
 }
 
@@ -149,7 +159,12 @@ func Init(fac service.Factory) {
 		panic(err.Error())
 	}
 
-	_, err = c.AddFunc("@every 1h", cronJobs.refreshPopularity)
+	_, err = c.AddFunc("@every 1h", cronJobs.refreshPopularityTrending)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	_, err = c.AddFunc("@daily", cronJobs.refreshPopularityAlltime)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -100,17 +100,17 @@ func (c Cron) refreshPopularityTrending() {
 	}
 }
 
-func (c Cron) refreshPopularityAlltime() {
-	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "cron.refreshPopularityAlltime")
+func (c Cron) refreshPopularityAllTime() {
+	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "cron.refreshPopularityAllTime")
 	defer span.End()
 
-	if err := c.fac.Scene().RefreshPopularityAlltime(ctx); err != nil {
+	if err := c.fac.Scene().RefreshPopularityAllTime(ctx); err != nil {
 		tracing.RecordError(span, err)
-		logger.Errorf("Error refreshing scene popularity alltime: %s", err)
+		logger.Errorf("Error refreshing scene popularity all_time: %s", err)
 	}
-	if err := c.fac.Performer().RefreshPopularityAlltime(ctx); err != nil {
+	if err := c.fac.Performer().RefreshPopularityAllTime(ctx); err != nil {
 		tracing.RecordError(span, err)
-		logger.Errorf("Error refreshing performer popularity alltime: %s", err)
+		logger.Errorf("Error refreshing performer popularity all_time: %s", err)
 	}
 }
 
@@ -164,7 +164,7 @@ func Init(fac service.Factory) {
 		panic(err.Error())
 	}
 
-	_, err = c.AddFunc("@daily", cronJobs.refreshPopularityAlltime)
+	_, err = c.AddFunc("@daily", cronJobs.refreshPopularityAllTime)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 64
+	schemaVersion  = 65
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/65_split_popularity_views.up.sql
+++ b/internal/database/migrations/postgres/65_split_popularity_views.up.sql
@@ -1,0 +1,64 @@
+-- Split combined popularity matviews into alltime + trending, so the hourly
+-- cron only refreshes the cheap trending slice while alltime moves to daily.
+
+DROP MATERIALIZED VIEW scene_popularity;
+DROP MATERIALIZED VIEW performer_popularity;
+
+-- BRIN on created_at: trending refresh scans only recent pages.
+CREATE INDEX scene_fingerprints_created_brin
+  ON scene_fingerprints USING brin (created_at) WITH (pages_per_range = 32);
+
+CREATE MATERIALIZED VIEW scene_popularity_alltime AS
+SELECT scene_id, COUNT(DISTINCT user_id)::INT AS user_count
+FROM scene_fingerprints
+GROUP BY scene_id;
+
+CREATE UNIQUE INDEX scene_popularity_alltime_scene_id_idx
+  ON scene_popularity_alltime (scene_id);
+CREATE INDEX scene_popularity_alltime_count_idx
+  ON scene_popularity_alltime (user_count DESC, scene_id DESC);
+
+CREATE MATERIALIZED VIEW scene_popularity_trending AS
+SELECT scene_id, COUNT(DISTINCT user_id)::INT AS trending_count
+FROM scene_fingerprints
+WHERE created_at >= (now()::DATE - 7)
+GROUP BY scene_id;
+
+CREATE UNIQUE INDEX scene_popularity_trending_scene_id_idx
+  ON scene_popularity_trending (scene_id);
+CREATE INDEX scene_popularity_trending_count_idx
+  ON scene_popularity_trending (trending_count DESC, scene_id DESC);
+
+CREATE MATERIALIZED VIEW performer_popularity_alltime AS
+SELECT sp.performer_id, COUNT(DISTINCT sf.user_id)::INT AS user_count
+FROM scene_fingerprints sf
+JOIN scene_performers sp ON sp.scene_id = sf.scene_id
+GROUP BY sp.performer_id;
+
+CREATE UNIQUE INDEX performer_popularity_alltime_performer_id_idx
+  ON performer_popularity_alltime (performer_id);
+CREATE INDEX performer_popularity_alltime_count_idx
+  ON performer_popularity_alltime (user_count DESC, performer_id DESC);
+
+-- Swap the unique constraint to (scene_id, user_id, fingerprint_id) so the
+-- (scene_id, user_id) prefix powers streaming dedupe for the alltime refresh
+-- and the LoadLinkedOshashSubmissions self-join.
+ALTER TABLE scene_fingerprints
+  DROP CONSTRAINT scene_fingerprints_scene_id_fingerprint_id_user_id_key;
+ALTER TABLE scene_fingerprints
+  ADD CONSTRAINT scene_fingerprints_scene_user_fp_key
+  UNIQUE (scene_id, user_id, fingerprint_id);
+
+-- Defaults never trigger autovacuum on these insert-heavy tables; without this,
+-- the visibility map rots and index-only scans regress to heap-fetch storms.
+ALTER TABLE scene_fingerprints SET (
+  autovacuum_vacuum_insert_scale_factor = 0.02,
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_vacuum_cost_limit = 2000
+);
+ALTER TABLE scene_performers SET (
+  autovacuum_vacuum_insert_scale_factor = 0.02,
+  autovacuum_vacuum_scale_factor = 0.05,
+  autovacuum_analyze_scale_factor = 0.02
+);

--- a/internal/database/migrations/postgres/65_split_popularity_views.up.sql
+++ b/internal/database/migrations/postgres/65_split_popularity_views.up.sql
@@ -1,5 +1,5 @@
--- Split combined popularity matviews into alltime + trending, so the hourly
--- cron only refreshes the cheap trending slice while alltime moves to daily.
+-- Split combined popularity matviews into all_time + trending, so the hourly
+-- cron only refreshes the cheap trending slice while all_time moves to daily.
 
 DROP MATERIALIZED VIEW scene_popularity;
 DROP MATERIALIZED VIEW performer_popularity;
@@ -8,15 +8,15 @@ DROP MATERIALIZED VIEW performer_popularity;
 CREATE INDEX scene_fingerprints_created_brin
   ON scene_fingerprints USING brin (created_at) WITH (pages_per_range = 32);
 
-CREATE MATERIALIZED VIEW scene_popularity_alltime AS
+CREATE MATERIALIZED VIEW scene_popularity_all_time AS
 SELECT scene_id, COUNT(DISTINCT user_id)::INT AS user_count
 FROM scene_fingerprints
 GROUP BY scene_id;
 
-CREATE UNIQUE INDEX scene_popularity_alltime_scene_id_idx
-  ON scene_popularity_alltime (scene_id);
-CREATE INDEX scene_popularity_alltime_count_idx
-  ON scene_popularity_alltime (user_count DESC, scene_id DESC);
+CREATE UNIQUE INDEX scene_popularity_all_time_scene_id_idx
+  ON scene_popularity_all_time (scene_id);
+CREATE INDEX scene_popularity_all_time_count_idx
+  ON scene_popularity_all_time (user_count DESC, scene_id DESC);
 
 CREATE MATERIALIZED VIEW scene_popularity_trending AS
 SELECT scene_id, COUNT(DISTINCT user_id)::INT AS trending_count
@@ -29,19 +29,19 @@ CREATE UNIQUE INDEX scene_popularity_trending_scene_id_idx
 CREATE INDEX scene_popularity_trending_count_idx
   ON scene_popularity_trending (trending_count DESC, scene_id DESC);
 
-CREATE MATERIALIZED VIEW performer_popularity_alltime AS
+CREATE MATERIALIZED VIEW performer_popularity_all_time AS
 SELECT sp.performer_id, COUNT(DISTINCT sf.user_id)::INT AS user_count
 FROM scene_fingerprints sf
 JOIN scene_performers sp ON sp.scene_id = sf.scene_id
 GROUP BY sp.performer_id;
 
-CREATE UNIQUE INDEX performer_popularity_alltime_performer_id_idx
-  ON performer_popularity_alltime (performer_id);
-CREATE INDEX performer_popularity_alltime_count_idx
-  ON performer_popularity_alltime (user_count DESC, performer_id DESC);
+CREATE UNIQUE INDEX performer_popularity_all_time_performer_id_idx
+  ON performer_popularity_all_time (performer_id);
+CREATE INDEX performer_popularity_all_time_count_idx
+  ON performer_popularity_all_time (user_count DESC, performer_id DESC);
 
 -- Swap the unique constraint to (scene_id, user_id, fingerprint_id) so the
--- (scene_id, user_id) prefix powers streaming dedupe for the alltime refresh
+-- (scene_id, user_id) prefix powers streaming dedupe for the all_time refresh
 -- and the LoadLinkedOshashSubmissions self-join.
 ALTER TABLE scene_fingerprints
   DROP CONSTRAINT scene_fingerprints_scene_id_fingerprint_id_user_id_key;
@@ -49,8 +49,7 @@ ALTER TABLE scene_fingerprints
   ADD CONSTRAINT scene_fingerprints_scene_user_fp_key
   UNIQUE (scene_id, user_id, fingerprint_id);
 
--- Defaults never trigger autovacuum on these insert-heavy tables; without this,
--- the visibility map rots and index-only scans regress to heap-fetch storms.
+-- Defaults never trigger autovacuum on these insert-heavy tables
 ALTER TABLE scene_fingerprints SET (
   autovacuum_vacuum_insert_scale_factor = 0.02,
   autovacuum_vacuum_scale_factor = 0.05,

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -35,7 +35,7 @@ func (q *Queries) CreateFingerprint(ctx context.Context, arg CreateFingerprintPa
 const createOrReplaceFingerprint = `-- name: CreateOrReplaceFingerprint :exec
 INSERT INTO scene_fingerprints (fingerprint_id, scene_id, user_id, duration, vote)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT ON CONSTRAINT scene_fingerprints_scene_id_fingerprint_id_user_id_key
+ON CONFLICT ON CONSTRAINT scene_fingerprints_scene_user_fp_key
 DO UPDATE SET
     duration = EXCLUDED.duration,
     vote = EXCLUDED.vote

--- a/internal/queries/models.go
+++ b/internal/queries/models.go
@@ -242,7 +242,7 @@ type PerformerPiercing struct {
 	Description *string   `db:"description" json:"description"`
 }
 
-type PerformerPopularity struct {
+type PerformerPopularityAllTime struct {
 	PerformerID uuid.UUID `db:"performer_id" json:"performer_id"`
 	UserCount   int       `db:"user_count" json:"user_count"`
 }
@@ -312,9 +312,13 @@ type ScenePerformer struct {
 	PerformerID uuid.UUID `db:"performer_id" json:"performer_id"`
 }
 
-type ScenePopularity struct {
+type ScenePopularityAllTime struct {
+	SceneID   uuid.UUID `db:"scene_id" json:"scene_id"`
+	UserCount int       `db:"user_count" json:"user_count"`
+}
+
+type ScenePopularityTrending struct {
 	SceneID       uuid.UUID `db:"scene_id" json:"scene_id"`
-	UserCount     int       `db:"user_count" json:"user_count"`
 	TrendingCount int       `db:"trending_count" json:"trending_count"`
 }
 

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -23,7 +23,7 @@ INSERT INTO scene_fingerprints (fingerprint_id, scene_id, user_id, duration) VAL
 -- name: CreateOrReplaceFingerprint :exec
 INSERT INTO scene_fingerprints (fingerprint_id, scene_id, user_id, duration, vote)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT ON CONSTRAINT scene_fingerprints_scene_id_fingerprint_id_user_id_key
+ON CONFLICT ON CONSTRAINT scene_fingerprints_scene_user_fp_key
 DO UPDATE SET
     duration = EXCLUDED.duration,
     vote = EXCLUDED.vote;

--- a/internal/service/performer/query.go
+++ b/internal/service/performer/query.go
@@ -209,8 +209,8 @@ func (s *Performer) applyPerformerSort(query sq.SelectBuilder, input models.Perf
 		}
 		return query.OrderBy(fmt.Sprintf("COALESCE(scene_count, 0) %s, name %s", sortDir, sortDir))
 	case models.PerformerSortEnumPopularity:
-		query = query.LeftJoin("performer_popularity ON performers.id = performer_popularity.performer_id")
-		return query.OrderBy(fmt.Sprintf("COALESCE(performer_popularity.user_count, 0) %s, name %s", sortDir, sortDir))
+		query = query.LeftJoin("performer_popularity_alltime ON performers.id = performer_popularity_alltime.performer_id")
+		return query.OrderBy(fmt.Sprintf("COALESCE(performer_popularity_alltime.user_count, 0) %s, name %s", sortDir, sortDir))
 	default:
 		if input.Sort != "" {
 			sortField = strings.ToLower(input.Sort.String())

--- a/internal/service/performer/query.go
+++ b/internal/service/performer/query.go
@@ -209,8 +209,8 @@ func (s *Performer) applyPerformerSort(query sq.SelectBuilder, input models.Perf
 		}
 		return query.OrderBy(fmt.Sprintf("COALESCE(scene_count, 0) %s, name %s", sortDir, sortDir))
 	case models.PerformerSortEnumPopularity:
-		query = query.LeftJoin("performer_popularity_alltime ON performers.id = performer_popularity_alltime.performer_id")
-		return query.OrderBy(fmt.Sprintf("COALESCE(performer_popularity_alltime.user_count, 0) %s, name %s", sortDir, sortDir))
+		query = query.LeftJoin("performer_popularity_all_time ON performers.id = performer_popularity_all_time.performer_id")
+		return query.OrderBy(fmt.Sprintf("COALESCE(performer_popularity_all_time.user_count, 0) %s, name %s", sortDir, sortDir))
 	default:
 		if input.Sort != "" {
 			sortField = strings.ToLower(input.Sort.String())

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -33,8 +33,8 @@ func (s *Performer) WithTxn(fn func(*queries.Queries) error) error {
 	return s.withTxn(fn)
 }
 
-func (s *Performer) RefreshPopularity(ctx context.Context) error {
-	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY performer_popularity")
+func (s *Performer) RefreshPopularityAlltime(ctx context.Context) error {
+	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY performer_popularity_alltime")
 	return err
 }
 

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -33,8 +33,8 @@ func (s *Performer) WithTxn(fn func(*queries.Queries) error) error {
 	return s.withTxn(fn)
 }
 
-func (s *Performer) RefreshPopularityAlltime(ctx context.Context) error {
-	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY performer_popularity_alltime")
+func (s *Performer) RefreshPopularityAllTime(ctx context.Context) error {
+	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY performer_popularity_all_time")
 	return err
 }
 

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -194,14 +194,14 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 	// Apply sort and pagination
 	switch input.Sort {
 	case models.SceneSortEnumPopularity:
-		query = query.LeftJoin("scene_popularity_alltime ON scenes.id = scene_popularity_alltime.scene_id")
+		query = query.LeftJoin("scene_popularity_all_time ON scenes.id = scene_popularity_all_time.scene_id")
 
 		if !forCount {
 			sortDir := "DESC"
 			if input.Direction != "" {
 				sortDir = strings.ToUpper(input.Direction.String())
 			}
-			query = query.OrderBy(fmt.Sprintf("COALESCE(scene_popularity_alltime.user_count, 0) %s, scenes.id %s", sortDir, sortDir))
+			query = query.OrderBy(fmt.Sprintf("COALESCE(scene_popularity_all_time.user_count, 0) %s, scenes.id %s", sortDir, sortDir))
 			query = queryhelper.ApplyPagination(query, input.Page, input.PerPage)
 		}
 	case models.SceneSortEnumTrending:

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -194,14 +194,14 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 	// Apply sort and pagination
 	switch input.Sort {
 	case models.SceneSortEnumPopularity:
-		query = query.LeftJoin("scene_popularity ON scenes.id = scene_popularity.scene_id")
+		query = query.LeftJoin("scene_popularity_alltime ON scenes.id = scene_popularity_alltime.scene_id")
 
 		if !forCount {
 			sortDir := "DESC"
 			if input.Direction != "" {
 				sortDir = strings.ToUpper(input.Direction.String())
 			}
-			query = query.OrderBy(fmt.Sprintf("COALESCE(scene_popularity.user_count, 0) %s, scenes.id %s", sortDir, sortDir))
+			query = query.OrderBy(fmt.Sprintf("COALESCE(scene_popularity_alltime.user_count, 0) %s, scenes.id %s", sortDir, sortDir))
 			query = queryhelper.ApplyPagination(query, input.Page, input.PerPage)
 		}
 	case models.SceneSortEnumTrending:
@@ -232,8 +232,7 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 
 			query = query.Join(fmt.Sprintf(`(
 				SELECT scene_id, trending_count AS count
-				FROM scene_popularity
-				WHERE trending_count IS NOT NULL
+				FROM scene_popularity_trending
 				ORDER BY trending_count DESC, scene_id DESC
 				LIMIT %d OFFSET %d
 			) TRENDING ON scenes.id = TRENDING.scene_id`, perPage, offset))
@@ -243,8 +242,7 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 			// Standard trending query without optimization
 			query = query.Join(`(
 				SELECT scene_id, trending_count AS count
-				FROM scene_popularity
-				WHERE trending_count IS NOT NULL
+				FROM scene_popularity_trending
 			) TRENDING ON scenes.id = TRENDING.scene_id`)
 
 			if !forCount {

--- a/internal/service/scene/service.go
+++ b/internal/service/scene/service.go
@@ -37,8 +37,8 @@ func (s *Scene) WithTxn(fn func(*queries.Queries) error) error {
 	return s.withTxn(fn)
 }
 
-func (s *Scene) RefreshPopularityAlltime(ctx context.Context) error {
-	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY scene_popularity_alltime")
+func (s *Scene) RefreshPopularityAllTime(ctx context.Context) error {
+	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY scene_popularity_all_time")
 	return err
 }
 

--- a/internal/service/scene/service.go
+++ b/internal/service/scene/service.go
@@ -37,8 +37,13 @@ func (s *Scene) WithTxn(fn func(*queries.Queries) error) error {
 	return s.withTxn(fn)
 }
 
-func (s *Scene) RefreshPopularity(ctx context.Context) error {
-	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY scene_popularity")
+func (s *Scene) RefreshPopularityAlltime(ctx context.Context) error {
+	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY scene_popularity_alltime")
+	return err
+}
+
+func (s *Scene) RefreshPopularityTrending(ctx context.Context) error {
+	_, err := s.queries.DB().Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY scene_popularity_trending")
 	return err
 }
 


### PR DESCRIPTION
Drafted with  claude.

Rebuilding the alltime matview is a fairly heavy process, and the only reason we do it every 1h is because of trending popularity.
By splitting the matviews we can do the cheap trending hourly, and do alltime nightly since it barely changes anyway.