### PR TITLE
Split search query and faceting

### DIFF
--- a/internal/api/resolver_query_performer.go
+++ b/internal/api/resolver_query_performer.go
@@ -75,6 +75,9 @@ func (r *queryResolver) SearchPerformer(ctx context.Context, term string, limit 
 	if result.SearchResults != nil {
 		return result.SearchResults.Performers, nil
 	}
+	if result.Search != nil {
+		return r.services.Performer().SearchPerformerPage(ctx, result.Search)
+	}
 	return nil, nil
 }
 

--- a/internal/api/resolver_query_performer.go
+++ b/internal/api/resolver_query_performer.go
@@ -24,6 +24,9 @@ func (r *queryPerformerResolver) Count(ctx context.Context, obj *models.Performe
 	if obj.SearchResults != nil {
 		return obj.SearchResults.Count, nil
 	}
+	if obj.Search != nil {
+		return r.services.Performer().SearchPerformerCount(ctx, obj.Search)
+	}
 	return r.services.Performer().QueryCount(ctx, obj.Filter)
 }
 
@@ -31,12 +34,18 @@ func (r *queryPerformerResolver) Performers(ctx context.Context, obj *models.Per
 	if obj.SearchResults != nil {
 		return obj.SearchResults.Performers, nil
 	}
+	if obj.Search != nil {
+		return r.services.Performer().SearchPerformerPage(ctx, obj.Search)
+	}
 	return r.services.Performer().Query(ctx, obj.Filter)
 }
 
 func (r *queryPerformerResolver) Facets(ctx context.Context, obj *models.PerformerQuery) (*models.PerformerSearchFacets, error) {
 	if obj.SearchResults != nil {
 		return obj.SearchResults.Facets, nil
+	}
+	if obj.Search != nil {
+		return r.services.Performer().SearchPerformerFacets(ctx, obj.Search)
 	}
 	return nil, nil
 }

