### PR TITLE
Remove `margin-right` from gender icons

### DIFF
--- a/frontend/src/pages/scenes/styles.scss
+++ b/frontend/src/pages/scenes/styles.scss
@@ -1,9 +1,3 @@
-.fa-mars,
-.fa-venus,
-.fa-transgender {
-  margin-right: 0.25rem;
-}
-
 .fa-mars {
   color: #89cff0;
 }


### PR DESCRIPTION
It seems that is no longer needed, and just adds additional space between the icon and text, that was not there before.

<details>
<summary>Performer Page</summary>

<img width="422" height="112" alt="before-performer" src="https://github.com/user-attachments/assets/1571fd32-6a50-4a94-8b3b-1b2ce5e4ef97" /><br><img width="422" height="112" alt="after-performer" src="https://github.com/user-attachments/assets/debea8fb-ec05-4e0b-b541-8950bcbae622" />
</details>
<details>
<summary>Scene Page</summary>

<img width="184" height="82" alt="before-scene" src="https://github.com/user-attachments/assets/68bae38a-5217-4bfb-8211-285de17cf37b" /><br><img width="176" height="82" alt="after-scene" src="https://github.com/user-attachments/assets/7210f192-93d1-4553-bb10-32728af0e637" />
</details>

Possibly changed in [Font Awesome v7.0.0](https://fontawesome.com/changelog#v7-0-0):
> Icon canvases now render at a consistent fixed width. To use the default rendering from v6, add our new fa-width-auto class.