### PR TITLE
Merge edit application paths and fix vote resolution

### DIFF
--- a/internal/api/edit_close_completed_integration_test.go
+++ b/internal/api/edit_close_completed_integration_test.go
@@ -17,8 +17,7 @@ import (
 // Long enough that no edit reaches the end of its voting period during a test.
 const neverElapses = 86400 * 365
 
-// voteAs casts a vote from a newly created user, since users cannot vote twice or
-// vote on their own edits.
+// A fresh user per vote, since users cannot vote twice or vote on their own edits.
 func (s *editTestRunner) voteAs(editID uuid.UUID, vote models.VoteTypeEnum) {
 	s.t.Helper()
 
@@ -33,8 +32,7 @@ func (s *editTestRunner) voteAs(editID uuid.UUID, vote models.VoteTypeEnum) {
 	assert.NoError(s.t, err)
 }
 
-// sweep runs the cron sweep with the voting periods overridden, which is how a test
-// places an edit past a deadline without waiting for it.
+// Overriding the periods is how a test places an edit past a deadline.
 func (s *editTestRunner) sweep(minPeriod, votingPeriod int) {
 	s.t.Helper()
 
@@ -59,9 +57,7 @@ func (s *editTestRunner) findEdit(id uuid.UUID) *models.Edit {
 	return edit
 }
 
-// createContestedEdit returns an edit whose net score equals the vote threshold, but
-// which has votes on both sides. The votes are ordered so the tally never reaches the
-// threshold unopposed, which would close the edit at vote time.
+// Votes are ordered so the tally never reaches the threshold unopposed, which would close the edit at vote time.
 func (s *editTestRunner) createContestedEdit() *models.Edit {
 	s.t.Helper()
 
@@ -88,9 +84,7 @@ func (s *editTestRunner) createContestedEdit() *models.Edit {
 	return edit
 }
 
-// A contested edit must run its full voting period. Its net score reaching the
-// threshold is not enough, since a net score cannot distinguish 5 accepts and 2
-// rejects from 3 unopposed accepts.
+// A net score at the threshold cannot distinguish 5 accepts and 2 rejects from 3 unopposed accepts.
 func (s *editTestRunner) testContestedEditNotClosedEarly() {
 	edit := s.createContestedEdit()
 
@@ -99,7 +93,6 @@ func (s *editTestRunner) testContestedEditNotClosedEarly() {
 	s.verifyEditPending(s.findEdit(edit.ID))
 }
 
-// Once the full voting period is up, the same edit is settled on its net score.
 func (s *editTestRunner) testContestedEditClosesOnFullPeriod() {
 	edit := s.createContestedEdit()
 
@@ -108,8 +101,6 @@ func (s *editTestRunner) testContestedEditClosesOnFullPeriod() {
 	s.verifyEditStatus(models.VoteStatusEnumAccepted.String(), s.findEdit(edit.ID))
 }
 
-// createDestructiveEdit returns a destructive edit, which is held open for the minimum
-// voting period however its votes fall.
 func (s *editTestRunner) createDestructiveEdit(vote models.VoteTypeEnum) *models.Edit {
 	s.t.Helper()
 
@@ -132,8 +123,7 @@ func (s *editTestRunner) createDestructiveEdit(vote models.VoteTypeEnum) *models
 	return createdEdit
 }
 
-// An uncontested destructive edit closes as soon as its minimum voting period is up,
-// without waiting for another vote to arrive and trigger the check.
+// The sweep must close it without another vote arriving to trigger the check.
 func (s *editTestRunner) testUnanimousAcceptClosesAfterMinPeriod() {
 	edit := s.createDestructiveEdit(models.VoteTypeEnumAccept)
 
@@ -142,7 +132,6 @@ func (s *editTestRunner) testUnanimousAcceptClosesAfterMinPeriod() {
 	s.verifyEditStatus(models.VoteStatusEnumAccepted.String(), s.findEdit(edit.ID))
 }
 
-// The mirror of the above, which the sweep has to handle on the same terms.
 func (s *editTestRunner) testUnanimousRejectClosesAfterMinPeriod() {
 	edit := s.createDestructiveEdit(models.VoteTypeEnumReject)
 

--- a/internal/api/edit_close_completed_integration_test.go
+++ b/internal/api/edit_close_completed_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stashapp/stash-box/internal/auth"
+	"github.com/stashapp/stash-box/internal/config"
+	dbtest "github.com/stashapp/stash-box/internal/database/testutil"
+	"github.com/stashapp/stash-box/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// Long enough that no edit reaches the end of its voting period during a test.
+const neverElapses = 86400 * 365
+
+// voteAs casts a vote from a newly created user, since users cannot vote twice or
+// vote on their own edits.
+func (s *editTestRunner) voteAs(editID uuid.UUID, vote models.VoteTypeEnum) {
+	s.t.Helper()
+
+	voter, err := s.createTestUser(nil, []models.RoleEnum{models.RoleEnumVote})
+	assert.NoError(s.t, err)
+
+	ctx := context.WithValue(s.ctx, auth.ContextUser, auth.FromUser(voter))
+	_, err = s.resolver.Mutation().EditVote(ctx, models.EditVoteInput{
+		ID:   editID,
+		Vote: vote,
+	})
+	assert.NoError(s.t, err)
+}
+
+// sweep runs the cron sweep with the voting periods overridden, which is how a test
+// places an edit past a deadline without waiting for it.
+func (s *editTestRunner) sweep(minPeriod, votingPeriod int) {
+	s.t.Helper()
+
+	originalMin := config.C.MinDestructiveVotingPeriod
+	originalVoting := config.C.VotingPeriod
+	config.C.MinDestructiveVotingPeriod = minPeriod
+	config.C.VotingPeriod = votingPeriod
+	defer func() {
+		config.C.MinDestructiveVotingPeriod = originalMin
+		config.C.VotingPeriod = originalVoting
+	}()
+
+	_, err := dbtest.Factory().Edit().CloseCompleted(context.TODO())
+	assert.NoError(s.t, err)
+}
+
+func (s *editTestRunner) findEdit(id uuid.UUID) *models.Edit {
+	s.t.Helper()
+
+	edit, err := s.resolver.Query().FindEdit(s.ctx, id)
+	assert.NoError(s.t, err)
+	return edit
+}
+
+// createContestedEdit returns an edit whose net score equals the vote threshold, but
+// which has votes on both sides. The votes are ordered so the tally never reaches the
+// threshold unopposed, which would close the edit at vote time.
+func (s *editTestRunner) createContestedEdit() *models.Edit {
+	s.t.Helper()
+
+	createdEdit, err := s.createTestTagEdit(models.OperationEnumCreate, nil, nil)
+	assert.NoError(s.t, err)
+
+	for _, vote := range []models.VoteTypeEnum{
+		models.VoteTypeEnumAccept,
+		models.VoteTypeEnumAccept,
+		models.VoteTypeEnumReject,
+		models.VoteTypeEnumAccept,
+		models.VoteTypeEnumAccept,
+		models.VoteTypeEnumAccept,
+		models.VoteTypeEnumReject,
+	} {
+		s.voteAs(createdEdit.ID, vote)
+	}
+
+	edit := s.findEdit(createdEdit.ID)
+	assert.Equal(s.t, config.GetVoteApplicationThreshold(), edit.VoteCount,
+		"net score should equal the vote threshold for the test to be meaningful")
+	s.verifyEditPending(edit)
+
+	return edit
+}
+
+// A contested edit must run its full voting period. Its net score reaching the
+// threshold is not enough, since a net score cannot distinguish 5 accepts and 2
+// rejects from 3 unopposed accepts.
+func (s *editTestRunner) testContestedEditNotClosedEarly() {
+	edit := s.createContestedEdit()
+
+	s.sweep(0, neverElapses)
+
+	s.verifyEditPending(s.findEdit(edit.ID))
+}
+
+// Once the full voting period is up, the same edit is settled on its net score.
+func (s *editTestRunner) testContestedEditClosesOnFullPeriod() {
+	edit := s.createContestedEdit()
+
+	s.sweep(0, 0)
+
+	s.verifyEditStatus(models.VoteStatusEnumAccepted.String(), s.findEdit(edit.ID))
+}
+
+// createDestructiveEdit returns a destructive edit, which is held open for the minimum
+// voting period however its votes fall.
+func (s *editTestRunner) createDestructiveEdit(vote models.VoteTypeEnum) *models.Edit {
+	s.t.Helper()
+
+	createdTag, err := s.createTestTag(nil)
+	assert.NoError(s.t, err)
+
+	id := createdTag.UUID()
+	createdEdit, err := s.createTestTagEdit(models.OperationEnumDestroy, nil, &models.EditInput{
+		ID:        &id,
+		Operation: models.OperationEnumDestroy,
+	})
+	assert.NoError(s.t, err)
+
+	for range config.GetVoteApplicationThreshold() {
+		s.voteAs(createdEdit.ID, vote)
+	}
+
+	s.verifyEditPending(s.findEdit(createdEdit.ID))
+
+	return createdEdit
+}
+
+// An uncontested destructive edit closes as soon as its minimum voting period is up,
+// without waiting for another vote to arrive and trigger the check.
+func (s *editTestRunner) testUnanimousAcceptClosesAfterMinPeriod() {
+	edit := s.createDestructiveEdit(models.VoteTypeEnumAccept)
+
+	s.sweep(0, neverElapses)
+
+	s.verifyEditStatus(models.VoteStatusEnumAccepted.String(), s.findEdit(edit.ID))
+}
+
+// The mirror of the above, which the sweep has to handle on the same terms.
+func (s *editTestRunner) testUnanimousRejectClosesAfterMinPeriod() {
+	edit := s.createDestructiveEdit(models.VoteTypeEnumReject)
+
+	s.sweep(0, neverElapses)
+
+	s.verifyEditStatus(models.VoteStatusEnumRejected.String(), s.findEdit(edit.ID))
+}
+
+func TestContestedEditNotClosedEarly(t *testing.T) {
+	pt := createEditTestRunner(t)
+	pt.testContestedEditNotClosedEarly()
+}
+
+func TestContestedEditClosesOnFullPeriod(t *testing.T) {
+	pt := createEditTestRunner(t)
+	pt.testContestedEditClosesOnFullPeriod()
+}
+
+func TestUnanimousAcceptClosesAfterMinPeriod(t *testing.T) {
+	pt := createEditTestRunner(t)
+	pt.testUnanimousAcceptClosesAfterMinPeriod()
+}
+
+func TestUnanimousRejectClosesAfterMinPeriod(t *testing.T) {
+	pt := createEditTestRunner(t)
+	pt.testUnanimousRejectClosesAfterMinPeriod()
+}

--- a/internal/queries/edit.sql.go
+++ b/internal/queries/edit.sql.go
@@ -195,56 +195,69 @@ func (q *Queries) DeleteEdit(ctx context.Context, id uuid.UUID) error {
 }
 
 const findCompletedEdits = `-- name: FindCompletedEdits :many
-SELECT id, user_id, operation, target_type, data, votes, status, applied, created_at, updated_at, closed_at, bot, update_count FROM edits
-WHERE status = 'PENDING'
+SELECT e.id, e.user_id, e.operation, e.target_type, e.data, e.votes, e.status, e.applied, e.created_at, e.updated_at, e.closed_at, e.bot, e.update_count, V.accept_count, V.reject_count,
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * $1)) AS full_period_elapsed,
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * $2)) AS min_period_elapsed
+FROM edits E
+CROSS JOIN LATERAL (
+    SELECT
+        COUNT(*) FILTER (WHERE vote = 'ACCEPT') AS accept_count,
+        COUNT(*) FILTER (WHERE vote = 'REJECT') AS reject_count
+    FROM edit_votes WHERE edit_id = E.id
+) V
+WHERE E.status = 'PENDING'
 AND (
-    (created_at <= (now()::timestamp - (INTERVAL '1 second' * $1)) AND updated_at IS NULL)
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * $1))
     OR
-    (updated_at <= (now()::timestamp - (INTERVAL '1 second' * $1)) AND updated_at IS NOT NULL)
-    OR (
-        votes >= $2
-        AND (
-            (created_at <= (now()::timestamp - (INTERVAL '1 second' * $3)) AND updated_at IS NULL)
-            OR
-            (updated_at <= (now()::timestamp - (INTERVAL '1 second' * $3)) AND updated_at IS NOT NULL)
-        )
-    )
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * $2))
 )
 `
 
 type FindCompletedEditsParams struct {
 	VotingPeriod        interface{} `db:"voting_period" json:"voting_period"`
-	MinimumVotes        int         `db:"minimum_votes" json:"minimum_votes"`
 	MinimumVotingPeriod interface{} `db:"minimum_voting_period" json:"minimum_voting_period"`
 }
 
-// Returns pending edits that fulfill one of the criteria for being closed:
-// * The full voting period has passed
-// * The minimum voting period has passed, and the number of votes has crossed the voting threshold.
-// The latter only applies for destructive edits. Non-destructive edits get auto-applied when sufficient votes are cast.
-func (q *Queries) FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]Edit, error) {
-	rows, err := q.db.Query(ctx, findCompletedEdits, arg.VotingPeriod, arg.MinimumVotes, arg.MinimumVotingPeriod)
+type FindCompletedEditsRow struct {
+	Edit              Edit  `db:"edit" json:"edit"`
+	AcceptCount       int64 `db:"accept_count" json:"accept_count"`
+	RejectCount       int64 `db:"reject_count" json:"reject_count"`
+	FullPeriodElapsed bool  `db:"full_period_elapsed" json:"full_period_elapsed"`
+	MinPeriodElapsed  bool  `db:"min_period_elapsed" json:"min_period_elapsed"`
+}
+
+// Returns pending edits that have been open long enough to be closable, along with the
+// tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
+// so that voting and the cron sweep share a single policy.
+// The `votes` column is deliberately unused here: it is a net score, and a net score cannot
+// tell a unanimous result apart from a contested one that balances out to the same number.
+func (q *Queries) FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]FindCompletedEditsRow, error) {
+	rows, err := q.db.Query(ctx, findCompletedEdits, arg.VotingPeriod, arg.MinimumVotingPeriod)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Edit{}
+	items := []FindCompletedEditsRow{}
 	for rows.Next() {
-		var i Edit
+		var i FindCompletedEditsRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.Operation,
-			&i.TargetType,
-			&i.Data,
-			&i.Votes,
-			&i.Status,
-			&i.Applied,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.ClosedAt,
-			&i.Bot,
-			&i.UpdateCount,
+			&i.Edit.ID,
+			&i.Edit.UserID,
+			&i.Edit.Operation,
+			&i.Edit.TargetType,
+			&i.Edit.Data,
+			&i.Edit.Votes,
+			&i.Edit.Status,
+			&i.Edit.Applied,
+			&i.Edit.CreatedAt,
+			&i.Edit.UpdatedAt,
+			&i.Edit.ClosedAt,
+			&i.Edit.Bot,
+			&i.Edit.UpdateCount,
+			&i.AcceptCount,
+			&i.RejectCount,
+			&i.FullPeriodElapsed,
+			&i.MinPeriodElapsed,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/queries/edit.sql.go
+++ b/internal/queries/edit.sql.go
@@ -226,11 +226,9 @@ type FindCompletedEditsRow struct {
 	MinPeriodElapsed  bool  `db:"min_period_elapsed" json:"min_period_elapsed"`
 }
 
-// Returns pending edits that have been open long enough to be closable, along with the
-// tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
-// so that voting and the cron sweep share a single policy.
-// The `votes` column is deliberately unused here: it is a net score, and a net score cannot
-// tell a unanimous result apart from a contested one that balances out to the same number.
+// Returns pending edits past either voting deadline, along with the tallies needed to
+// decide their outcome in Go. The `votes` column is unusable here: a net score cannot tell
+// a unanimous result apart from a contested one adding up to the same number.
 func (q *Queries) FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]FindCompletedEditsRow, error) {
 	rows, err := q.db.Query(ctx, findCompletedEdits, arg.VotingPeriod, arg.MinimumVotingPeriod)
 	if err != nil {

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -153,11 +153,9 @@ type Querier interface {
 	ExpandPhashNeighbors(ctx context.Context, arg ExpandPhashNeighborsParams) ([]ExpandPhashNeighborsRow, error)
 	ExpandSceneCoMembers(ctx context.Context, sceneIds []uuid.UUID) ([]ExpandSceneCoMembersRow, error)
 	FindActiveInviteKeysForUser(ctx context.Context, generatedBy uuid.UUID) ([]InviteKey, error)
-	// Returns pending edits that have been open long enough to be closable, along with the
-	// tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
-	// so that voting and the cron sweep share a single policy.
-	// The `votes` column is deliberately unused here: it is a net score, and a net score cannot
-	// tell a unanimous result apart from a contested one that balances out to the same number.
+	// Returns pending edits past either voting deadline, along with the tallies needed to
+	// decide their outcome in Go. The `votes` column is unusable here: a net score cannot tell
+	// a unanimous result apart from a contested one adding up to the same number.
 	FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]FindCompletedEditsRow, error)
 	FindDraft(ctx context.Context, id uuid.UUID) (Draft, error)
 	FindDraftsByUser(ctx context.Context, userID uuid.UUID) ([]Draft, error)

--- a/internal/queries/querier.go
+++ b/internal/queries/querier.go
@@ -153,11 +153,12 @@ type Querier interface {
 	ExpandPhashNeighbors(ctx context.Context, arg ExpandPhashNeighborsParams) ([]ExpandPhashNeighborsRow, error)
 	ExpandSceneCoMembers(ctx context.Context, sceneIds []uuid.UUID) ([]ExpandSceneCoMembersRow, error)
 	FindActiveInviteKeysForUser(ctx context.Context, generatedBy uuid.UUID) ([]InviteKey, error)
-	// Returns pending edits that fulfill one of the criteria for being closed:
-	// * The full voting period has passed
-	// * The minimum voting period has passed, and the number of votes has crossed the voting threshold.
-	// The latter only applies for destructive edits. Non-destructive edits get auto-applied when sufficient votes are cast.
-	FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]Edit, error)
+	// Returns pending edits that have been open long enough to be closable, along with the
+	// tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
+	// so that voting and the cron sweep share a single policy.
+	// The `votes` column is deliberately unused here: it is a net score, and a net score cannot
+	// tell a unanimous result apart from a contested one that balances out to the same number.
+	FindCompletedEdits(ctx context.Context, arg FindCompletedEditsParams) ([]FindCompletedEditsRow, error)
 	FindDraft(ctx context.Context, id uuid.UUID) (Draft, error)
 	FindDraftsByUser(ctx context.Context, userID uuid.UUID) ([]Draft, error)
 	FindEdit(ctx context.Context, id uuid.UUID) (Edit, error)

--- a/internal/queries/sql/edit.sql
+++ b/internal/queries/sql/edit.sql
@@ -387,11 +387,9 @@ UNION
 SELECT jsonb_array_elements_text(COALESCE(data->'new_data'->'added_aliases', '[]'::jsonb)) AS alias FROM edit;
 
 -- name: FindCompletedEdits :many
--- Returns pending edits that have been open long enough to be closable, along with the
--- tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
--- so that voting and the cron sweep share a single policy.
--- The `votes` column is deliberately unused here: it is a net score, and a net score cannot
--- tell a unanimous result apart from a contested one that balances out to the same number.
+-- Returns pending edits past either voting deadline, along with the tallies needed to
+-- decide their outcome in Go. The `votes` column is unusable here: a net score cannot tell
+-- a unanimous result apart from a contested one adding up to the same number.
 SELECT sqlc.embed(E), V.accept_count, V.reject_count,
     COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('voting_period'))) AS full_period_elapsed,
     COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('minimum_voting_period'))) AS min_period_elapsed

--- a/internal/queries/sql/edit.sql
+++ b/internal/queries/sql/edit.sql
@@ -387,24 +387,26 @@ UNION
 SELECT jsonb_array_elements_text(COALESCE(data->'new_data'->'added_aliases', '[]'::jsonb)) AS alias FROM edit;
 
 -- name: FindCompletedEdits :many
--- Returns pending edits that fulfill one of the criteria for being closed:
--- * The full voting period has passed
--- * The minimum voting period has passed, and the number of votes has crossed the voting threshold.
--- The latter only applies for destructive edits. Non-destructive edits get auto-applied when sufficient votes are cast.
-SELECT * FROM edits
-WHERE status = 'PENDING'
+-- Returns pending edits that have been open long enough to be closable, along with the
+-- tallies needed to decide their outcome. Whether an edit actually closes is decided in Go,
+-- so that voting and the cron sweep share a single policy.
+-- The `votes` column is deliberately unused here: it is a net score, and a net score cannot
+-- tell a unanimous result apart from a contested one that balances out to the same number.
+SELECT sqlc.embed(E), V.accept_count, V.reject_count,
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('voting_period'))) AS full_period_elapsed,
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('minimum_voting_period'))) AS min_period_elapsed
+FROM edits E
+CROSS JOIN LATERAL (
+    SELECT
+        COUNT(*) FILTER (WHERE vote = 'ACCEPT') AS accept_count,
+        COUNT(*) FILTER (WHERE vote = 'REJECT') AS reject_count
+    FROM edit_votes WHERE edit_id = E.id
+) V
+WHERE E.status = 'PENDING'
 AND (
-    (created_at <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('voting_period'))) AND updated_at IS NULL)
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('voting_period')))
     OR
