### PR TITLE
Reassign unique fingerprints to system user when deleting user

### DIFF
--- a/internal/api/user_integration_test.go
+++ b/internal/api/user_integration_test.go
@@ -457,6 +457,103 @@ func TestUpdateNotificationSubscriptions(t *testing.T) {
 	pt.testUpdateNotificationSubscriptions()
 }
 
+func sceneHasFingerprint(scene *sceneOutput, hashHex string) bool {
+	for _, f := range scene.Fingerprints {
+		if f.Hash == hashHex {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *userTestRunner) testDestroyUserRetainsOrphanedFingerprints() {
+	createdUser, err := s.createTestUser(nil, nil)
+	assert.NoError(s.t, err)
+	userID := createdUser.ID
+
+	// Scene where the deleted user is the only contributor - its fingerprint
+	// would otherwise be lost to the delete cascade.
+	soleTitle := s.generateSceneName()
+	soleScene, err := s.createTestScene(&models.SceneCreateInput{
+		Title:        &soleTitle,
+		Date:         "2020-03-02",
+		Fingerprints: []models.FingerprintEditInput{},
+	})
+	assert.NoError(s.t, err)
+
+	soleFP := s.generateSceneFingerprint(nil)
+	_, err = s.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: soleScene.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      soleFP.Hash,
+			Algorithm: soleFP.Algorithm,
+			Duration:  soleFP.Duration,
+			UserIds:   []uuid.UUID{userID},
+		},
+	})
+	assert.NoError(s.t, err, "Error submitting sole fingerprint")
+
+	// Scene where another user (admin) also has a fingerprint - the deleted
+	// user's fingerprint here should still cascade away.
+	sharedScene, err := s.createTestScene(nil)
+	assert.NoError(s.t, err)
+	adminHash := sharedScene.Fingerprints[0].Hash
+
+	sharedFP := s.generateSceneFingerprint(nil)
+	_, err = s.client.submitFingerprint(models.FingerprintSubmission{
+		SceneID: sharedScene.UUID(),
+		Fingerprint: &models.FingerprintInput{
+			Hash:      sharedFP.Hash,
+			Algorithm: sharedFP.Algorithm,
+			Duration:  sharedFP.Duration,
+			UserIds:   []uuid.UUID{userID},
+		},
+	})
+	assert.NoError(s.t, err, "Error submitting shared-scene fingerprint")
+
+	destroyed, err := s.resolver.Mutation().UserDestroy(s.ctx, models.UserDestroyInput{
+		ID: userID,
+	})
+	assert.NoError(s.t, err, "Error destroying user")
+	assert.True(s.t, destroyed)
+
+	// The orphaned fingerprint is retained (reassigned to the deleted user).
+	scene1, err := s.client.findScene(soleScene.UUID())
+	assert.NoError(s.t, err)
+	assert.True(s.t, sceneHasFingerprint(scene1, soleFP.Hash.Hex()),
+		"Orphaned fingerprint should be retained after user deletion")
+
+	// The shared scene keeps the other user's fingerprint but drops the deleted user's.
+	scene2, err := s.client.findScene(sharedScene.UUID())
+	assert.NoError(s.t, err)
+	assert.True(s.t, sceneHasFingerprint(scene2, adminHash),
+		"Other user's fingerprint should remain")
+	assert.False(s.t, sceneHasFingerprint(scene2, sharedFP.Hash.Hex()),
+		"Deleted user's fingerprint should cascade when another user has one")
+}
+
+func (s *userTestRunner) testCannotDeleteSentinelUser() {
+	name := "[deleted user]"
+	sentinel, err := s.resolver.Query().FindUser(s.ctx, nil, &name)
+	assert.NoError(s.t, err)
+	assert.NotNil(s.t, sentinel, "deleted-user sentinel should exist")
+
+	_, err = s.resolver.Mutation().UserDestroy(s.ctx, models.UserDestroyInput{
+		ID: sentinel.ID,
+	})
+	assert.Error(s.t, err, "sentinel deleted user should not be deletable")
+}
+
+func TestDestroyUserRetainsOrphanedFingerprints(t *testing.T) {
+	pt := createUserTestRunner(t)
+	pt.testDestroyUserRetainsOrphanedFingerprints()
+}
+
+func TestCannotDeleteSentinelUser(t *testing.T) {
+	pt := createUserTestRunner(t)
+	pt.testCannotDeleteSentinelUser()
+}
+
 func (s *userTestRunner) testNewUser() {
 	// Grant invite tokens to the admin user
 	adminID := userDB.admin.ID

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -596,6 +596,31 @@ func (q *Queries) PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSc
 	return items, nil
 }
 
