### PR TITLE
Fix performer search query error

### DIFF
--- a/internal/queries/performer.sql.go
+++ b/internal/queries/performer.sql.go
@@ -1059,7 +1059,7 @@ WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     ))::paradedb.searchqueryinput
 ])
 AND ($2::TEXT IS NULL OR gender = $2::TEXT)
-ORDER BY pdb.score(performer_id) DESC
+ORDER BY pdb.score(performer_id) DESC, performer_id
 LIMIT $4 OFFSET $3
 `
 

--- a/internal/queries/scene.sql.go
+++ b/internal/queries/scene.sql.go
@@ -608,7 +608,7 @@ WHERE scene_id @@@ paradedb.boolean(should =>
         FROM unnest($1::TEXT[]) AS tok
     )
 )
-ORDER BY pdb.score(scene_id) DESC
+ORDER BY pdb.score(scene_id) DESC, scene_id
 LIMIT $3 OFFSET $2
 `
 

--- a/internal/queries/sql/performer.sql
+++ b/internal/queries/sql/performer.sql
@@ -96,7 +96,7 @@ WHERE performer_id @@@ paradedb.disjunction_max(disjuncts => ARRAY[
     ))::paradedb.searchqueryinput
 ])
 AND (sqlc.narg('filter_gender')::TEXT IS NULL OR gender = sqlc.narg('filter_gender')::TEXT)
-ORDER BY pdb.score(performer_id) DESC
+ORDER BY pdb.score(performer_id) DESC, performer_id
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: CountPerformerSearchMatches :one

--- a/internal/queries/sql/scene.sql
+++ b/internal/queries/sql/scene.sql
@@ -102,7 +102,7 @@ WHERE scene_id @@@ paradedb.boolean(should =>
         FROM unnest(sqlc.arg('tokens')::TEXT[]) AS tok
     )
 )
-ORDER BY pdb.score(scene_id) DESC
+ORDER BY pdb.score(scene_id) DESC, scene_id
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: CountScenesByPerformer :one

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -522,12 +522,31 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 	}, nil
 }
 
+// bm25Search wraps a ParadeDB BM25 query in a tx with plan_cache_mode=
+// force_custom_plan. Without this the planner switches to a generic plan
+// after 5 prepared-statement executes and pdb.score() fails with
+// "Unsupported query shape".
+func bm25Search[T any](s *Performer, ctx context.Context, fn func(*queries.Queries) (T, error)) (T, error) {
+	var out T
+	err := s.withTxn(func(q *queries.Queries) error {
+		if _, err := q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan"); err != nil {
+			return err
+		}
+		var err error
+		out, err = fn(q)
+		return err
+	})
+	return out, err
+}
+
 func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.PerformerSearchParams) ([]models.Performer, error) {
-	ids, err := s.queries.SearchPerformers(ctx, queries.SearchPerformersParams{
-		Term:         params.Term,
-		FilterGender: params.FilterGender,
-		Limit:        int32(params.Limit),
-		Offset:       int32(params.Offset),
+	ids, err := bm25Search(s, ctx, func(q *queries.Queries) ([]uuid.UUID, error) {
+		return q.SearchPerformers(ctx, queries.SearchPerformersParams{
+			Term:         params.Term,
+			FilterGender: params.FilterGender,
+			Limit:        int32(params.Limit),
+			Offset:       int32(params.Offset),
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -544,9 +563,11 @@ func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.Perf
 }
 
 func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.PerformerSearchParams) (int, error) {
-	raw, err := s.queries.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
-		Term:         params.Term,
-		FilterGender: params.FilterGender,
+	raw, err := bm25Search(s, ctx, func(q *queries.Queries) (interface{}, error) {
+		return q.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
+			Term:         params.Term,
+			FilterGender: params.FilterGender,
+		})
 	})
 	if err != nil {
 		return 0, err
@@ -555,9 +576,11 @@ func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.Per
 }
 
 func (s *Performer) SearchPerformerFacets(ctx context.Context, params *models.PerformerSearchParams) (*models.PerformerSearchFacets, error) {
-	raw, err := s.queries.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
-		Term:         params.Term,
-		FilterGender: params.FilterGender,
+	raw, err := bm25Search(s, ctx, func(q *queries.Queries) (interface{}, error) {
+		return q.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
+			Term:         params.Term,
+			FilterGender: params.FilterGender,
+		})
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -526,7 +526,7 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 // force_custom_plan. Without this the planner switches to a generic plan
 // after 5 prepared-statement executes and pdb.score() fails with
 // "Unsupported query shape".
-func bm25Search[T any](s *Performer, ctx context.Context, fn func(*queries.Queries) (T, error)) (T, error) {
+func bm25Search[T any](ctx context.Context, s *Performer, fn func(*queries.Queries) (T, error)) (T, error) {
 	var out T
 	err := s.withTxn(func(q *queries.Queries) error {
 		if _, err := q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan"); err != nil {
@@ -540,7 +540,7 @@ func bm25Search[T any](s *Performer, ctx context.Context, fn func(*queries.Queri
 }
 
 func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.PerformerSearchParams) ([]models.Performer, error) {
-	ids, err := bm25Search(s, ctx, func(q *queries.Queries) ([]uuid.UUID, error) {
+	ids, err := bm25Search(ctx, s, func(q *queries.Queries) ([]uuid.UUID, error) {
 		return q.SearchPerformers(ctx, queries.SearchPerformersParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,
@@ -563,7 +563,7 @@ func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.Perf
 }
 
 func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.PerformerSearchParams) (int, error) {
-	raw, err := bm25Search(s, ctx, func(q *queries.Queries) (interface{}, error) {
+	raw, err := bm25Search(ctx, s, func(q *queries.Queries) (interface{}, error) {
 		return q.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,
@@ -576,7 +576,7 @@ func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.Per
 }
 
 func (s *Performer) SearchPerformerFacets(ctx context.Context, params *models.PerformerSearchParams) (*models.PerformerSearchFacets, error) {
-	raw, err := bm25Search(s, ctx, func(q *queries.Queries) (interface{}, error) {
+	raw, err := bm25Search(ctx, s, func(q *queries.Queries) (interface{}, error) {
 		return q.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,


### PR DESCRIPTION
Weird query issues are causing prepared queries to fail, so we force plan every performer search query to avoid the issue. Extremely minor performance impact.

Also added secondary sort to searches so they're stable when multiple results have the same score. Prevents pagination issues.