--- a/internal/api/search_integration_test.go
+++ b/internal/api/search_integration_test.go
@@ -26,7 +26,8 @@ func (s *searchTestRunner) testSearchPerformerByTerm() {
 	result, err := s.resolver.Query().SearchPerformers(s.ctx, createdPerformer.Name, nil, nil, nil, nil)
 	assert.NoError(s.t, err, "Error finding performer")
 
-	performers := result.SearchResults.Performers
+	performers, err := s.resolver.QueryPerformersResultType().Performers(s.ctx, result)
+	assert.NoError(s.t, err, "Error resolving performers")
 
 	// ensure returned performer is not nil
 	assert.True(s.t, len(performers) > 0, "Did not find performer by name search")
@@ -186,10 +187,14 @@ func (s *searchTestRunner) testSearchPerformerFacets() {
 	// Search and check facets
 	result, err := s.resolver.Query().SearchPerformers(s.ctx, "Test Facet Performer", nil, nil, nil, nil)
 	assert.NoError(s.t, err, "Error searching performers")
-	assert.True(s.t, len(result.SearchResults.Performers) >= 2, "Should find at least 2 performers")
+
+	performers, err := s.resolver.QueryPerformersResultType().Performers(s.ctx, result)
+	assert.NoError(s.t, err, "Error resolving performers")
+	assert.True(s.t, len(performers) >= 2, "Should find at least 2 performers")
 
 	// Check facets are present
-	facets := result.SearchResults.Facets
+	facets, err := s.resolver.QueryPerformersResultType().Facets(s.ctx, result)
+	assert.NoError(s.t, err, "Error resolving facets")
 	assert.NotNil(s.t, facets, "Facets should be present for search results")
 }
 

--- a/internal/models/model_performer.go
+++ b/internal/models/model_performer.go
@@ -39,6 +39,14 @@ type PerformerQuery struct {
 	Filter PerformerQueryInput
 
 	SearchResults *PerformerSearchResults
+	Search        *PerformerSearchParams
+}
+
+type PerformerSearchParams struct {
+	Term         string
+	FilterGender *string
+	Limit        int
+	Offset       int
 }
 
 type GenderFacet struct {

--- a/internal/queries/performer.sql.go
+++ b/internal/queries/performer.sql.go
@@ -29,6 +29,33 @@ func (q *Queries) ClearScenePerformerAlias(ctx context.Context, arg ClearScenePe
 	return err
 }
 
+const countPerformerSearchMatches = `-- name: CountPerformerSearchMatches :one
+SELECT pdb.agg('{"value_count": {"field": "performer_id"}}') AS total_count
+FROM performer_search
+WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
+    paradedb.boolean(
+        should => ARRAY[
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => $1::TEXT)),
+            paradedb.match(field => 'disambiguation', value => $1::TEXT)
+        ]
+    ),
+    paradedb.match(field => 'aliases', value => $1::TEXT)
+])
+AND ($2::TEXT IS NULL OR gender = $2::TEXT)
+`
+
+type CountPerformerSearchMatchesParams struct {
+	Term         *string `db:"term" json:"term"`
+	FilterGender *string `db:"filter_gender" json:"filter_gender"`
+}
+
+func (q *Queries) CountPerformerSearchMatches(ctx context.Context, arg CountPerformerSearchMatchesParams) (interface{}, error) {
+	row := q.db.QueryRow(ctx, countPerformerSearchMatches, arg.Term, arg.FilterGender)
+	var total_count interface{}
+	err := row.Scan(&total_count)
+	return total_count, err
+}
+
 const createPerformer = `-- name: CreatePerformer :one
 
 INSERT INTO performers (
@@ -873,6 +900,33 @@ func (q *Queries) GetPerformerPiercings(ctx context.Context, performerID uuid.UU
 	return items, nil
 }
 
+const getPerformerSearchFacets = `-- name: GetPerformerSearchFacets :one
+SELECT pdb.agg('{"terms": {"field": "gender"}}') AS gender_facets
+FROM performer_search
+WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
+    paradedb.boolean(
+        should => ARRAY[
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => $1::TEXT)),
+            paradedb.match(field => 'disambiguation', value => $1::TEXT)
+        ]
+    ),
+    paradedb.match(field => 'aliases', value => $1::TEXT)
+])
+AND ($2::TEXT IS NULL OR gender = $2::TEXT)
+`
+
+type GetPerformerSearchFacetsParams struct {
+	Term         *string `db:"term" json:"term"`
+	FilterGender *string `db:"filter_gender" json:"filter_gender"`
+}
+
+func (q *Queries) GetPerformerSearchFacets(ctx context.Context, arg GetPerformerSearchFacetsParams) (interface{}, error) {
+	row := q.db.QueryRow(ctx, getPerformerSearchFacets, arg.Term, arg.FilterGender)
+	var gender_facets interface{}
+	err := row.Scan(&gender_facets)
+	return gender_facets, err
+}
+
 const getPerformerTattoos = `-- name: GetPerformerTattoos :many
 SELECT location, description FROM performer_tattoos WHERE performer_id = $1
 `
@@ -969,11 +1023,8 @@ func (q *Queries) ReassignPerformerFavorites(ctx context.Context, arg ReassignPe
 	return err
 }
 
-const searchPerformersWithFacets = `-- name: SearchPerformersWithFacets :many
-SELECT
-    performer_id,
-    pdb.agg('{"terms": {"field": "gender"}}') OVER () as gender_facets,
-    pdb.agg('{"value_count": {"field": "performer_id"}}') OVER () as total_count
+const searchPerformers = `-- name: SearchPerformers :many
+SELECT performer_id
 FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     paradedb.boolean(
@@ -989,21 +1040,15 @@ ORDER BY pdb.score(performer_id) DESC
 LIMIT $4 OFFSET $3
 `
 
