### PR TITLE
Add code filter to queryScenes

### DIFF
--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1986,6 +1986,8 @@ export type SceneEditInput = {
 export type SceneQueryInput = {
   /** Filter to include scenes with performer appearing as alias */
   alias?: InputMaybe<StringCriterionInput>;
+  /** Filter by scene code */
+  code?: InputMaybe<StringCriterionInput>;
   /** Filter by date */
   date?: InputMaybe<DateCriterionInput>;
   direction?: SortDirectionEnum;

--- a/graphql/schema/types/scene.graphql
+++ b/graphql/schema/types/scene.graphql
@@ -242,6 +242,8 @@ input SceneQueryInput {
   title: String
   """Filter to search urls - assumes like query unless quoted"""
   url: String
+  """Filter by scene code"""
+  code: StringCriterionInput
   """Filter by date"""
   date: DateCriterionInput
   """Filter by production date"""

--- a/internal/api/scene_integration_test.go
+++ b/internal/api/scene_integration_test.go
@@ -757,6 +757,70 @@ func (s *sceneTestRunner) testQueryScenesByTag() {
 	s.verifyInvalidModifier(filter)
 }
 
+func (s *sceneTestRunner) testQueryScenesByCode() {
+	prefix := "testQueryScenesByCode_"
+
+	code1 := "ABC-001"
+	code2 := "ABC-002"
+	code3 := "XYZ-001"
+	title1 := prefix + "scene1"
+	title2 := prefix + "scene2"
+	title3 := prefix + "scene3"
+	title4 := prefix + "scene4"
+
+	scene1, err := s.createTestScene(&models.SceneCreateInput{Title: &title1, Code: &code1, Date: "2020-01-01"})
+	assert.NoError(s.t, err)
+	scene2, err := s.createTestScene(&models.SceneCreateInput{Title: &title2, Code: &code2, Date: "2020-01-02"})
+	assert.NoError(s.t, err)
+	scene3, err := s.createTestScene(&models.SceneCreateInput{Title: &title3, Code: &code3, Date: "2020-01-03"})
+	assert.NoError(s.t, err)
+	scene4, err := s.createTestScene(&models.SceneCreateInput{Title: &title4, Date: "2020-01-04"})
+	assert.NoError(s.t, err)
+
+	scene1ID := scene1.UUID()
+	scene2ID := scene2.UUID()
+	scene3ID := scene3.UUID()
+	scene4ID := scene4.UUID()
+
+	titleSearch := prefix
+
+	// EQUALS - exact match
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Value: code1, Modifier: models.CriterionModifierEquals},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene1ID})
+
+	// NOT_EQUALS
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Value: code1, Modifier: models.CriterionModifierNotEquals},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene2ID, scene3ID})
+
+	// INCLUDES - partial match on "ABC" returns scene1 and scene2
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Value: "ABC", Modifier: models.CriterionModifierIncludes},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene1ID, scene2ID})
+
+	// INCLUDES - partial match on "001" returns scene1 and scene3
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Value: "001", Modifier: models.CriterionModifierIncludes},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene1ID, scene3ID})
+
+	// IS_NULL - only scene without code
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Modifier: models.CriterionModifierIsNull},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene4ID})
+
+	// NOT_NULL - all scenes with a code
+	s.verifyQueryScenesResult(models.SceneQueryInput{
+		Code:  &models.StringCriterionInput{Modifier: models.CriterionModifierNotNull},
+		Title: &titleSearch,
+	}, []uuid.UUID{scene1ID, scene2ID, scene3ID})
+}
+
 func TestCreateScene(t *testing.T) {
 	pt := createSceneTestRunner(t)
 	pt.testCreateScene()
@@ -793,6 +857,11 @@ func TestQueryScenesByPerformer(t *testing.T) {
 func TestQueryScenesByTag(t *testing.T) {
 	pt := createSceneTestRunner(t)
 	pt.testQueryScenesByTag()
+}
+
+func TestQueryScenesByCode(t *testing.T) {
+	pt := createSceneTestRunner(t)
+	pt.testQueryScenesByCode()
 }
 
 func TestSubmitFingerprint(t *testing.T) {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	postgresDriver = "postgres"
-	schemaVersion  = 72
+	schemaVersion  = 73
 )
 
 //go:embed migrations/postgres/*.sql

--- a/internal/database/migrations/postgres/73_scene_code_trgm_index.up.sql
+++ b/internal/database/migrations/postgres/73_scene_code_trgm_index.up.sql
@@ -1,0 +1,6 @@
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+    CREATE INDEX scenes_code_trgm_idx ON "scenes" USING GIN ("code" gin_trgm_ops);
+  END IF;
+END$$;

--- a/internal/models/generated_exec.go
+++ b/internal/models/generated_exec.go
@@ -6127,6 +6127,8 @@ input SceneQueryInput {
   title: String
   """Filter to search urls - assumes like query unless quoted"""
   url: String
+  """Filter by scene code"""
+  code: StringCriterionInput
   """Filter by date"""
   date: DateCriterionInput
   """Filter by production date"""
@@ -30751,7 +30753,7 @@ func (ec *executionContext) unmarshalInputSceneQueryInput(ctx context.Context, o
 		asMap["sort"] = "DATE"
 	}
 
-	fieldsInOrder := [...]string{"text", "title", "url", "date", "production_date", "studios", "parentStudio", "tags", "performers", "alias", "fingerprints", "favorites", "has_fingerprint_submissions", "page", "per_page", "direction", "sort"}
+	fieldsInOrder := [...]string{"text", "title", "url", "code", "date", "production_date", "studios", "parentStudio", "tags", "performers", "alias", "fingerprints", "favorites", "has_fingerprint_submissions", "page", "per_page", "direction", "sort"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -30779,6 +30781,13 @@ func (ec *executionContext) unmarshalInputSceneQueryInput(ctx context.Context, o
 				return it, err
 			}
 			it.URL = data
+		case "code":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("code"))
+			data, err := ec.unmarshalOStringCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐStringCriterionInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Code = data
 		case "date":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date"))
 			data, err := ec.unmarshalODateCriterionInput2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐDateCriterionInput(ctx, v)

--- a/internal/models/generated_models.go
+++ b/internal/models/generated_models.go
@@ -770,6 +770,8 @@ type SceneQueryInput struct {
 	Title *string `json:"title,omitempty"`
 	// Filter to search urls - assumes like query unless quoted
 	URL *string `json:"url,omitempty"`
+	// Filter by scene code
+	Code *StringCriterionInput `json:"code,omitempty"`
 	// Filter by date
 	Date *DateCriterionInput `json:"date,omitempty"`
 	// Filter by production date

--- a/internal/service/query/criterion.go
+++ b/internal/service/query/criterion.go
@@ -98,7 +98,7 @@ func ApplyIntCriterion(query sq.SelectBuilder, field string, criterion *models.I
 	}
 }
 
-// ApplyStringCriterion applies string criterion (equals, not equals, is null, not null)
+// ApplyStringCriterion applies string criterion (equals, not equals, includes, is null, not null)
 // Returns the modified query
 func ApplyStringCriterion(query sq.SelectBuilder, field string, criterion *models.StringCriterionInput) sq.SelectBuilder {
 	switch criterion.Modifier {
@@ -106,6 +106,8 @@ func ApplyStringCriterion(query sq.SelectBuilder, field string, criterion *model
 		return query.Where(sq.Eq{field: criterion.Value})
 	case models.CriterionModifierNotEquals:
 		return query.Where(sq.NotEq{field: criterion.Value})
+	case models.CriterionModifierIncludes:
+		return query.Where(sq.ILike{field: "%" + criterion.Value + "%"})
 	case models.CriterionModifierIsNull:
 		return query.Where(field + " IS NULL")
 	case models.CriterionModifierNotNull:

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -117,6 +117,11 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 		query = query.Where(sq.ILike{"scenes.title": searchTerm})
 	}
 
+	// Filter by code
+	if input.Code != nil {
+		query = queryhelper.ApplyStringCriterion(query, "scenes.code", input.Code)
+	}
+
 	// Filter by studios
 	if input.Studios != nil && len(input.Studios.Value) > 0 {
 		switch input.Studios.Modifier {
@@ -211,7 +216,8 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 			(input.Text != nil && *input.Text != "") ||
 			(input.Title != nil && *input.Title != "") ||
 			(input.Studios != nil && len(input.Studios.Value) > 0) ||
-			input.Date != nil || input.Favorites != nil
+			input.Date != nil || input.Favorites != nil ||
+			input.Code != nil
 
 		if !hasOtherFilters && !forCount {
 			// Optimize: limit the trending subquery directly


### PR DESCRIPTION
# Add code filter to queryScenes

## Summary

Adds a `code` field to `SceneQueryInput` so scenes can be queried by their scene code, supporting both exact and partial matching.

## Changes

- **GraphQL schema** — added `code: StringCriterionInput` to `SceneQueryInput`
- **Backend filter** — added filter logic in `internal/service/scene/query.go` using `scenes.code`
- **`ApplyStringCriterion`** — extended with `INCLUDES` modifier (case-insensitive `ILIKE`) for reuse by other string fields
- **Generated models** — regenerated `generated_models.go` and `generated_exec.go` to include the new field
- **Integration test** — added `TestQueryScenesByCode` covering `EQUALS`, `NOT_EQUALS`, `INCLUDES`, `IS_NULL`, and `NOT_NULL` modifiers

## Supported modifiers

| Modifier | Behaviour |
|---|---|
| `EQUALS` | Exact match |
| `NOT_EQUALS` | Excludes exact match |
| `INCLUDES` | Case-insensitive partial match |
| `IS_NULL` | Scenes with no code |
| `NOT_NULL` | Scenes with any code |

## Example

```graphql
query {
  queryScenes(input: {
    code: { value: "ABC-001", modifier: EQUALS }
    page: 1
    per_page: 25
  }) {
    count
    scenes { id title code }
  }
}
```