+const reassignOrphaningSceneFingerprints = `-- name: ReassignOrphaningSceneFingerprints :exec
+UPDATE scene_fingerprints sf
+SET user_id = $1
+WHERE sf.user_id = $2
+  AND NOT EXISTS (
+    SELECT 1 FROM scene_fingerprints o
+    WHERE o.scene_id = sf.scene_id
+      AND o.user_id <> $2
+  )
+`
+
+type ReassignOrphaningSceneFingerprintsParams struct {
+	TargetUserID uuid.UUID `db:"target_user_id" json:"target_user_id"`
+	SourceUserID uuid.UUID `db:"source_user_id" json:"source_user_id"`
+}
+
+// Reassign a deleted user's fingerprints to the sentinel user, but only on
+// scenes where no other user has any fingerprint, so the scene keeps at least
+// one fingerprint instead of losing all of them to the delete cascade. Scenes
+// with other contributors let the user's rows cascade-delete as usual.
+func (q *Queries) ReassignOrphaningSceneFingerprints(ctx context.Context, arg ReassignOrphaningSceneFingerprintsParams) error {
+	_, err := q.db.Exec(ctx, reassignOrphaningSceneFingerprints, arg.TargetUserID, arg.SourceUserID)
+	return err
+}
+
 const submittedHashExists = `-- name: SubmittedHashExists :one
 SELECT EXISTS(
 		SELECT

--- a/internal/queries/fingerprint.sql.go
+++ b/internal/queries/fingerprint.sql.go
@@ -613,9 +613,7 @@ type ReassignOrphaningSceneFingerprintsParams struct {
 }
 
 // Reassign a deleted user's fingerprints to the sentinel user, but only on
-// scenes where no other user has any fingerprint, so the scene keeps at least
-// one fingerprint instead of losing all of them to the delete cascade. Scenes
-// with other contributors let the user's rows cascade-delete as usual.
+// scenes where no other user has any fingerprint.
 func (q *Queries) ReassignOrphaningSceneFingerprints(ctx context.Context, arg ReassignOrphaningSceneFingerprintsParams) error {
 	_, err := q.db.Exec(ctx, reassignOrphaningSceneFingerprints, arg.TargetUserID, arg.SourceUserID)
 	return err

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -313,9 +313,7 @@ type Querier interface {
 	PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) ([]PruneSceneFingerprintsForMoveRow, error)
 	QueryModAudits(ctx context.Context, arg QueryModAuditsParams) ([]ModAudit, error)
 	// Reassign a deleted user's fingerprints to the sentinel user, but only on
-	// scenes where no other user has any fingerprint, so the scene keeps at least
-	// one fingerprint instead of losing all of them to the delete cascade. Scenes
-	// with other contributors let the user's rows cascade-delete as usual.
+	// scenes where no other user has any fingerprint.
 	ReassignOrphaningSceneFingerprints(ctx context.Context, arg ReassignOrphaningSceneFingerprintsParams) error
 	ReassignPerformerAliases(ctx context.Context, arg ReassignPerformerAliasesParams) error
 	ReassignPerformerFavorites(ctx context.Context, arg ReassignPerformerFavoritesParams) error

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -312,6 +312,11 @@ type Querier interface {
 	// Prepare a fingerprint move by dropping reports and dupe fingerprint submissions
 	PruneSceneFingerprintsForMove(ctx context.Context, arg PruneSceneFingerprintsForMoveParams) ([]PruneSceneFingerprintsForMoveRow, error)
 	QueryModAudits(ctx context.Context, arg QueryModAuditsParams) ([]ModAudit, error)
+	// Reassign a deleted user's fingerprints to the sentinel user, but only on
+	// scenes where no other user has any fingerprint, so the scene keeps at least
+	// one fingerprint instead of losing all of them to the delete cascade. Scenes
+	// with other contributors let the user's rows cascade-delete as usual.
+	ReassignOrphaningSceneFingerprints(ctx context.Context, arg ReassignOrphaningSceneFingerprintsParams) error
 	ReassignPerformerAliases(ctx context.Context, arg ReassignPerformerAliasesParams) error
 	ReassignPerformerFavorites(ctx context.Context, arg ReassignPerformerFavoritesParams) error
 	ReassignStudioFavorites(ctx context.Context, arg ReassignStudioFavoritesParams) error

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -33,9 +33,7 @@ DELETE FROM scene_fingerprints WHERE scene_id = $1;
 
 -- name: ReassignOrphaningSceneFingerprints :exec
 -- Reassign a deleted user's fingerprints to the sentinel user, but only on
--- scenes where no other user has any fingerprint, so the scene keeps at least
--- one fingerprint instead of losing all of them to the delete cascade. Scenes
--- with other contributors let the user's rows cascade-delete as usual.
+-- scenes where no other user has any fingerprint.
 UPDATE scene_fingerprints sf
 SET user_id = sqlc.arg(target_user_id)
 WHERE sf.user_id = sqlc.arg(source_user_id)

--- a/internal/queries/sql/fingerprint.sql
+++ b/internal/queries/sql/fingerprint.sql
@@ -31,6 +31,20 @@ DO UPDATE SET
 -- name: DeleteSceneFingerprintsByScene :exec
 DELETE FROM scene_fingerprints WHERE scene_id = $1;
 
+-- name: ReassignOrphaningSceneFingerprints :exec
+-- Reassign a deleted user's fingerprints to the sentinel user, but only on
+-- scenes where no other user has any fingerprint, so the scene keeps at least
+-- one fingerprint instead of losing all of them to the delete cascade. Scenes
+-- with other contributors let the user's rows cascade-delete as usual.
+UPDATE scene_fingerprints sf
+SET user_id = sqlc.arg(target_user_id)
+WHERE sf.user_id = sqlc.arg(source_user_id)
+  AND NOT EXISTS (
+    SELECT 1 FROM scene_fingerprints o
+    WHERE o.scene_id = sf.scene_id
+      AND o.user_id <> sqlc.arg(source_user_id)
+  );
+
 -- name: DeleteSceneFingerprint :exec
 DELETE FROM scene_fingerprints SFP
 USING fingerprints FP

--- a/internal/service/user/service.go
+++ b/internal/service/user/service.go
@@ -310,8 +310,12 @@ func (s *User) Delete(ctx context.Context, input models.UserDestroyInput) error 
 
 		// Retain fingerprints on scenes that would otherwise be left with none by
 		// reassigning them to the sentinel deleted user before the cascade.
+		deletedUser, err := tx.FindUserByName(ctx, deletedUserName)
+		if err != nil {
+			return err
+		}
 		if err := tx.ReassignOrphaningSceneFingerprints(ctx, queries.ReassignOrphaningSceneFingerprintsParams{
-			TargetUserID: DeletedUserID,
+			TargetUserID: deletedUser.ID,
 			SourceUserID: input.ID,
 		}); err != nil {
 			return err
@@ -759,7 +763,7 @@ func (s *User) CreateSystemUsers(ctx context.Context) {
 			}
 		}
 
-		_, err = tx.FindUser(ctx, DeletedUserID)
+		_, err = tx.FindUserByName(ctx, deletedUserName)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			panic(fmt.Errorf("error getting deleted user: %w", err))
 		}
@@ -776,7 +780,7 @@ func (s *User) CreateSystemUsers(ctx context.Context) {
 				Roles:    deletedUserRoles,
 			}
 
-			if _, err = createUserWithID(ctx, tx, newUser, false, DeletedUserID); err != nil {
+			if _, err = createUser(ctx, tx, newUser, false); err != nil {
 				return err
 			}
 		}

--- a/internal/service/user/service.go
+++ b/internal/service/user/service.go
@@ -308,6 +308,15 @@ func (s *User) Delete(ctx context.Context, input models.UserDestroyInput) error 
 			return err
 		}
 
+		// Retain fingerprints on scenes that would otherwise be left with none by
+		// reassigning them to the sentinel deleted user before the cascade.
+		if err := tx.ReassignOrphaningSceneFingerprints(ctx, queries.ReassignOrphaningSceneFingerprintsParams{
+			TargetUserID: DeletedUserID,
+			SourceUserID: input.ID,
+		}); err != nil {
+			return err
+		}
+
 		if err := tx.DeleteUser(ctx, input.ID); err != nil {
 			return err
 		}
@@ -746,6 +755,28 @@ func (s *User) CreateSystemUsers(ctx context.Context) {
 			}
 
 			if _, err = createUser(ctx, tx, newUser, false); err != nil {
+				return err
+			}
+		}
+
+		_, err = tx.FindUser(ctx, DeletedUserID)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			panic(fmt.Errorf("error getting deleted user: %w", err))
+		}
+
+		if errors.Is(err, pgx.ErrNoRows) {
+			password, err := utils.GenerateRandomPassword(32)
+			if err != nil {
+				panic(fmt.Errorf("error creating deleted user: %w", err))
+			}
+			newUser := models.UserCreateInput{
+				Name:     deletedUserName,
+				Password: password,
+				Email:    deletedUserEmail,
+				Roles:    deletedUserRoles,
+			}
+
+			if _, err = createUserWithID(ctx, tx, newUser, false, DeletedUserID); err != nil {
 				return err
 			}
 		}

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -21,13 +21,9 @@ const (
 	modUserName  = "StashBot"
 	unsetEmail   = "root@example.com"
 
-	deletedUserName  = "[deleted]"
+	deletedUserName  = "[deleted user]"
 	deletedUserEmail = "deleted@example.com"
 )
-
-// DeletedUserID is the sentinel user that owns fingerprints retained from
-// deleted users when they would otherwise leave a scene with none.
-var DeletedUserID = uuid.FromStringOrNil("deaddead-dead-4ead-bead-deaddeaddead")
 
 var (
 	ErrUserNotExist                    = errors.New("user not found")
@@ -62,16 +58,12 @@ var modUserRoles []models.RoleEnum = []models.RoleEnum{
 var deletedUserRoles []models.RoleEnum = []models.RoleEnum{}
 
 func createUser(ctx context.Context, tx *queries.Queries, input models.UserCreateInput, defaultNotifications bool) (*queries.User, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
+	if err := validateCreate(input); err != nil {
 		return nil, err
 	}
 
-	return createUserWithID(ctx, tx, input, defaultNotifications, id)
-}
-
-func createUserWithID(ctx context.Context, tx *queries.Queries, input models.UserCreateInput, defaultNotifications bool, id uuid.UUID) (*queries.User, error) {
-	if err := validateCreate(input); err != nil {
+	id, err := uuid.NewV7()
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -20,7 +20,14 @@ const (
 	rootUserName = "root"
 	modUserName  = "StashBot"
 	unsetEmail   = "root@example.com"
+
+	deletedUserName  = "[deleted]"
+	deletedUserEmail = "deleted@example.com"
 )
+
+// DeletedUserID is the sentinel user that owns fingerprints retained from
+// deleted users when they would otherwise leave a scene with none.
+var DeletedUserID = uuid.FromStringOrNil("deaddead-dead-4ead-bead-deaddeaddead")
 
 var (
 	ErrUserNotExist                    = errors.New("user not found")
@@ -51,13 +58,20 @@ var modUserRoles []models.RoleEnum = []models.RoleEnum{
 	models.RoleEnumBot,
 }
 
+// The sentinel deleted user only owns retained fingerprints; it has no roles.
+var deletedUserRoles []models.RoleEnum = []models.RoleEnum{}
+
 func createUser(ctx context.Context, tx *queries.Queries, input models.UserCreateInput, defaultNotifications bool) (*queries.User, error) {
-	if err := validateCreate(input); err != nil {
+	id, err := uuid.NewV7()
+	if err != nil {
 		return nil, err
 	}
 
-	id, err := uuid.NewV7()
-	if err != nil {
+	return createUserWithID(ctx, tx, input, defaultNotifications, id)
+}
+
+func createUserWithID(ctx context.Context, tx *queries.Queries, input models.UserCreateInput, defaultNotifications bool, id uuid.UUID) (*queries.User, error) {
+	if err := validateCreate(input); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/user/validate.go
+++ b/internal/service/user/validate.go
@@ -95,7 +95,7 @@ func validateUpdate(ctx context.Context, input models.UserUpdateInput, current q
 }
 
 func validateDelete(user queries.User) error {
-	if user.Name == rootUserName || user.Name == modUserName {
+	if user.Name == rootUserName || user.Name == modUserName || user.Name == deletedUserName {
 		return ErrDeleteSystemUser
 	}
 


### PR DESCRIPTION
When deleting a user, reassign any fingerprints from scenes that they are the only submitter of, to a `[deleted user]` sentinel user. This way scenes aren't left in an undiscoverable state.

Drafted with claude.