### PR TITLE
Query optimizations

### DIFF
--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1962,7 +1962,7 @@ export type SceneQueryInput = {
   studios?: InputMaybe<MultiIdCriterionInput>;
   /** Filter to only include scenes with these tags */
   tags?: InputMaybe<MultiIdCriterionInput>;
-  /** Filter to search title and details - assumes like query unless quoted */
+  /** @deprecated Use `title` instead. */
   text?: InputMaybe<Scalars['String']['input']>;
   /** Filter to search title - assumes like query unless quoted */
   title?: InputMaybe<Scalars['String']['input']>;

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -236,8 +236,7 @@ enum SceneSortEnum {
 }
 
 input SceneQueryInput {
-  """Filter to search title and details - assumes like query unless quoted"""
-  text: String
+  text: String @deprecated(reason: "Use `title` instead.")
   """Filter to search title - assumes like query unless quoted"""
   title: String
   """Filter to search urls - assumes like query unless quoted"""

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 66
+	schemaVersion  = 67
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/67_edits_index_and_performer_trigger.up.sql
+++ b/internal/database/migrations/postgres/67_edits_index_and_performer_trigger.up.sql
@@ -1,0 +1,12 @@
+CREATE INDEX edits_user_id_idx ON edits (user_id);
+
+-- upsert_scene_search only reads performers.name from the performer row,
+-- so the per-scene fan-out only needs to fire when the name actually changes.
+-- Previously this trigger ran on every UPDATE (height, ethnicity, ...),
+-- causing 1+ second writes for performers with many scenes.
+DROP TRIGGER trg_scene_search_on_performer ON performers;
+CREATE TRIGGER trg_scene_search_on_performer
+AFTER UPDATE OF name ON performers
+FOR EACH ROW
+WHEN (NEW.name IS DISTINCT FROM OLD.name)
+EXECUTE FUNCTION trg_performer_changed_scenes();

--- a/internal/database/migrations/postgres/67_edits_index_and_performer_trigger.up.sql
+++ b/internal/database/migrations/postgres/67_edits_index_and_performer_trigger.up.sql
@@ -1,9 +1,6 @@
 CREATE INDEX edits_user_id_idx ON edits (user_id);
 
--- upsert_scene_search only reads performers.name from the performer row,
--- so the per-scene fan-out only needs to fire when the name actually changes.
--- Previously this trigger ran on every UPDATE (height, ethnicity, ...),
--- causing 1+ second writes for performers with many scenes.
+-- Trigger is  only necessary when name changes. Ignore other field updates.
 DROP TRIGGER trg_scene_search_on_performer ON performers;
 CREATE TRIGGER trg_scene_search_on_performer
 AFTER UPDATE OF name ON performers

--- a/internal/database/migrations/postgres/67_edits_user_id_idx.up.sql
+++ b/internal/database/migrations/postgres/67_edits_user_id_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX edits_user_id_idx ON edits (user_id);

--- a/internal/database/migrations/postgres/67_edits_user_id_idx.up.sql
+++ b/internal/database/migrations/postgres/67_edits_user_id_idx.up.sql
@@ -1,1 +1,0 @@
-CREATE INDEX edits_user_id_idx ON edits (user_id);

--- a/internal/models/generated_exec.go
+++ b/internal/models/generated_exec.go
@@ -5873,8 +5873,7 @@ enum SceneSortEnum {
 }
 
 input SceneQueryInput {
-  """Filter to search title and details - assumes like query unless quoted"""
-  text: String
+  text: String @deprecated(reason: "Use ` + "`" + `title` + "`" + ` instead.")
   """Filter to search title - assumes like query unless quoted"""
   title: String
   """Filter to search urls - assumes like query unless quoted"""

--- a/internal/models/generated_models.go
+++ b/internal/models/generated_models.go
@@ -752,7 +752,6 @@ type SceneEditInput struct {
 }
 
 type SceneQueryInput struct {
-	// Filter to search title and details - assumes like query unless quoted
 	Text *string `json:"text,omitempty"`
 	// Filter to search title - assumes like query unless quoted
 	Title *string `json:"title,omitempty"`

--- a/internal/service/edit/query.go
+++ b/internal/service/edit/query.go
@@ -72,9 +72,10 @@ func (s *Edit) buildEditQuery(psql sq.StatementBuilderType, filter models.EditQu
 	if filter.Voted != nil && *filter.Voted != "" {
 		switch *filter.Voted {
 		case models.UserVotedFilterEnumNotVoted:
-			query = query.
-				LeftJoin("edit_votes ON edits.id = edit_votes.edit_id AND edit_votes.user_id = ?", userID).
-				Where("edit_votes.user_id IS NULL")
+			query = query.Where(
+				"NOT EXISTS (SELECT 1 FROM edit_votes WHERE edit_id = edits.id AND user_id = ?)",
+				userID,
+			)
 		default:
 			query = query.
 				Join("edit_votes ON edits.id = edit_votes.edit_id").

--- a/internal/service/query/criterion.go
+++ b/internal/service/query/criterion.go
@@ -39,10 +39,11 @@ func ApplyMultiIDCriterion(query *sq.SelectBuilder, tableName, joinTable, fkColu
 			Having(sq.Eq{"COUNT(*)": len(criterion.Value)})
 		*query = query.JoinClause(sq.Expr(fmt.Sprintf("INNER JOIN (?) AS %s_filter ON %s.id = %s_filter.%s", joinTable, tableName, joinTable, fkColumn), subquery))
 	case models.CriterionModifierExcludes:
-		subquery := sq.Select(fkColumn).
+		subquery := sq.Select("1").
 			From(joinTable).
-			Where(sq.Eq{joinField: criterion.Value})
-		*query = query.Where(sq.Expr(fmt.Sprintf("%s.id NOT IN (?)", tableName), subquery))
+			Where(sq.Eq{joinField: criterion.Value}).
+			Where(sq.Expr(fmt.Sprintf("%s.%s = %s.id", joinTable, fkColumn, tableName)))
+		*query = query.Where(sq.Expr("NOT EXISTS (?)", subquery))
 	default:
 		return fmt.Errorf("unsupported modifier %s for %s.%s", criterion.Modifier, joinTable, joinField)
 	}

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -106,13 +106,9 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 		) SFP ON scenes.id = SFP.scene_id`, userID)
 	}
 
-	// Filter by text (title and details)
 	if input.Text != nil && *input.Text != "" {
 		searchTerm := "%" + *input.Text + "%"
-		query = query.Where(sq.Or{
-			sq.ILike{"scenes.title": searchTerm},
-			sq.ILike{"scenes.details": searchTerm},
-		})
+		query = query.Where(sq.ILike{"scenes.title": searchTerm})
 	}
 
 	// Filter by title only


### PR DESCRIPTION
Optimizes a few different queries that show up in traces.
Also deprecates the `text` filter and removes `description` searching. It's very slow since it's unindexed, and and index would be enormous due to the corpus size. As far as I know nobody actually uses it for desc searching.