### PR TITLE
Remove client-side image sorting

### DIFF
--- a/frontend/src/components/image/Image.tsx
+++ b/frontend/src/components/image/Image.tsx
@@ -6,7 +6,6 @@ import {
 import cx from "classnames";
 import { type FC, useState } from "react";
 import { Icon, LoadingIndicator } from "src/components/fragments";
-import { sortImageURLs } from "src/utils";
 import ImageLightbox from "./ImageLightbox";
 
 const CLASSNAME = "Image";
@@ -84,20 +83,15 @@ interface ContainerProps {
 const ImageContainer: FC<ContainerProps> = ({
   className,
   images,
-  orientation = "landscape",
   lightbox,
   lightboxImages,
   ...props
 }) => {
   const [showLightbox, setShowLightbox] = useState(false);
 
-  const sortedImages = Array.isArray(images)
-    ? sortImageURLs(images, orientation)
-    : images
-      ? [images]
-      : [];
-  const image = sortedImages[0];
-  const galleryImages = lightboxImages ?? (lightbox ? sortedImages : undefined);
+  const imageArray = Array.isArray(images) ? images : images ? [images] : [];
+  const image = imageArray[0];
+  const galleryImages = lightboxImages ?? (lightbox ? imageArray : undefined);
 
   const aspectRatio = image ? `${image.width}/${image.height}` : "16/6";
 
@@ -120,10 +114,10 @@ const ImageContainer: FC<ContainerProps> = ({
         <span className={`${CLASSNAME}-magnify`}>
           <Icon icon={faMagnifyingGlass} />
         </span>
-        {sortedImages.length > 1 && (
+        {imageArray.length > 1 && (
           <span className={`${CLASSNAME}-count`}>
             <Icon icon={faImages} />
-            {sortedImages.length}
+            {imageArray.length}
           </span>
         )}
       </button>

--- a/frontend/src/components/image/Image.tsx
+++ b/frontend/src/components/image/Image.tsx
@@ -70,7 +70,6 @@ const ImageComponent: FC<ImageProps> = ({
 
 interface ContainerProps {
   images: Image[] | Image | undefined;
-  orientation?: "landscape" | "portrait";
   emptyMessage?: string;
   size?: ImageSize;
   alt?: string;

--- a/frontend/src/components/performerCard/PerformerCard.tsx
+++ b/frontend/src/components/performerCard/PerformerCard.tsx
@@ -9,7 +9,7 @@ import {
   Thumbnail,
 } from "src/components/fragments";
 import type { Performer } from "src/graphql";
-import { getImage, performerHref } from "src/utils";
+import { performerHref } from "src/utils";
 
 type PerformerType = Pick<
   Performer,
@@ -30,7 +30,7 @@ const PerformerCard: FC<PerformerCardProps> = ({ className, performer }) => (
     <Link to={performerHref(performer)}>
       <div className={CLASSNAME_IMAGE}>
         <Thumbnail
-          image={getImage(performer.images, "portrait")}
+          image={performer.images[0]?.url}
           alt={performer.name}
           size={300}
           orientation="portrait"

--- a/frontend/src/components/sceneCard/SceneCard.tsx
+++ b/frontend/src/components/sceneCard/SceneCard.tsx
@@ -4,13 +4,7 @@ import { Card } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { Icon, Thumbnail } from "src/components/fragments";
 import type { Scene, Studio } from "src/graphql";
-import {
-  formatDuration,
-  getImage,
-  imageType,
-  sceneHref,
-  studioHref,
-} from "src/utils";
+import { formatDuration, imageType, sceneHref, studioHref } from "src/utils";
 
 type Performance = Pick<
   Scene,
@@ -30,7 +24,7 @@ const SceneCard: FC<{ scene: Performance }> = ({ scene }) => (
         <Thumbnail
           alt={scene.title}
           className={imageType(scene.images[0])}
-          image={getImage(scene.images, "landscape")}
+          image={scene.images[0]?.url}
           size={300}
         />
       </Link>

--- a/frontend/src/components/searchField/SearchField.tsx
+++ b/frontend/src/components/searchField/SearchField.tsx
@@ -18,7 +18,6 @@ import {
 import type { SearchAllQuery, SearchPerformersQuery } from "src/graphql";
 import SearchAllGQL from "src/graphql/queries/SearchAll.gql";
 import SearchPerformersGQL from "src/graphql/queries/SearchPerformers.gql";
-import { getImage } from "src/utils";
 import {
   handleResult,
   type PerformerResult,
@@ -65,7 +64,7 @@ const formatOptionLabel = ({ label, sublabel, value }: SearchResult) => (
   <div className="d-flex">
     {valueIsPerformer(value) && (
       <Thumbnail
-        image={getImage(value.images, "portrait")}
+        image={value.images[0]?.url}
         className="SearchField-thumb"
         alt={value.name}
         size={300}

--- a/frontend/src/pages/performers/components/performerInfo.tsx
+++ b/frontend/src/pages/performers/components/performerInfo.tsx
@@ -223,7 +223,6 @@ export const PerformerInfo: FC<Props> = ({ performer }) => {
         <Col xs={6} className="performer-photo">
           <Image
             images={performer.images}
-            orientation="portrait"
             size={600}
             alt="Performer"
             lightbox

--- a/frontend/src/pages/search/PerformerCard.tsx
+++ b/frontend/src/pages/search/PerformerCard.tsx
@@ -14,7 +14,7 @@ import {
   Thumbnail,
 } from "src/components/fragments";
 import type { SearchAllQuery } from "src/graphql";
-import { getCountryByISO, getImage, performerHref } from "src/utils";
+import { getCountryByISO, performerHref } from "src/utils";
 
 export type Performer = NonNullable<
   SearchAllQuery["searchPerformers"]["performers"][number]
@@ -25,7 +25,7 @@ export const PerformerCard: FC<{ performer: Performer }> = ({ performer }) => (
     <Card>
       <Thumbnail
         orientation="portrait"
-        image={getImage(performer.images, "portrait")}
+        image={performer.images[0]?.url}
         className="SearchPage-performer-image"
         size={300}
       />

--- a/frontend/src/pages/search/SceneCard.tsx
+++ b/frontend/src/pages/search/SceneCard.tsx
@@ -8,7 +8,7 @@ import { Card } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { Icon, Thumbnail } from "src/components/fragments";
 import type { SearchAllQuery } from "src/graphql";
-import { formatDuration, getImage, sceneHref } from "src/utils";
+import { formatDuration, sceneHref } from "src/utils";
 
 export type Scene = NonNullable<
   SearchAllQuery["searchScenes"]["scenes"][number]
@@ -18,7 +18,7 @@ export const SceneCard: FC<{ scene: Scene }> = ({ scene }) => (
   <Link to={sceneHref(scene)} className="SearchPage-scene">
     <Card>
       <Thumbnail
-        image={getImage(scene.images, "landscape")}
+        image={scene.images[0]?.url}
         className="SearchPage-scene-image"
         size={300}
       />

--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -97,7 +97,7 @@ const StudioComponent: FC<Props> = ({ studio }) => {
         </div>
         {studioImage && (
           <div className="studio-photo">
-            <img src={studio.images[0]?.url} alt="Studio logo" />
+            <img src={studioImage} alt="Studio logo" />
           </div>
         )}
         <div>

--- a/frontend/src/pages/studios/Studio.tsx
+++ b/frontend/src/pages/studios/Studio.tsx
@@ -18,7 +18,6 @@ import { useCurrentUser } from "src/hooks";
 import {
   createHref,
   formatPendingEdits,
-  getImage,
   getUrlBySite,
   studioHref,
 } from "src/utils";
@@ -46,7 +45,7 @@ const StudioComponent: FC<Props> = ({ studio }) => {
   });
   const pendingEditCount = editData?.queryEdits.count;
 
-  const studioImage = getImage(studio.images, "landscape");
+  const studioImage = studio.images[0]?.url;
   const hasSubStudios = studio.sub_studios.count > 0;
 
   const setTab = (tab: string | null) =>
@@ -98,7 +97,7 @@ const StudioComponent: FC<Props> = ({ studio }) => {
         </div>
         {studioImage && (
           <div className="studio-photo">
-            <img src={getImage(studio.images, "landscape")} alt="Studio logo" />
+            <img src={studio.images[0]?.url} alt="Studio logo" />
           </div>
         )}
         <div>

--- a/frontend/src/utils/__tests__/transforms.test.ts
+++ b/frontend/src/utils/__tests__/transforms.test.ts
@@ -8,11 +8,9 @@ import {
   formatMeasurements,
   formatPendingEdits,
   getBraSize,
-  getImage,
   imageType,
   parseBraSize,
   parseDuration,
-  sortImageURLs,
 } from "../transforms";
 
 describe("formatCareer", () => {
@@ -167,38 +165,18 @@ describe("formatDisambiguation", () => {
   });
 });
 
-describe("sortImageURLs / getImage / imageType", () => {
+describe("imageType", () => {
   const img = (width: number, height: number) => ({
     url: `${width}x${height}`,
     width,
     height,
   });
 
-  it("sortImageURLs prefers portrait aspect when orientation=portrait", () => {
-    const out = sortImageURLs(
-      [img(100, 50), img(50, 100), img(100, 100)],
-      "portrait",
-    );
-    expect(out[0].url).toBe("50x100");
-  });
-
-  it("sortImageURLs prefers landscape aspect when orientation=landscape", () => {
-    const out = sortImageURLs(
-      [img(100, 50), img(50, 100), img(100, 100)],
-      "landscape",
-    );
-    expect(out[0].url).toBe("100x50");
-  });
-
-  it("getImage returns the first URL after sort", () => {
-    expect(getImage([img(100, 50), img(50, 100)], "portrait")).toBe("50x100");
-  });
-
-  it("imageType returns vertical for tall images", () => {
+  it("returns vertical for tall images", () => {
     expect(imageType(img(50, 100))).toBe("vertical-img");
   });
 
-  it("imageType returns horizontal otherwise", () => {
+  it("returns horizontal otherwise", () => {
     expect(imageType(img(100, 50))).toBe("horizontal-img");
     expect(imageType(undefined)).toBe("horizontal-img");
   });

--- a/frontend/src/utils/transforms.ts
+++ b/frontend/src/utils/transforms.ts
@@ -36,36 +36,6 @@ type Image = {
   height: number;
 };
 
-export const sortImageURLs = <T extends Image>(
-  urls: T[],
-  orientation: "portrait" | "landscape",
-) =>
-  urls
-    .map((u) => ({
-      ...u,
-      aspect:
-        orientation === "portrait"
-          ? u.height / u.width > 1
-          : u.width / u.height > 1,
-    }))
-    .sort((a, b) => {
-      if (a.aspect > b.aspect) return -1;
-      if (a.aspect < b.aspect) return 1;
-      if (orientation === "portrait" && a.height > b.height) return -1;
-      if (orientation === "portrait" && a.height < b.height) return 1;
-      if (orientation === "landscape" && a.width > b.width) return -1;
-      if (orientation === "landscape" && a.width < b.width) return 1;
-      return 0;
-    });
-
-export const getImage = (
-  urls: Image[],
-  orientation: "portrait" | "landscape",
-) => {
-  const images = sortImageURLs(urls, orientation);
-  return images?.[0]?.url;
-};
-
 export const imageType = (image?: Image) => {
   if (image && image.height > image.width) {
     return `vertical-img`;

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stashapp/stash-box/internal/dataloader"
+	"github.com/stashapp/stash-box/internal/image"
 	"github.com/stashapp/stash-box/internal/models"
 )
 
@@ -49,7 +50,10 @@ func (r *studioResolver) Images(ctx context.Context, obj *models.Studio) ([]mode
 	if err != nil {
 		return nil, err
 	}
-	return imageList(ctx, imageIDs)
+
+	images, err := imageList(ctx, imageIDs)
+	image.OrderLandscape(images)
+	return images, err
 }
 
 func (r *studioResolver) IsFavorite(ctx context.Context, obj *models.Studio) (bool, error) {


### PR DESCRIPTION
Removes all client-side image sorting, just passing through the server's ordering of images. Removes client-side image sorting tests.

Resolves issue #1147. Full context is available in that issue, but the motivation boils down to: *"PR https://github.com/stashapp/stash-box/pull/1089 revamped how performer images are sorted server-side. However, it had no impact on what is shown to the user in the front end because the front end applies different sorting logic."*

**LLM usage**: Written almost entirely by Google Antigravity CLI. I have read and understand the code :)

**Validation**: Spun up a local `stash-box` and added/modified a couple of performers with multiple images. At each stage, images were always shown in the order we'd expect the server to return them.