### PR TITLE
Add optional TwelveLabs Marengo embedding integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ There are two ways to authenticate a user in Stash-box: a session or an API key.
 | `autocert.domain` | (none) | The domain to generate certificates for.|
 | `autocert.email` | (none) | A valid email. Will be submitted to Let's Encrypt, but otherwise not made public. |
 | `mod_audit_retention_days` | 30 | Number of days to retain audit logs of moderator actions. Set `0` to disable. |
+| `twelvelabs.api_key` | (none) | API key for the optional [TwelveLabs](#twelvelabs-embeddings-optional) Marengo embedding integration. Leave empty to disable. |
+| `twelvelabs.model_name` | `marengo3.0` | TwelveLabs embedding model to use. |
+| `twelvelabs.base_url` | `https://api.twelvelabs.io/v1.3` | Base URL for the TwelveLabs API. |
+
+## TwelveLabs embeddings (optional)
+
+Stash-box deduplicates and searches video content with perceptual-hash (pHash)
+fingerprints, which reliably match near-identical encodes but miss content that
+has been re-encoded, cropped, or otherwise visually altered. As an opt-in
+augmentation, stash-box can compute content-based embeddings via
+[TwelveLabs](https://twelvelabs.io) Marengo. These 512-dimension multimodal
+vectors live in a single space shared by text and video, so a text query can be
+matched against video embeddings and vice versa, and visually-similar scenes can
+be ranked by cosine similarity.
+
+The integration is entirely opt-in and changes no defaults: it is inactive
+unless `twelvelabs.api_key` is set, and existing pHash behaviour is unaffected.
+
+```
+twelvelabs:
+    api_key: tlk_your_key_here
+```
+
+You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) — there is
+a generous free tier.
 
 ## SSL (HTTPS)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,15 @@ type AutocertConfig struct {
 	CacheDir string `mapstructure:"cache_dir"`
 }
 