-type SearchPerformersWithFacetsParams struct {
+type SearchPerformersParams struct {
 	Term         *string `db:"term" json:"term"`
 	FilterGender *string `db:"filter_gender" json:"filter_gender"`
 	Offset       int32   `db:"offset" json:"offset"`
 	Limit        int32   `db:"limit" json:"limit"`
 }
 
-type SearchPerformersWithFacetsRow struct {
-	PerformerID  uuid.UUID   `db:"performer_id" json:"performer_id"`
-	GenderFacets interface{} `db:"gender_facets" json:"gender_facets"`
-	TotalCount   interface{} `db:"total_count" json:"total_count"`
-}
-
-func (q *Queries) SearchPerformersWithFacets(ctx context.Context, arg SearchPerformersWithFacetsParams) ([]SearchPerformersWithFacetsRow, error) {
-	rows, err := q.db.Query(ctx, searchPerformersWithFacets,
+func (q *Queries) SearchPerformers(ctx context.Context, arg SearchPerformersParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, searchPerformers,
 		arg.Term,
 		arg.FilterGender,
 		arg.Offset,
@@ -1013,13 +1058,13 @@ func (q *Queries) SearchPerformersWithFacets(ctx context.Context, arg SearchPerf
 		return nil, err
 	}
 	defer rows.Close()
-	items := []SearchPerformersWithFacetsRow{}
+	items := []uuid.UUID{}
 	for rows.Next() {
-		var i SearchPerformersWithFacetsRow
-		if err := rows.Scan(&i.PerformerID, &i.GenderFacets, &i.TotalCount); err != nil {
+		var performer_id uuid.UUID
+		if err := rows.Scan(&performer_id); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, performer_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/queries/performer.sql.go
+++ b/internal/queries/performer.sql.go
@@ -1024,6 +1024,7 @@ func (q *Queries) ReassignPerformerFavorites(ctx context.Context, arg ReassignPe
 }
 
 const searchPerformers = `-- name: SearchPerformers :many
+
 SELECT performer_id
 FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
@@ -1047,6 +1048,8 @@ type SearchPerformersParams struct {
 	Limit        int32   `db:"limit" json:"limit"`
 }
 
+// Keep the WHERE clause in sync across SearchPerformers, CountPerformerSearchMatches,
+// and GetPerformerSearchFacets so paging, counts, and facets stay consistent.
 func (q *Queries) SearchPerformers(ctx context.Context, arg SearchPerformersParams) ([]uuid.UUID, error) {
 	rows, err := q.db.Query(ctx, searchPerformers,
 		arg.Term,

--- a/internal/queries/performer.sql.go
+++ b/internal/queries/performer.sql.go
@@ -45,7 +45,7 @@ AND ($2::TEXT IS NULL OR gender = $2::TEXT)
 `
 
 type CountPerformerSearchMatchesParams struct {
-	Term         *string `db:"term" json:"term"`
+	Term         string  `db:"term" json:"term"`
 	FilterGender *string `db:"filter_gender" json:"filter_gender"`
 }
 
@@ -916,7 +916,7 @@ AND ($2::TEXT IS NULL OR gender = $2::TEXT)
 `
 
 type GetPerformerSearchFacetsParams struct {
-	Term         *string `db:"term" json:"term"`
+	Term         string  `db:"term" json:"term"`
 	FilterGender *string `db:"filter_gender" json:"filter_gender"`
 }
 
@@ -1041,7 +1041,7 @@ LIMIT $4 OFFSET $3
 `
 
 type SearchPerformersParams struct {
-	Term         *string `db:"term" json:"term"`
+	Term         string  `db:"term" json:"term"`
 	FilterGender *string `db:"filter_gender" json:"filter_gender"`
 	Offset       int32   `db:"offset" json:"offset"`
 	Limit        int32   `db:"limit" json:"limit"`

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -307,6 +307,8 @@ type Querier interface {
 	ReassignPerformerFavorites(ctx context.Context, arg ReassignPerformerFavoritesParams) error
 	ReassignStudioFavorites(ctx context.Context, arg ReassignStudioFavoritesParams) error
 	ResetVotes(ctx context.Context, editID uuid.UUID) error
+	// Keep the WHERE clause in sync across SearchPerformers, CountPerformerSearchMatches,
+	// and GetPerformerSearchFacets so paging, counts, and facets stay consistent.
 	SearchPerformers(ctx context.Context, arg SearchPerformersParams) ([]uuid.UUID, error)
 	// Token-at-a-time scoring. The search term is tokenized by the caller and
 	// passed as an array. Each token is scored independently against every field

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -14,6 +14,7 @@ type Querier interface {
 	CancelUserEdits(ctx context.Context, userID uuid.NullUUID) error
 	ClearScenePerformerAlias(ctx context.Context, arg ClearScenePerformerAliasParams) error
 	CountNotificationsByUser(ctx context.Context, arg CountNotificationsByUserParams) (int64, error)
+	CountPerformerSearchMatches(ctx context.Context, arg CountPerformerSearchMatchesParams) (interface{}, error)
 	CountScenesByPerformer(ctx context.Context, performerID uuid.UUID) (int64, error)
 	CountUserEditsByStatus(ctx context.Context, userID uuid.NullUUID) ([]CountUserEditsByStatusRow, error)
 	CountUsers(ctx context.Context) (int64, error)
@@ -269,6 +270,7 @@ type Querier interface {
 	// Performer images
 	GetPerformerImages(ctx context.Context, performerID uuid.UUID) ([]Image, error)
 	GetPerformerPiercings(ctx context.Context, performerID uuid.UUID) ([]GetPerformerPiercingsRow, error)
+	GetPerformerSearchFacets(ctx context.Context, arg GetPerformerSearchFacetsParams) (interface{}, error)
 	GetPerformerTattoos(ctx context.Context, performerID uuid.UUID) ([]GetPerformerTattoosRow, error)
 	GetPerformerURLs(ctx context.Context, performerID uuid.UUID) ([]GetPerformerURLsRow, error)
 	GetPrimaryEditCommentID(ctx context.Context, editID uuid.UUID) (uuid.UUID, error)
@@ -305,7 +307,7 @@ type Querier interface {
 	ReassignPerformerFavorites(ctx context.Context, arg ReassignPerformerFavoritesParams) error
 	ReassignStudioFavorites(ctx context.Context, arg ReassignStudioFavoritesParams) error
 	ResetVotes(ctx context.Context, editID uuid.UUID) error
-	SearchPerformersWithFacets(ctx context.Context, arg SearchPerformersWithFacetsParams) ([]SearchPerformersWithFacetsRow, error)
+	SearchPerformers(ctx context.Context, arg SearchPerformersParams) ([]uuid.UUID, error)
 	// Token-at-a-time scoring. The search term is tokenized by the caller and
 	// passed as an array. Each token is scored independently against every field
 	// via disjunction_max, so a token that hits several fields (e.g. a studio named

--- a/internal/queries/sql/performer.sql
+++ b/internal/queries/sql/performer.sql
@@ -73,11 +73,8 @@ JOIN performer_urls PU ON PU.performer_id = P.id
 WHERE LOWER(PU.url) = LOWER(sqlc.narg('url'))
 LIMIT sqlc.arg('limit');
 
--- name: SearchPerformersWithFacets :many
-SELECT
-    performer_id,
-    pdb.agg('{"terms": {"field": "gender"}}') OVER () as gender_facets,
-    pdb.agg('{"value_count": {"field": "performer_id"}}') OVER () as total_count
+-- name: SearchPerformers :many
+SELECT performer_id
 FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     paradedb.boolean(
@@ -91,6 +88,34 @@ WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
 AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT)
 ORDER BY pdb.score(performer_id) DESC
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
+
+-- name: CountPerformerSearchMatches :one
+SELECT pdb.agg('{"value_count": {"field": "performer_id"}}') AS total_count
+FROM performer_search
+WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
+    paradedb.boolean(
+        should => ARRAY[
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.narg('term')::TEXT)),
+            paradedb.match(field => 'disambiguation', value => sqlc.narg('term')::TEXT)
+        ]
+    ),
+    paradedb.match(field => 'aliases', value => sqlc.narg('term')::TEXT)
+])
+AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT);
+
+-- name: GetPerformerSearchFacets :one
+SELECT pdb.agg('{"terms": {"field": "gender"}}') AS gender_facets
+FROM performer_search
+WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
+    paradedb.boolean(
+        should => ARRAY[
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.narg('term')::TEXT)),
+            paradedb.match(field => 'disambiguation', value => sqlc.narg('term')::TEXT)
+        ]
+    ),
+    paradedb.match(field => 'aliases', value => sqlc.narg('term')::TEXT)
+])
+AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT);
 
 -- Performer aliases
 

--- a/internal/queries/sql/performer.sql
+++ b/internal/queries/sql/performer.sql
@@ -73,17 +73,20 @@ JOIN performer_urls PU ON PU.performer_id = P.id
 WHERE LOWER(PU.url) = LOWER(sqlc.narg('url'))
 LIMIT sqlc.arg('limit');
 
+-- Keep the WHERE clause in sync across SearchPerformers, CountPerformerSearchMatches,
+-- and GetPerformerSearchFacets so paging, counts, and facets stay consistent.
+
 -- name: SearchPerformers :many
 SELECT performer_id
 FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     paradedb.boolean(
         should => ARRAY[
-            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.narg('term')::TEXT)),
-            paradedb.match(field => 'disambiguation', value => sqlc.narg('term')::TEXT)
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.arg('term')::TEXT)),
+            paradedb.match(field => 'disambiguation', value => sqlc.arg('term')::TEXT)
         ]
     ),
