### PR TITLE
Remove notifications for deleted edits

### DIFF
--- a/internal/api/edit_delete_integration_test.go
+++ b/internal/api/edit_delete_integration_test.go
@@ -4,6 +4,7 @@ package api_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stashapp/stash-box/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -221,6 +222,108 @@ func (s *editDeleteTestRunner) testDeleteEditWithVotes() {
 	assert.Nil(s.t, edit)
 }
 
+func (s *editDeleteTestRunner) testDeleteEditClearsEditNotifications() {
+	// Create edit as a user who will receive notifications
+	editRunner := asEdit(s.t)
+	createdEdit, err := editRunner.createTestTagEdit(models.OperationEnumCreate, nil, nil)
+	assert.NoError(s.t, err)
+
+	// Subscribe the edit owner to downvote notifications
+	_, err = editRunner.client.updateNotificationSubscriptions([]models.NotificationEnum{
+		models.NotificationEnumDownvoteOwnEdit,
+	})
+	assert.NoError(s.t, err)
+
+	// Downvote the edit as moderator; the resolver fires the notification asynchronously
+	_, err = s.resolver.Mutation().EditVote(s.ctx, models.EditVoteInput{
+		ID:   createdEdit.ID,
+		Vote: models.VoteTypeEnumReject,
+	})
+	assert.NoError(s.t, err)
+
+	// Wait for the async notification to land
+	var initialCount int
+	assert.Eventually(s.t, func() bool {
+		result, err := editRunner.client.queryNotifications(models.QueryNotificationsInput{Page: 1, PerPage: 25})
+		if err != nil || result.Count == 0 {
+			return false
+		}
+		initialCount = result.Count
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Close and delete the edit
+	adminRunner := asAdmin(s.t)
+	appliedEdit, err := adminRunner.approveEdit(createdEdit.ID)
+	assert.NoError(s.t, err)
+
+	deleted, err := s.resolver.Mutation().DeleteEdit(s.ctx, models.DeleteEditInput{
+		ID:     appliedEdit.ID,
+		Reason: "test cleanup",
+	})
+	assert.NoError(s.t, err)
+	assert.True(s.t, deleted)
+
+	// queryNotifications must not error and the notification must be gone
+	result, err := editRunner.client.queryNotifications(models.QueryNotificationsInput{
+		Page:    1,
+		PerPage: 25,
+	})
+	assert.NoError(s.t, err)
+	assert.Equal(s.t, initialCount-1, result.Count)
+}
+
+func (s *editDeleteTestRunner) testDeleteEditClearsCommentNotifications() {
+	// Create edit as a user who will receive notifications
+	editRunner := asEdit(s.t)
+	createdEdit, err := editRunner.createTestTagEdit(models.OperationEnumCreate, nil, nil)
+	assert.NoError(s.t, err)
+
+	// Subscribe the edit owner to comment notifications
+	_, err = editRunner.client.updateNotificationSubscriptions([]models.NotificationEnum{
+		models.NotificationEnumCommentOwnEdit,
+	})
+	assert.NoError(s.t, err)
+
+	// Add a comment as moderator; the resolver fires the notification asynchronously
+	_, err = s.resolver.Mutation().EditComment(s.ctx, models.EditCommentInput{
+		ID:      createdEdit.ID,
+		Comment: "test comment",
+	})
+	assert.NoError(s.t, err)
+
+	// Wait for the async notification to land
+	var initialCount int
+	assert.Eventually(s.t, func() bool {
+		result, err := editRunner.client.queryNotifications(models.QueryNotificationsInput{Page: 1, PerPage: 25})
+		if err != nil || result.Count == 0 {
+			return false
+		}
+		initialCount = result.Count
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Close and delete the edit
+	adminRunner := asAdmin(s.t)
+	appliedEdit, err := adminRunner.approveEdit(createdEdit.ID)
+	assert.NoError(s.t, err)
+
+	deleted, err := s.resolver.Mutation().DeleteEdit(s.ctx, models.DeleteEditInput{
+		ID:     appliedEdit.ID,
+		Reason: "test cleanup",
+	})
+	assert.NoError(s.t, err)
+	assert.True(s.t, deleted)
+
+	// queryNotifications must not error and the comment notification must be gone
+	result, err := editRunner.client.queryNotifications(models.QueryNotificationsInput{
+		Page:    1,
+		PerPage: 25,
+	})
+	assert.NoError(s.t, err)
+	assert.Equal(s.t, initialCount-1, result.Count)
+}
+
 func TestDeleteClosedEdit(t *testing.T) {
 	s := createEditDeleteTestRunner(t)
 	s.testDeleteClosedEdit()
@@ -249,4 +352,14 @@ func TestDeleteEditWithComments(t *testing.T) {
 func TestDeleteEditWithVotes(t *testing.T) {
 	s := createEditDeleteTestRunner(t)
 	s.testDeleteEditWithVotes()
+}
+
+func TestDeleteEditClearsEditNotifications(t *testing.T) {
+	s := createEditDeleteTestRunner(t)
+	s.testDeleteEditClearsEditNotifications()
+}
+
+func TestDeleteEditClearsCommentNotifications(t *testing.T) {
+	s := createEditDeleteTestRunner(t)
+	s.testDeleteEditClearsCommentNotifications()
 }

--- a/internal/queries/notification.sql.go
+++ b/internal/queries/notification.sql.go
@@ -33,6 +33,24 @@ type CreateUserNotificationSubscriptionsParams struct {
 	Type   NotificationType `db:"type" json:"type"`
 }
 
+const deleteNotificationsByEditComments = `-- name: DeleteNotificationsByEditComments :exec
+DELETE FROM notifications WHERE id IN (SELECT id FROM edit_comments WHERE edit_id = $1)
+`
+
+func (q *Queries) DeleteNotificationsByEditComments(ctx context.Context, editID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteNotificationsByEditComments, editID)
+	return err
+}
+
+const deleteNotificationsByTargetID = `-- name: DeleteNotificationsByTargetID :exec
+DELETE FROM notifications WHERE id = $1
+`
+
+func (q *Queries) DeleteNotificationsByTargetID(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteNotificationsByTargetID, id)
+	return err
+}
+
 const deleteUserNotificationSubscriptions = `-- name: DeleteUserNotificationSubscriptions :exec
 DELETE FROM user_notifications WHERE user_id = $1
 `

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -99,6 +99,8 @@ type Querier interface {
 	DeleteExpiredUserTokens(ctx context.Context) error
 	DeleteImage(ctx context.Context, id uuid.UUID) error
 	DeleteInviteKey(ctx context.Context, id uuid.UUID) error
+	DeleteNotificationsByEditComments(ctx context.Context, editID uuid.UUID) error
+	DeleteNotificationsByTargetID(ctx context.Context, id uuid.UUID) error
 	DeletePerformer(ctx context.Context, id uuid.UUID) error
 	// Performer aliases
 	DeletePerformerAliases(ctx context.Context, performerID uuid.UUID) error

--- a/internal/queries/sql/notification.sql
+++ b/internal/queries/sql/notification.sql
@@ -23,6 +23,12 @@ INSERT INTO user_notifications (user_id, type) VALUES ($1, $2);
 -- name: DeleteUserNotificationSubscriptions :exec
 DELETE FROM user_notifications WHERE user_id = $1;
 
+-- name: DeleteNotificationsByTargetID :exec
+DELETE FROM notifications WHERE id = $1;
+
+-- name: DeleteNotificationsByEditComments :exec
+DELETE FROM notifications WHERE id IN (SELECT id FROM edit_comments WHERE edit_id = $1);
+
 -- name: DestroyExpiredNotifications :exec
 DELETE FROM notifications
 WHERE read_at < CURRENT_DATE - INTERVAL '1 day'

--- a/internal/service/edit/service.go
+++ b/internal/service/edit/service.go
@@ -150,6 +150,14 @@ func (s *Edit) DeleteWithAudit(ctx context.Context, input models.DeleteEditInput
 			}
 		}
 
+		if err := tx.DeleteNotificationsByEditComments(ctx, input.ID); err != nil {
+			return fmt.Errorf("failed to delete comment notifications for edit: %w", err)
+		}
+
+		if err := tx.DeleteNotificationsByTargetID(ctx, input.ID); err != nil {
+			return fmt.Errorf("failed to delete notifications for edit: %w", err)
+		}
+
 		// Delete the edit (cascades to comments and votes)
 		if err := tx.DeleteEdit(ctx, input.ID); err != nil {
 			return fmt.Errorf("failed to delete edit: %w", err)


### PR DESCRIPTION
There's no FK cascade since the `id` column in notifications is a union of different entities. We largely don't hard delete entities, but we do hard delete edits, so we have to clean up affected edits and comments. 

Drafted with claude.