### PR TITLE
Support alternate frontends on sub-paths

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1"
     />
     <meta name="theme-color" content="#000000" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="%BASE_URL%manifest.json" />
     <title>{{.}}</title>
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ const client = createClient();
 
 const App: FC = () => (
   <ApolloProvider client={client}>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <ToastProvider>
         <Routes>
           <Route

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
 
   /** @type {import("vite").UserConfig} */
   const config = {
+    base: env.VITE_BASE_PATH || "/",
     build: {
       outDir: "build",
       assetsDir: "assets",

--- a/internal/api/routes_frontend.go
+++ b/internal/api/routes_frontend.go
@@ -9,7 +9,6 @@ import (
 )
 
 // frontendRoutes serves an on-disk SPA build mounted at a configurable prefix,
-// alongside the embedded UI served by rootRoutes at /.
 type frontendRoutes struct {
 	dir    string
 	prefix string
@@ -21,8 +20,6 @@ func (fr frontendRoutes) Routes() chi.Router {
 
 	r := chi.NewRouter()
 
-	// The URL still carries the mount prefix here, so strip it before
-	// resolving paths against the build directory.
 	fileServer := http.StripPrefix(fr.prefix, http.FileServer(http.Dir(fr.dir)))
 	assets := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Cache-Control", "max-age=604800000")

--- a/internal/api/routes_frontend.go
+++ b/internal/api/routes_frontend.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// frontendRoutes serves an on-disk SPA build mounted at a configurable prefix,
+// alongside the embedded UI served by rootRoutes at /.
+type frontendRoutes struct {
+	dir    string
+	prefix string
+	index  []byte
+}
+
+func (fr frontendRoutes) Routes() chi.Router {
+	fr.index = getDiskIndex(fr.dir)
+
+	r := chi.NewRouter()
+
+	// The URL still carries the mount prefix here, so strip it before
+	// resolving paths against the build directory.
+	fileServer := http.StripPrefix(fr.prefix, http.FileServer(http.Dir(fr.dir)))
+	assets := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Cache-Control", "max-age=604800000")
+		fileServer.ServeHTTP(w, r)
+	}
+
+	r.HandleFunc("/assets/*", assets)
+	r.HandleFunc("/favicon.ico", assets)
+	r.HandleFunc("/manifest.json", assets)
+
+	r.HandleFunc("/*", fr.app)
+
+	return r
+}
+
+func (fr frontendRoutes) app(w http.ResponseWriter, r *http.Request) {
+	writeAppHeaders(w)
+	_, _ = w.Write(fr.index)
+}
+
+func getDiskIndex(dir string) []byte {
+	indexFile, err := os.ReadFile(filepath.Join(dir, "index.html"))
+	if err != nil {
+		panic(error.Error(err))
+	}
+	return renderIndex(indexFile)
+}

--- a/internal/api/routes_root.go
+++ b/internal/api/routes_root.go
@@ -51,6 +51,12 @@ func (rr rootRoutes) assets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rr rootRoutes) app(w http.ResponseWriter, r *http.Request) {
+	writeAppHeaders(w)
+	_, _ = w.Write(rr.index)
+}
+
+// writeAppHeaders sets the security headers used when serving an SPA index.
+func writeAppHeaders(w http.ResponseWriter) {
 	csp := config.GetCSP()
 	if csp != "" {
 		w.Header().Add("Content-Security-Policy", csp)
@@ -59,14 +65,10 @@ func (rr rootRoutes) app(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Content-Type-Options", "nosniff")
 	w.Header().Add("Referrer-Policy", "same-origin")
 	w.Header().Add("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()")
-	_, _ = w.Write(rr.index)
 }
 
-func getIndex(ui embed.FS) []byte {
-	indexFile, err := ui.ReadFile("build/index.html")
-	if err != nil {
-		panic(error.Error(err))
-	}
+// renderIndex applies the title template to an index.html document.
+func renderIndex(indexFile []byte) []byte {
 	tmpl := template.Must(template.New("index").Parse(string(indexFile)))
 	title := template.HTMLEscapeString(config.GetTitle())
 	output := new(strings.Builder)
@@ -74,4 +76,12 @@ func getIndex(ui embed.FS) []byte {
 		panic(error.Error(err))
 	}
 	return []byte(output.String())
+}
+
+func getIndex(ui embed.FS) []byte {
+	indexFile, err := ui.ReadFile("build/index.html")
+	if err != nil {
+		panic(error.Error(err))
+	}
+	return renderIndex(indexFile)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -203,6 +203,21 @@ func Start(fac service.Factory, ui embed.FS) {
 		r.Handle("/playground", gqlPlayground.Handler("GraphQL playground", "/graphql"))
 	}
 
+	mountedPrefixes := make(map[string]bool)
+	for _, fe := range config.GetFrontends() {
+		if fe.Path == "" || fe.Prefix == "" || fe.Prefix == "/" {
+			logger.Warnf("skipping frontend with missing path/prefix or reserved prefix: %+v", fe)
+			continue
+		}
+		if mountedPrefixes[fe.Prefix] {
+			logger.Warnf("skipping frontend with duplicate prefix %s", fe.Prefix)
+			continue
+		}
+		mountedPrefixes[fe.Prefix] = true
+		r.Mount(fe.Prefix, frontendRoutes{dir: fe.Path, prefix: fe.Prefix}.Routes())
+		logger.Infof("serving frontend from %s at %s", fe.Path, fe.Prefix)
+	}
+
 	r.Mount("/", rootRoutes{ui: ui}.Routes(fac))
 
 	if config.GetProfilerPort() != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,11 @@ type AutocertConfig struct {
 	CacheDir string `mapstructure:"cache_dir"`
 }
 
+type FrontendConfig struct {
+	Path   string `mapstructure:"path"`   // directory holding the build (index.html + assets/)
+	Prefix string `mapstructure:"prefix"` // URL mount point, e.g. "/v2"
+}
+
 type config struct {
 	Host         string `mapstructure:"host"`
 	Port         int    `mapstructure:"port"`
@@ -128,6 +133,10 @@ type config struct {
 	PHashDistance int `mapstructure:"phash_distance"`
 
 	Title string `mapstructure:"title"`
+
+	// Additional on-disk frontend builds mounted at their own prefixes,
+	// served alongside the embedded UI at /.
+	Frontends []FrontendConfig `mapstructure:"frontends"`
 
 	DraftTimeLimit int `mapstructure:"draft_time_limit"`
 
@@ -479,6 +488,10 @@ func GetTitle() string {
 		return "Stash-Box"
 	}
 	return C.Title
+}
+
+func GetFrontends() []FrontendConfig {
+	return C.Frontends
 }
 
 func GetFaviconPath() (*string, error) {


### PR DESCRIPTION
For testing purposes, add the option of serving a custom frontend bundle at a configurable path, i.e. `/beta`.

No impact if not enables.