-    paradedb.match(field => 'aliases', value => sqlc.narg('term')::TEXT)
+    paradedb.match(field => 'aliases', value => sqlc.arg('term')::TEXT)
 ])
 AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT)
 ORDER BY pdb.score(performer_id) DESC
@@ -95,11 +98,11 @@ FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     paradedb.boolean(
         should => ARRAY[
-            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.narg('term')::TEXT)),
-            paradedb.match(field => 'disambiguation', value => sqlc.narg('term')::TEXT)
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.arg('term')::TEXT)),
+            paradedb.match(field => 'disambiguation', value => sqlc.arg('term')::TEXT)
         ]
     ),
-    paradedb.match(field => 'aliases', value => sqlc.narg('term')::TEXT)
+    paradedb.match(field => 'aliases', value => sqlc.arg('term')::TEXT)
 ])
 AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT);
 
@@ -109,11 +112,11 @@ FROM performer_search
 WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     paradedb.boolean(
         should => ARRAY[
-            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.narg('term')::TEXT)),
-            paradedb.match(field => 'disambiguation', value => sqlc.narg('term')::TEXT)
+            paradedb.boost(factor => 1.5, query => paradedb.match(field => 'name', value => sqlc.arg('term')::TEXT)),
+            paradedb.match(field => 'disambiguation', value => sqlc.arg('term')::TEXT)
         ]
     ),
