### PR TITLE
Fix image size calculation

### DIFF
--- a/frontend/src/components/image/styles.scss
+++ b/frontend/src/components/image/styles.scss
@@ -1,12 +1,10 @@
 .Image {
   position: relative;
   display: flex;
-  max-height: 100%;
-  max-width: 100%;
 
   &-image {
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     z-index: 1;
   }
 


### PR DESCRIPTION
Updated image styles to use width and height instead of max dimensions.

This should finally fix #931 (related: #1030)
- Removed max-width and max-height, so Safari doesn't get confused about aspect-ratio.
- After that, correct dimensions is calculated 
- .Image-image fills 100% of it's container