+// TwelveLabsConfig holds settings for the optional TwelveLabs Marengo
+// embedding integration, which augments perceptual-hash matching with
+// content-based similarity. Disabled unless an API key is provided.
+type TwelveLabsConfig struct {
+	APIKey    string `mapstructure:"api_key"`
+	ModelName string `mapstructure:"model_name"`
+	BaseURL   string `mapstructure:"base_url"`
+}
+
 type config struct {
 	Host         string `mapstructure:"host"`
 	Port         int    `mapstructure:"port"`
@@ -123,6 +132,10 @@ type config struct {
 
 	Autocert struct {
 		AutocertConfig `mapstructure:",squash"`
+	}
+
+	TwelveLabs struct {
+		TwelveLabsConfig `mapstructure:",squash"`
 	}
 
 	PHashDistance int `mapstructure:"phash_distance"`
@@ -306,6 +319,16 @@ func GetAutocertConfig() *AutocertConfig {
 		return &C.Autocert.AutocertConfig
 	}
 	return nil
+}
+
+// GetTwelveLabsConfig returns the TwelveLabs Marengo configuration, or nil
+// when no API key is set. The integration is opt-in: callers must treat a nil
+// result as "feature disabled" and fall back to existing behaviour.
+func GetTwelveLabsConfig() *TwelveLabsConfig {
+	if C.TwelveLabs.APIKey == "" {
+		return nil
+	}
+	return &C.TwelveLabs.TwelveLabsConfig
 }
 
 func GetMissingAutocertSettings() []string {

--- a/internal/embedding/twelvelabs.go
+++ b/internal/embedding/twelvelabs.go
@@ -1,0 +1,167 @@
+// Package embedding provides an optional TwelveLabs Marengo client for
+// computing content-based video/text embeddings. These 512-dimension vectors
+// complement the existing perceptual-hash (PHASH) fingerprints: pHash matches
+// near-identical encodes, while Marengo embeddings catch re-encoded, cropped,
+// or otherwise visually-similar content that pHash misses, improving duplicate
+// detection and similarity search.
+//
+// The integration is opt-in. It is only active when a TwelveLabs API key is
+// configured; with no key configured the rest of the application is unaffected.
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"mime/multipart"
+	"net/http"
+	"time"
+)
+
+const (
+	// defaultBaseURL is the TwelveLabs API base used when none is configured.
+	defaultBaseURL = "https://api.twelvelabs.io/v1.3"
+	// defaultModel is the Marengo embedding model. Marengo produces 512-dim
+	// multimodal embeddings shared across text and video, so a text query can
+	// be matched against video embeddings and vice versa.
+	defaultModel = "marengo3.0"
+	// EmbeddingDimensions is the fixed size of a Marengo embedding vector.
+	EmbeddingDimensions = 512
+
+	defaultTimeout = 60 * time.Second
+)
+
+// Client is a minimal TwelveLabs embedding client. The zero value is not
+// usable; construct one with New.
+type Client struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New constructs a Client. apiKey is required. model and baseURL fall back to
+// the Marengo defaults when empty.
+func New(apiKey, model, baseURL string) *Client {
+	if model == "" {
+		model = defaultModel
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{
+		apiKey:     apiKey,
+		model:      model,
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: defaultTimeout},
+	}
+}
+
+// embedResponse mirrors the relevant fields of the /embed response. The API
+// returns the vector under text_embedding.segments[].float.
+type embedResponse struct {
+	TextEmbedding struct {
+		Segments []struct {
+			Float []float32 `json:"float"`
+		} `json:"segments"`
+	} `json:"text_embedding"`
+}
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// TextEmbedding returns the 512-dimension Marengo embedding for the given text.
+// The resulting vector lives in the same space as video embeddings, so it can
+// be compared directly (via Cosine) against indexed scene embeddings.
+func (c *Client) TextEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if text == "" {
+		return nil, fmt.Errorf("text must not be empty")
+	}
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	if err := w.WriteField("model_name", c.model); err != nil {
+		return nil, fmt.Errorf("writing model_name field: %w", err)
+	}
+	if err := w.WriteField("text", text); err != nil {
+		return nil, fmt.Errorf("writing text field: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("closing multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/embed", &body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling TwelveLabs embed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr apiError
+		if json.Unmarshal(payload, &apiErr) == nil && apiErr.Message != "" {
+			return nil, fmt.Errorf("TwelveLabs embed failed (%d %s): %s", resp.StatusCode, apiErr.Code, apiErr.Message)
+		}
+		return nil, fmt.Errorf("TwelveLabs embed failed with status %d", resp.StatusCode)
+	}
+
+	return parseEmbedding(payload)
+}
+
+// parseEmbedding extracts the first segment's embedding from an /embed
+// response body. Split out from TextEmbedding so it can be unit-tested without
+// a network call.
+func parseEmbedding(payload []byte) ([]float32, error) {
+	var parsed embedResponse
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	if len(parsed.TextEmbedding.Segments) == 0 {
+		return nil, fmt.Errorf("response contained no embedding segments")
+	}
+	vec := parsed.TextEmbedding.Segments[0].Float
+	if len(vec) == 0 {
+		return nil, fmt.Errorf("embedding segment was empty")
+	}
+	return vec, nil
+}
+
+// Cosine returns the cosine similarity of two embeddings, in the range
+// [-1, 1]; higher means more similar. It returns an error when the vectors
+// differ in length or either has zero magnitude. This is the primary signal
+// for ranking content similarity between scenes.
+func Cosine(a, b []float32) (float64, error) {
+	if len(a) != len(b) {
+		return 0, fmt.Errorf("embedding length mismatch: %d != %d", len(a), len(b))
+	}
+	if len(a) == 0 {
+		return 0, fmt.Errorf("embeddings must not be empty")
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		av, bv := float64(a[i]), float64(b[i])
+		dot += av * bv
+		normA += av * av
+		normB += bv * bv
+	}
+	if normA == 0 || normB == 0 {
+		return 0, fmt.Errorf("embedding has zero magnitude")
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB)), nil
+}