-    paradedb.match(field => 'aliases', value => sqlc.narg('term')::TEXT)
+    paradedb.match(field => 'aliases', value => sqlc.arg('term')::TEXT)
 ])
 AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT);
 

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -524,7 +524,7 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 
 func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.PerformerSearchParams) ([]models.Performer, error) {
 	ids, err := s.queries.SearchPerformers(ctx, queries.SearchPerformersParams{
-		Term:         &params.Term,
+		Term:         params.Term,
 		FilterGender: params.FilterGender,
 		Limit:        int32(params.Limit),
 		Offset:       int32(params.Offset),
@@ -545,7 +545,7 @@ func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.Perf
 
 func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.PerformerSearchParams) (int, error) {
 	raw, err := s.queries.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
-		Term:         &params.Term,
+		Term:         params.Term,
 		FilterGender: params.FilterGender,
 	})
 	if err != nil {
@@ -556,7 +556,7 @@ func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.Per
 
 func (s *Performer) SearchPerformerFacets(ctx context.Context, params *models.PerformerSearchParams) (*models.PerformerSearchFacets, error) {
 	raw, err := s.queries.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
-		Term:         &params.Term,
+		Term:         params.Term,
 		FilterGender: params.FilterGender,
 	})
 	if err != nil {

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -512,19 +512,25 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 		}
 	}
 
-	rows, err := s.queries.SearchPerformersWithFacets(ctx, queries.SearchPerformersWithFacetsParams{
-		Term:         &trimmedQuery,
-		Limit:        int32(searchLimit),
-		Offset:       int32(searchOffset),
-		FilterGender: filterGender,
+	return &models.PerformerQuery{
+		Search: &models.PerformerSearchParams{
+			Term:         trimmedQuery,
+			FilterGender: filterGender,
+			Limit:        searchLimit,
+			Offset:       searchOffset,
+		},
+	}, nil
+}
+
+func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.PerformerSearchParams) ([]models.Performer, error) {
+	ids, err := s.queries.SearchPerformers(ctx, queries.SearchPerformersParams{
+		Term:         &params.Term,
+		FilterGender: params.FilterGender,
+		Limit:        int32(params.Limit),
+		Offset:       int32(params.Offset),
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	ids := make([]uuid.UUID, len(rows))
-	for i, row := range rows {
-		ids[i] = row.PerformerID
 	}
 
 	performerPtrs, _ := s.LoadByIds(ctx, ids)
@@ -534,22 +540,29 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 			performers = append(performers, *p)
 		}
 	}
+	return performers, nil
+}
 
-	// Parse facets and count from the first row (all rows have the same aggregated values)
-	var facets *models.PerformerSearchFacets
-	count := 0
-	if len(rows) > 0 {
-		facets = parsePerformerFacets(rows[0].GenderFacets)
-		count = parseParadeDBCount(rows[0].TotalCount)
+func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.PerformerSearchParams) (int, error) {
+	raw, err := s.queries.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
+		Term:         &params.Term,
+		FilterGender: params.FilterGender,
+	})
+	if err != nil {
+		return 0, err
 	}
+	return parseParadeDBCount(raw), nil
+}
 
-	return &models.PerformerQuery{
-		SearchResults: &models.PerformerSearchResults{
-			Performers: performers,
-			Count:      count,
-			Facets:     facets,
-		},
-	}, nil
+func (s *Performer) SearchPerformerFacets(ctx context.Context, params *models.PerformerSearchParams) (*models.PerformerSearchFacets, error) {
+	raw, err := s.queries.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
+		Term:         &params.Term,
+		FilterGender: params.FilterGender,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return parsePerformerFacets(raw), nil
 }
 
 type paradeDBCountResult struct {


### PR DESCRIPTION
Drafted with claude.

There's a [bug in paradedb](https://github.com/paradedb/paradedb/issues/5051) which is triggered by the way we do faceting and results in filtering breaking.

Instead of waiting for the fix we can resolve it by splitting the query into a search query and a facet count query. This should also be very slightly faster for the base case where we don't do faceting.