### PR TITLE
Cluster page: Show durations for clusters and fingerprints

### DIFF
--- a/frontend/src/pages/scenes/fingerprintClusters/components/ClusterList.tsx
+++ b/frontend/src/pages/scenes/fingerprintClusters/components/ClusterList.tsx
@@ -1,10 +1,13 @@
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faClock,
+  faExclamationTriangle,
+} from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import type { FC } from "react";
 import { Badge } from "react-bootstrap";
 import { Icon } from "src/components/fragments";
 import { useClusterPage } from "../ClusterPageContext";
-import { clusterSceneSummaries } from "../utils";
+import { clusterDurationLabel, clusterSceneSummaries } from "../utils";
 import { SceneChip } from "./SceneChip";
 
 interface Props {
@@ -31,6 +34,7 @@ export const ClusterList: FC<Props> = ({ onSelect }) => {
           0,
         );
         const memberCount = c.members.length;
+        const durationLabel = clusterDurationLabel(c);
         const warn = sceneSummaries.some((s) => s.scene.id !== seedSceneId);
         return (
           <button
@@ -51,10 +55,21 @@ export const ClusterList: FC<Props> = ({ onSelect }) => {
               )}
             </div>
             <div className="small text-muted mb-2">
-              {memberCount} phash{memberCount === 1 ? "" : "es"} ·{" "}
-              {sceneSummaries.length} scene
-              {sceneSummaries.length === 1 ? "" : "s"} · {totalSubs} submission
-              {totalSubs === 1 ? "" : "s"}
+              <div>
+                <span className="text-nowrap">
+                  {memberCount} phash{memberCount === 1 ? "" : "es"}
+                </span>
+                {" · "}
+                <span className="text-nowrap">
+                  {totalSubs} submission{totalSubs === 1 ? "" : "s"}
+                </span>
+              </div>
+              {durationLabel && (
+                <div>
+                  <Icon icon={faClock} className="me-1" />
+                  {durationLabel}
+                </div>
+              )}
             </div>
             <div className="d-flex flex-wrap gap-1">
               {sceneSummaries.map((s) => (

--- a/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMembersTable.tsx
+++ b/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMembersTable.tsx
@@ -6,7 +6,12 @@ import { Icon } from "src/components/fragments";
 import { ROUTE_SCENE } from "src/constants/route";
 import { useClusterPage } from "../ClusterPageContext";
 import type { Cluster, ClusterLinkedFingerprint, ClusterScene } from "../types";
-import { fingerprintSearchHref, memberTotalSubmissions } from "../utils";
+import {
+  fingerprintSearchHref,
+  formatDurationCounts,
+  memberDurationCounts,
+  memberTotalSubmissions,
+} from "../utils";
 import { SceneChip } from "./SceneChip";
 
 const memberTotalReports = (m: { scene_submissions: { reports: number }[] }) =>
@@ -59,6 +64,7 @@ export const ClusterMembersTable: FC = () => {
       <thead>
         <tr>
           <th>Hash</th>
+          <th>Duration</th>
           <th>Scenes</th>
           <th className="text-end">Submissions</th>
           <th className="text-end">Reports</th>
@@ -90,6 +96,9 @@ export const ClusterMembersTable: FC = () => {
                   <code>{m.hash}</code>
                 </Link>
               </td>
+              <td className="small">
+                {formatDurationCounts(memberDurationCounts(m))}
+              </td>
               <td>
                 <SceneCell submissions={m.scene_submissions} />
               </td>
@@ -104,7 +113,7 @@ export const ClusterMembersTable: FC = () => {
                 key={`${rowKey}::oshash-summary`}
                 className="ClusterMembersTable-oshash-summary text-muted"
               >
-                <td colSpan={4}>
+                <td colSpan={5}>
                   <button
                     type="button"
                     onClick={() => expandedRows.toggle(rowKey)}
@@ -144,6 +153,7 @@ export const ClusterMembersTable: FC = () => {
                         <code>↪ {o.hash}</code>
                       </Link>
                     </td>
+                    <td />
                     <td>
                       <SceneCell
                         submissions={[

--- a/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMoveModal.tsx
+++ b/frontend/src/pages/scenes/fingerprintClusters/components/ClusterMoveModal.tsx
@@ -9,22 +9,13 @@ import { useClusterPage } from "../ClusterPageContext";
 import type { ClusterMember } from "../types";
 import {
   clusterSceneSummaries,
+  formatDurationCounts,
   linkedFingerprintCount,
+  memberDurationCounts,
   selectedMembers as selectedMembersOf,
   sumSelectedSubmissions,
 } from "../utils";
 import { SceneChip } from "./SceneChip";
-
-/** Sum of (duration → count) across all this member's scene submissions. */
-const memberDurationCounts = (m: ClusterMember): [number, number][] => {
-  const counts = m.scene_submissions
-    .flatMap((s) => s.durations)
-    .reduce(
-      (acc, d) => acc.set(d.duration, (acc.get(d.duration) ?? 0) + d.count),
-      new Map<number, number>(),
-    );
-  return [...counts.entries()].sort((a, b) => a[0] - b[0]);
-};
 
 /** Most-submitted duration for a member, or null when unavailable. */
 const dominantDuration = (m: ClusterMember): number | null =>
@@ -161,15 +152,7 @@ export const ClusterMoveModal: FC<Props> = ({ show, onHide, onMove }) => {
                         <code>{m.hash}</code>
                       </td>
                       <td className="small">
-                        {durations.length === 0
-                          ? "—"
-                          : durations
-                              .map(([d, n]) =>
-                                durations.length === 1
-                                  ? formatDuration(d)
-                                  : `${formatDuration(d)} (${n}×)`,
-                              )
-                              .join(", ")}
+                        {formatDurationCounts(durations)}
                       </td>
                       <td>
                         <div className="d-flex flex-wrap gap-1">

--- a/frontend/src/pages/scenes/fingerprintClusters/utils.ts
+++ b/frontend/src/pages/scenes/fingerprintClusters/utils.ts
@@ -1,5 +1,6 @@
 import { ROUTE_SCENES } from "src/constants/route";
 import { FingerprintAlgorithm } from "src/graphql";
+import { formatDuration } from "src/utils";
 import type { Cluster, ClusterMember, ClusterScene } from "./types";
 
 /** Search route for a fingerprint hash. */
@@ -54,6 +55,42 @@ export const linkedFingerprintCount = (
 /** Sum of phash user-submission counts on this member across all scenes. */
 export const memberTotalSubmissions = (m: ClusterMember): number =>
   m.scene_submissions.reduce((s, x) => s + x.submissions, 0);
+
+/** Sum of (duration → count) across all this member's scene submissions. */
+export const memberDurationCounts = (m: ClusterMember): [number, number][] => {
+  const counts = m.scene_submissions
+    .flatMap((s) => s.durations)
+    .reduce(
+      (acc, d) => acc.set(d.duration, (acc.get(d.duration) ?? 0) + d.count),
+      new Map<number, number>(),
+    );
+  return [...counts.entries()].sort((a, b) => a[0] - b[0]);
+};
+
+/** Distinct submitted durations across the whole cluster, ascending. */
+export const clusterDurations = (cluster: Cluster | undefined): number[] => {
+  const set = new Set<number>();
+  for (const m of cluster?.members ?? [])
+    for (const s of m.scene_submissions)
+      for (const d of s.durations) set.add(d.duration);
+  return [...set].sort((a, b) => a - b);
+};
+
+/** All distinct submitted durations for a cluster, ascending, comma-joined. */
+export const clusterDurationLabel = (cluster: Cluster | undefined): string =>
+  clusterDurations(cluster).map(formatDuration).join(", ");
+
+/** Human-readable "MM:SS (n×), …" list of submitted durations. */
+export const formatDurationCounts = (counts: [number, number][]): string =>
+  counts.length === 0
+    ? "—"
+    : counts
+        .map(([d, n]) =>
+          counts.length === 1
+            ? formatDuration(d)
+            : `${formatDuration(d)} (${n}×)`,
+        )
+        .join(", ");
 
 /** Phash hashes that exist on more than one scene in the cluster. */
 export const multiSceneHashes = (cluster: Cluster | undefined): string[] => {

--- a/frontend/src/pages/scenes/fingerprintClusters/utils.ts
+++ b/frontend/src/pages/scenes/fingerprintClusters/utils.ts
@@ -69,11 +69,11 @@ export const memberDurationCounts = (m: ClusterMember): [number, number][] => {
 
 /** Distinct submitted durations across the whole cluster, ascending. */
 export const clusterDurations = (cluster: Cluster | undefined): number[] => {
-  const set = new Set<number>();
-  for (const m of cluster?.members ?? [])
-    for (const s of m.scene_submissions)
-      for (const d of s.durations) set.add(d.duration);
-  return [...set].sort((a, b) => a - b);
+  const durations = (cluster?.members ?? [])
+    .flatMap((m) => m.scene_submissions)
+    .flatMap((s) => s.durations)
+    .map((d) => d.duration);
+  return [...new Set(durations)].sort((a, b) => a - b);
 };
 
 /** All distinct submitted durations for a cluster, ascending, comma-joined. */
@@ -81,16 +81,14 @@ export const clusterDurationLabel = (cluster: Cluster | undefined): string =>
   clusterDurations(cluster).map(formatDuration).join(", ");
 
 /** Human-readable "MM:SS (n×), …" list of submitted durations. */
-export const formatDurationCounts = (counts: [number, number][]): string =>
-  counts.length === 0
-    ? "—"
-    : counts
-        .map(([d, n]) =>
-          counts.length === 1
-            ? formatDuration(d)
-            : `${formatDuration(d)} (${n}×)`,
-        )
-        .join(", ");
+export const formatDurationCounts = (counts: [number, number][]): string => {
+  if (counts.length === 0) return "—";
+  return counts
+    .map(([d, n]) =>
+      counts.length === 1 ? formatDuration(d) : `${formatDuration(d)} (${n}×)`,
+    )
+    .join(", ");
+};
 
 /** Phash hashes that exist on more than one scene in the cluster. */
 export const multiSceneHashes = (cluster: Cluster | undefined): string[] => {


### PR DESCRIPTION
Adds durations to the clusters and fingerprints table so it's easier to distinguish them at a glance.

Drafted with claude.