-    (updated_at <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('voting_period'))) AND updated_at IS NOT NULL)
-    OR (
-        votes >= sqlc.arg('minimum_votes')
-        AND (
-            (created_at <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('minimum_voting_period'))) AND updated_at IS NULL)
-            OR
-            (updated_at <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('minimum_voting_period'))) AND updated_at IS NOT NULL)
-        )
-    )
+    COALESCE(E.updated_at, E.created_at) <= (now()::timestamp - (INTERVAL '1 second' * sqlc.arg('minimum_voting_period')))
 );
 
 -- name: GetEditsByIds :many

--- a/internal/service/edit/service.go
+++ b/internal/service/edit/service.go
@@ -1253,7 +1253,6 @@ func (s *Edit) CloseEdit(ctx context.Context, editID uuid.UUID, status models.Vo
 	return updatedEdit, err
 }
 
-// editTally is everything the closing policy is allowed to consider.
 type editTally struct {
 	Accept            int
 	Reject            int
@@ -1262,9 +1261,7 @@ type editTally struct {
 	FullPeriodElapsed bool
 }
 
-// decideEdit is the single source of truth for whether a pending edit closes, and how.
-// Both casting a vote and the cron sweep route their decision through it, so that the two
-// can never disagree about what counts as a settled edit.
+// Shared by vote casting and the cron sweep so the two can't disagree on what closes an edit.
 func decideEdit(tally editTally) models.VoteStatusEnum {
 	threshold := config.GetVoteApplicationThreshold()
 
@@ -1278,7 +1275,6 @@ func decideEdit(tally editTally) models.VoteStatusEnum {
 		}
 	}
 
-	// Once the full period is up a contested edit is settled on its net score.
 	if tally.FullPeriodElapsed {
 		netThreshold := 0
 		if tally.Destructive {
@@ -1294,7 +1290,6 @@ func decideEdit(tally editTally) models.VoteStatusEnum {
 	return models.VoteStatusEnumPending
 }
 
-// resolveEditStatus applies the closing policy to an edit that has just been voted on.
 func (s *Edit) resolveEditStatus(ctx context.Context, edit *models.Edit) (models.VoteStatusEnum, error) {
 	votes, err := s.queries.GetEditVotes(ctx, edit.ID)
 	if err != nil {
@@ -1392,8 +1387,7 @@ func (s *Edit) CloseCompleted(ctx context.Context) ([]*models.Edit, error) {
 			continue
 		}
 
-		// One edit failing must not hold up the rest of the sweep, or it blocks the
-		// queue on every subsequent run as well.
+		// One failure must not block the rest of the queue on every subsequent run.
 		if err != nil {
 			logger.Errorf("Failed to close edit %s: %v", e.ID, err)
 			errs = append(errs, err)

--- a/internal/service/edit/service.go
+++ b/internal/service/edit/service.go
@@ -1012,7 +1012,7 @@ func (s *Edit) CreateVote(ctx context.Context, input models.EditVoteInput) (*mod
 		return nil, err
 	}
 
-	result, err := s.ResolveVotingThreshold(ctx, voteEdit)
+	result, err := s.resolveEditStatus(ctx, voteEdit)
 	// nolint: exhaustive
 	switch result {
 	case models.VoteStatusEnumAccepted:
@@ -1253,41 +1253,79 @@ func (s *Edit) CloseEdit(ctx context.Context, editID uuid.UUID, status models.Vo
 	return updatedEdit, err
 }
 
-func (s *Edit) ResolveVotingThreshold(ctx context.Context, edit *models.Edit) (models.VoteStatusEnum, error) {
-	threshold := config.GetVoteApplicationThreshold()
-	if threshold == 0 {
-		return models.VoteStatusEnumPending, nil
-	}
+// editTally is everything the closing policy is allowed to consider.
+type editTally struct {
+	Accept            int
+	Reject            int
+	Destructive       bool
+	MinPeriodElapsed  bool
+	FullPeriodElapsed bool
+}
 
-	// For destructive edits we check if they've been open for a minimum period before applying
-	if edit.IsDestructive() {
-		if time.Since(edit.CreatedAt).Seconds() <= float64(config.GetMinDestructiveVotingPeriod()) {
-			return models.VoteStatusEnumPending, nil
+// decideEdit is the single source of truth for whether a pending edit closes, and how.
+// Both casting a vote and the cron sweep route their decision through it, so that the two
+// can never disagree about what counts as a settled edit.
+func decideEdit(tally editTally) models.VoteStatusEnum {
+	threshold := config.GetVoteApplicationThreshold()
+
+	// Destructive edits stay open for a minimum period however the votes fall.
+	if threshold > 0 && (tally.MinPeriodElapsed || !tally.Destructive) {
+		if tally.Accept >= threshold && tally.Reject == 0 {
+			return models.VoteStatusEnumAccepted
+		}
+		if tally.Reject >= threshold && tally.Accept == 0 {
+			return models.VoteStatusEnumRejected
 		}
 	}
 
+	// Once the full period is up a contested edit is settled on its net score.
+	if tally.FullPeriodElapsed {
+		netThreshold := 0
+		if tally.Destructive {
+			// Require at least +1 votes to pass destructive edits
+			netThreshold = 1
+		}
+		if tally.Accept-tally.Reject >= netThreshold {
+			return models.VoteStatusEnumAccepted
+		}
+		return models.VoteStatusEnumRejected
+	}
+
+	return models.VoteStatusEnumPending
+}
+
+// resolveEditStatus applies the closing policy to an edit that has just been voted on.
+func (s *Edit) resolveEditStatus(ctx context.Context, edit *models.Edit) (models.VoteStatusEnum, error) {
 	votes, err := s.queries.GetEditVotes(ctx, edit.ID)
 	if err != nil {
 		return models.VoteStatusEnumPending, err
 	}
 
-	positive := 0
-	negative := 0
+	accept := 0
+	reject := 0
 	for _, vote := range votes {
-		if vote.Vote == models.VoteTypeEnumAccept.String() {
-			positive++
-		} else if vote.Vote == models.VoteTypeEnumReject.String() {
-			negative++
+		switch vote.Vote {
+		case models.VoteTypeEnumAccept.String():
+			accept++
+		case models.VoteTypeEnumReject.String():
+			reject++
 		}
 	}
 
-	if positive >= threshold && negative == 0 {
-		return models.VoteStatusEnumAccepted, nil
-	} else if negative >= threshold && positive == 0 {
-		return models.VoteStatusEnumRejected, nil
+	// An amended edit restarts its voting period.
+	opened := edit.CreatedAt
+	if edit.UpdatedAt != nil {
+		opened = *edit.UpdatedAt
 	}
+	elapsed := time.Since(opened).Seconds()
 
-	return models.VoteStatusEnumPending, nil
+	return decideEdit(editTally{
+		Accept:            accept,
+		Reject:            reject,
+		Destructive:       edit.IsDestructive(),
+		MinPeriodElapsed:  elapsed > float64(config.GetMinDestructiveVotingPeriod()),
+		FullPeriodElapsed: elapsed > float64(config.GetVotingPeriod()),
+	}), nil
 }
 
 func (s *Edit) FindPendingPerformerCreation(ctx context.Context, input models.QueryExistingPerformerInput) ([]models.Edit, error) {
@@ -1324,41 +1362,49 @@ func (s *Edit) FindPendingSceneCreation(ctx context.Context, input models.QueryE
 }
 
 func (s *Edit) CloseCompleted(ctx context.Context) ([]*models.Edit, error) {
-	edits, err := s.queries.FindCompletedEdits(ctx, queries.FindCompletedEditsParams{
+	rows, err := s.queries.FindCompletedEdits(ctx, queries.FindCompletedEditsParams{
 		VotingPeriod:        config.GetVotingPeriod(),
-		MinimumVotes:        config.GetVoteApplicationThreshold(),
 		MinimumVotingPeriod: config.GetMinDestructiveVotingPeriod(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Debugf("Closing %d completed edits", len(edits))
 	var closedEdits []*models.Edit
-	for _, edit := range edits {
-		e := converter.EditToModel(edit)
-		voteThreshold := 0
-		if e.IsDestructive() {
-			// Require at least +1 votes to pass destructive edits
-			voteThreshold = 1
-		}
+	var errs []error
+	for _, row := range rows {
+		e := converter.EditToModel(row.Edit)
 
 		var err error
 		var closedEdit *models.Edit
-		if e.VoteCount >= voteThreshold {
+		switch decideEdit(editTally{
+			Accept:            int(row.AcceptCount),
+			Reject:            int(row.RejectCount),
+			Destructive:       e.IsDestructive(),
+			MinPeriodElapsed:  row.MinPeriodElapsed,
+			FullPeriodElapsed: row.FullPeriodElapsed,
+		}) {
+		case models.VoteStatusEnumAccepted:
 			closedEdit, err = s.ApplyEdit(ctx, e.ID, false)
-		} else {
+		case models.VoteStatusEnumRejected:
 			closedEdit, err = s.CloseEdit(ctx, e.ID, models.VoteStatusEnumRejected)
+		default:
+			continue
 		}
 
+		// One edit failing must not hold up the rest of the sweep, or it blocks the
+		// queue on every subsequent run as well.
 		if err != nil {
-			return closedEdits, err
+			logger.Errorf("Failed to close edit %s: %v", e.ID, err)
+			errs = append(errs, err)
+			continue
 		}
 
 		closedEdits = append(closedEdits, closedEdit)
 	}
 
-	return closedEdits, nil
+	logger.Debugf("Closed %d of %d candidate edits", len(closedEdits), len(rows))
+	return closedEdits, errors.Join(errs...)
 }
 
 func (s *Edit) PromoteUserVoteRights(ctx context.Context, userID uuid.UUID, threshold int) error {


### PR DESCRIPTION
The two edit resolution paths behaved differently. They've now been merged in one function which correctly takes opposing edits into account when determining voting period.