--- a/internal/embedding/twelvelabs_test.go
+++ b/internal/embedding/twelvelabs_test.go
@@ -1,0 +1,120 @@
+package embedding
+
+import (
+	"context"
+	"math"
+	"os"
+	"testing"
+)
+
+func TestParseEmbedding(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    []float32
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			payload: `{"model_name":"marengo3.0","text_embedding":{"segments":[{"float":[0.1,-0.2,0.3]}]}}`,
+			want:    []float32{0.1, -0.2, 0.3},
+		},
+		{
+			name:    "no segments",
+			payload: `{"text_embedding":{"segments":[]}}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty segment",
+			payload: `{"text_embedding":{"segments":[{"float":[]}]}}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed json",
+			payload: `not json`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseEmbedding([]byte(tt.payload))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("length %d != %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: %v != %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCosine(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    []float32
+		want    float64
+		wantErr bool
+	}{
+		{name: "identical", a: []float32{1, 0, 0}, b: []float32{1, 0, 0}, want: 1},
+		{name: "orthogonal", a: []float32{1, 0}, b: []float32{0, 1}, want: 0},
+		{name: "opposite", a: []float32{1, 1}, b: []float32{-1, -1}, want: -1},
+		{name: "length mismatch", a: []float32{1, 0}, b: []float32{1}, wantErr: true},
+		{name: "empty", a: []float32{}, b: []float32{}, wantErr: true},
+		{name: "zero magnitude", a: []float32{0, 0}, b: []float32{1, 1}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Cosine(tt.a, tt.b)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if math.Abs(got-tt.want) > 1e-6 {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTextEmbeddingLive hits the real TwelveLabs API. It is skipped unless
+// TWELVELABS_API_KEY is set, so it never runs in CI without credentials.
+func TestTextEmbeddingLive(t *testing.T) {
+	apiKey := os.Getenv("TWELVELABS_API_KEY")
+	if apiKey == "" {
+		t.Skip("TWELVELABS_API_KEY not set; skipping live embedding test")
+	}
+
+	c := New(apiKey, "", "")
+	vec, err := c.TextEmbedding(context.Background(), "a person walking on a beach at sunset")
+	if err != nil {
+		t.Fatalf("TextEmbedding failed: %v", err)
+	}
+	if len(vec) != EmbeddingDimensions {
+		t.Fatalf("expected %d dimensions, got %d", EmbeddingDimensions, len(vec))
+	}
+
+	// A self-similarity sanity check on the cosine helper against a live vector.
+	sim, err := Cosine(vec, vec)
+	if err != nil {
+		t.Fatalf("Cosine failed: %v", err)
+	}
+	if math.Abs(sim-1) > 1e-6 {
+		t.Errorf("self-similarity should be 1, got %v", sim)
+	}
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an **opt-in** TwelveLabs Marengo embedding integration to augment stash-box's existing perceptual-hash (pHash) video matching.

### What it adds
- A small `internal/embedding` package with a stdlib-only TwelveLabs client (no new third-party dependency) that computes 512-dimension Marengo embeddings via the `/embed` endpoint, plus a `Cosine` similarity helper.
- A `twelvelabs` config block (`api_key`, `model_name`, `base_url`) wired through viper using the same `,squash` nested-struct pattern as the existing `s3`/`autocert` config, and a `GetTwelveLabsConfig()` accessor that returns `nil` when no key is set.
- README documentation for the new config keys and a short section explaining the integration.

### Why it helps
pHash reliably matches near-identical encodes but misses content that has been re-encoded, cropped, or otherwise visually altered. Marengo produces multimodal embeddings in a single space shared by text and video, so visually-similar scenes can be ranked by cosine similarity and text queries can be matched against video embeddings — a complementary signal for duplicate detection and search.

### Opt-in / non-breaking
The integration is inactive unless `twelvelabs.api_key` is configured. No defaults change and existing pHash behaviour is untouched. This PR adds the client + config seam; it deliberately does not alter any existing matching path.

### Testing
- `go test ./internal/embedding/` — table-driven unit tests for response parsing and cosine similarity (no network).
- A live test (`TestTextEmbeddingLive`) gated on `TWELVELABS_API_KEY`, skipped in CI without credentials. Ran it against the real API and confirmed a 512-dim vector is returned.
- `gofmt` and `go vet` clean on changed files; `go build ./internal/...` passes.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
