### PR TITLE
Add bulk find queries for performers, studios, tags and scenes

### DIFF
--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1479,8 +1479,22 @@ export type Query = {
   findEdit?: Maybe<Edit>;
   /** Find a performer by ID */
   findPerformer?: Maybe<Performer>;
+  /**
+   * Find multiple performers by ID.
+   * The results are returned in the same order as the provided ids, with null in
+   * the place of any id that could not be found.
+   * A maximum of 100 ids may be requested at a time.
+   */
+  findPerformers: Array<Maybe<Performer>>;
   /** Find a scene by ID */
   findScene?: Maybe<Scene>;
+  /**
+   * Find multiple scenes by ID.
+   * The results are returned in the same order as the provided ids, with null in
+   * the place of any id that could not be found.
+   * A maximum of 100 ids may be requested at a time.
+   */
+  findScenes: Array<Maybe<Scene>>;
   /** Finds scenes that match a list of hashes */
   findScenesBySceneFingerprints: Array<Array<Maybe<Scene>>>;
   /** Find an external site by ID */
@@ -1488,12 +1502,26 @@ export type Query = {
   findSiteCategory?: Maybe<SiteCategory>;
   /** Find a studio by ID or name */
   findStudio?: Maybe<Studio>;
+  /**
+   * Find multiple studios by ID.
+   * The results are returned in the same order as the provided ids, with null in
+   * the place of any id that could not be found.
+   * A maximum of 100 ids may be requested at a time.
+   */
+  findStudios: Array<Maybe<Studio>>;
   /** Find a tag by ID or name */
   findTag?: Maybe<Tag>;
   /** Find a tag category by ID */
   findTagCategory?: Maybe<TagCategory>;
   /** Find a tag with a matching name or alias */
   findTagOrAlias?: Maybe<Tag>;
+  /**
+   * Find multiple tags by ID.
+   * The results are returned in the same order as the provided ids, with null in
+   * the place of any id that could not be found.
+   * A maximum of 100 ids may be requested at a time.
+   */
+  findTags: Array<Maybe<Tag>>;
   /** Find user by ID or username */
   findUser?: Maybe<User>;
   /** Returns phash clusters for a scene */
@@ -1552,8 +1580,20 @@ export type QueryFindPerformerArgs = {
 
 
 /** The query root for this schema */
+export type QueryFindPerformersArgs = {
+  ids: Array<Scalars['ID']['input']>;
+};
+
+
+/** The query root for this schema */
 export type QueryFindSceneArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+/** The query root for this schema */
+export type QueryFindScenesArgs = {
+  ids: Array<Scalars['ID']['input']>;
 };
 
 
@@ -1583,6 +1623,12 @@ export type QueryFindStudioArgs = {
 
 
 /** The query root for this schema */
+export type QueryFindStudiosArgs = {
+  ids: Array<Scalars['ID']['input']>;
+};
+
+
+/** The query root for this schema */
 export type QueryFindTagArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
@@ -1598,6 +1644,12 @@ export type QueryFindTagCategoryArgs = {
 /** The query root for this schema */
 export type QueryFindTagOrAliasArgs = {
   name: Scalars['String']['input'];
+};
+
+
+/** The query root for this schema */
+export type QueryFindTagsArgs = {
+  ids: Array<Scalars['ID']['input']>;
 };
 
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -5,6 +5,13 @@ type Query {
   # performer names may not be unique
   """Find a performer by ID"""
   findPerformer(id: ID!): Performer @hasRole(role: READ)
+  """
+  Find multiple performers by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findPerformers(ids: [ID!]!): [Performer]! @hasRole(role: READ)
   queryPerformers(input: PerformerQueryInput!): QueryPerformersResultType! @hasRole(role: READ)
 
   #### Studios ####
@@ -12,6 +19,13 @@ type Query {
   # studio names should be unique
   """Find a studio by ID or name"""
   findStudio(id: ID, name: String): Studio @hasRole(role: READ)
+  """
+  Find multiple studios by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findStudios(ids: [ID!]!): [Studio]! @hasRole(role: READ)
   queryStudios(input: StudioQueryInput!): QueryStudiosResultType! @hasRole(role: READ)
 
   #### Tags ####
@@ -19,6 +33,13 @@ type Query {
   # tag names will be unique
   """Find a tag by ID or name"""
   findTag(id: ID, name: String): Tag @hasRole(role: READ)
+  """
+  Find multiple tags by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findTags(ids: [ID!]!): [Tag]! @hasRole(role: READ)
   """Find a tag with a matching name or alias"""
   findTagOrAlias(name: String!): Tag @hasRole(role: READ)
   queryTags(input: TagQueryInput!): QueryTagsResultType! @hasRole(role: READ)
@@ -32,6 +53,13 @@ type Query {
   # ids should be unique
   """Find a scene by ID"""
   findScene(id: ID!): Scene @hasRole(role: READ)
+  """
+  Find multiple scenes by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findScenes(ids: [ID!]!): [Scene]! @hasRole(role: READ)
 
   """Finds scenes that match a list of hashes"""
   findScenesBySceneFingerprints(fingerprints: [[FingerprintQueryInput!]!]!): [[Scene]!]! @hasRole(role: READ)

--- a/internal/api/bulk_find_integration_test.go
+++ b/internal/api/bulk_find_integration_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type bulkFindTestRunner struct {
+	testRunner
+}
+
+func createBulkFindTestRunner(t *testing.T) *bulkFindTestRunner {
+	return &bulkFindTestRunner{
+		testRunner: *asAdmin(t),
+	}
+}
+
+func TestFindPerformers(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	first, err := s.createTestPerformer(nil)
+	assert.NoError(t, err)
+	second, err := s.createTestPerformer(nil)
+	assert.NoError(t, err)
+
+	missingID := uuid.Must(uuid.NewV4())
+	// duplicate ids, an unknown id, and reversed creation order to verify that
+	// the results are positional
+	ids := []uuid.UUID{second.UUID(), missingID, first.UUID(), second.UUID()}
+
+	performers, err := s.client.findPerformers(ids)
+	assert.NoError(t, err)
+
+	if !assert.Len(t, performers, len(ids)) {
+		return
+	}
+	assert.Equal(t, second.ID, performers[0].ID)
+	assert.Nil(t, performers[1])
+	assert.Equal(t, first.ID, performers[2].ID)
+	assert.Equal(t, second.ID, performers[3].ID)
+	assert.Equal(t, second.Name, performers[0].Name)
+}
+
+func TestFindStudios(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	first, err := s.createTestStudio(nil)
+	assert.NoError(t, err)
+	second, err := s.createTestStudio(nil)
+	assert.NoError(t, err)
+
+	missingID := uuid.Must(uuid.NewV4())
+	ids := []uuid.UUID{second.UUID(), missingID, first.UUID()}
+
+	studios, err := s.client.findStudios(ids)
+	assert.NoError(t, err)
+
+	if !assert.Len(t, studios, len(ids)) {
+		return
+	}
+	assert.Equal(t, second.ID, studios[0].ID)
+	assert.Nil(t, studios[1])
+	assert.Equal(t, first.ID, studios[2].ID)
+	assert.Equal(t, second.Name, studios[0].Name)
+}
+
+func TestFindTags(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	first, err := s.createTestTag(nil)
+	assert.NoError(t, err)
+	second, err := s.createTestTag(nil)
+	assert.NoError(t, err)
+
+	missingID := uuid.Must(uuid.NewV4())
+	ids := []uuid.UUID{second.UUID(), missingID, first.UUID()}
+
+	tags, err := s.client.findTags(ids)
+	assert.NoError(t, err)
+
+	if !assert.Len(t, tags, len(ids)) {
+		return
+	}
+	assert.Equal(t, second.ID, tags[0].ID)
+	assert.Nil(t, tags[1])
+	assert.Equal(t, first.ID, tags[2].ID)
+	assert.Equal(t, second.Name, tags[0].Name)
+}
+
+func TestFindScenes(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	first, err := s.createTestScene(nil)
+	assert.NoError(t, err)
+	second, err := s.createTestScene(nil)
+	assert.NoError(t, err)
+
+	missingID := uuid.Must(uuid.NewV4())
+	ids := []uuid.UUID{second.UUID(), missingID, first.UUID()}
+
+	scenes, err := s.client.findScenes(ids)
+	assert.NoError(t, err)
+
+	if !assert.Len(t, scenes, len(ids)) {
+		return
+	}
+	assert.Equal(t, second.ID, scenes[0].ID)
+	assert.Nil(t, scenes[1])
+	assert.Equal(t, first.ID, scenes[2].ID)
+	assert.Equal(t, second.Title, scenes[0].Title)
+}
+
+func TestFindBulkEmptyIDs(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	performers, err := s.client.findPerformers([]uuid.UUID{})
+	assert.NoError(t, err)
+	assert.Empty(t, performers)
+
+	scenes, err := s.client.findScenes([]uuid.UUID{})
+	assert.NoError(t, err)
+	assert.Empty(t, scenes)
+}
+
+func TestFindBulkTooManyIDs(t *testing.T) {
+	s := createBulkFindTestRunner(t)
+
+	ids := make([]uuid.UUID, 101)
+	for i := range ids {
+		ids[i] = uuid.Must(uuid.NewV4())
+	}
+
+	_, err := s.client.findPerformers(ids)
+	assert.ErrorContains(t, err, "too many ids")
+
+	_, err = s.client.findStudios(ids)
+	assert.ErrorContains(t, err, "too many ids")
+
+	_, err = s.client.findTags(ids)
+	assert.ErrorContains(t, err, "too many ids")
+
+	_, err = s.client.findScenes(ids)
+	assert.ErrorContains(t, err, "too many ids")
+}

--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -534,6 +534,78 @@ func (c *graphqlClient) findPerformer(id uuid.UUID) (*performerOutput, error) {
 	return resp.FindPerformer, nil
 }
 
+func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, error) {
+	q := `
+	query FindPerformers($ids: [ID!]!) {
+		findPerformers(ids: $ids) {
+			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+		}
+	}`
+
+	var resp struct {
+		FindPerformers []*performerOutput
+	}
+	if err := c.Post(q, &resp, client.Var("ids", ids)); err != nil {
+		return nil, err
+	}
+
+	return resp.FindPerformers, nil
+}
+
+func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
+	q := `
+	query FindStudios($ids: [ID!]!) {
+		findStudios(ids: $ids) {
+			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+		}
+	}`
+
+	var resp struct {
+		FindStudios []*studioOutput
+	}
+	if err := c.Post(q, &resp, client.Var("ids", ids)); err != nil {
+		return nil, err
+	}
+
+	return resp.FindStudios, nil
+}
+
+func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
+	q := `
+	query FindTags($ids: [ID!]!) {
+		findTags(ids: $ids) {
+			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+		}
+	}`
+
+	var resp struct {
+		FindTags []*tagOutput
+	}
+	if err := c.Post(q, &resp, client.Var("ids", ids)); err != nil {
+		return nil, err
+	}
+
+	return resp.FindTags, nil
+}
+
+func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
+	q := `
+	query FindScenes($ids: [ID!]!) {
+		findScenes(ids: $ids) {
+			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+		}
+	}`
+
+	var resp struct {
+		FindScenes []*sceneOutput
+	}
+	if err := c.Post(q, &resp, client.Var("ids", ids)); err != nil {
+		return nil, err
+	}
+
+	return resp.FindScenes, nil
+}
+
 func (c *graphqlClient) createStudio(input models.StudioCreateInput) (*studioOutput, error) {
 	q := `
 	mutation StudioCreate($input: StudioCreateInput!) {

--- a/internal/api/loaders.go
+++ b/internal/api/loaders.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/stashapp/stash-box/internal/dataloader"
@@ -48,4 +49,27 @@ func imageList(ctx context.Context, imageIDs []uuid.UUID) ([]models.Image, error
 		}
 	}
 	return images, nil
+}
+
+// maxBulkFindIDs is the maximum number of ids accepted by the bulk find queries.
+const maxBulkFindIDs = 100
+
+// loadByIDs resolves a list of ids using a dataloader, returning the results in
+// the same order as the ids, with nil in the place of any id that was not found.
+func loadByIDs[T any](ids []uuid.UUID, loadAll func([]uuid.UUID) ([]*T, []error)) ([]*T, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if len(ids) > maxBulkFindIDs {
+		return nil, fmt.Errorf("too many ids: %d, maximum is %d", len(ids), maxBulkFindIDs)
+	}
+
+	res, errors := loadAll(ids)
+	for _, err := range errors {
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
 }

--- a/internal/api/resolver_query_performer.go
+++ b/internal/api/resolver_query_performer.go
@@ -5,11 +5,16 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/stashapp/stash-box/internal/dataloader"
 	"github.com/stashapp/stash-box/internal/models"
 )
 
 func (r *queryResolver) FindPerformer(ctx context.Context, id uuid.UUID) (*models.Performer, error) {
 	return r.services.Performer().FindByID(ctx, id)
+}
+
+func (r *queryResolver) FindPerformers(ctx context.Context, ids []uuid.UUID) ([]*models.Performer, error) {
+	return loadByIDs(ids, dataloader.For(ctx).PerformerByID.LoadAll)
 }
 
 func (r *queryResolver) QueryPerformers(ctx context.Context, input models.PerformerQueryInput) (*models.PerformerQuery, error) {

--- a/internal/api/resolver_query_scene.go
+++ b/internal/api/resolver_query_scene.go
@@ -7,11 +7,16 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/stashapp/stash-box/internal/dataloader"
 	"github.com/stashapp/stash-box/internal/models"
 )
 
 func (r *queryResolver) FindScene(ctx context.Context, id uuid.UUID) (*models.Scene, error) {
 	return r.services.Scene().FindByID(ctx, id)
+}
+
+func (r *queryResolver) FindScenes(ctx context.Context, ids []uuid.UUID) ([]*models.Scene, error) {
+	return loadByIDs(ids, dataloader.For(ctx).SceneByID.LoadAll)
 }
 
 func (r *queryResolver) QueryScenes(ctx context.Context, input models.SceneQueryInput) (*models.SceneQuery, error) {

--- a/internal/api/resolver_query_studio.go
+++ b/internal/api/resolver_query_studio.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/stashapp/stash-box/internal/dataloader"
 	"github.com/stashapp/stash-box/internal/models"
 )
 
@@ -16,6 +17,10 @@ func (r *queryResolver) FindStudio(ctx context.Context, id *uuid.UUID, name *str
 	}
 
 	return nil, nil
+}
+
+func (r *queryResolver) FindStudios(ctx context.Context, ids []uuid.UUID) ([]*models.Studio, error) {
+	return loadByIDs(ids, dataloader.For(ctx).StudioByID.LoadAll)
 }
 
 func (r *queryResolver) QueryStudios(ctx context.Context, input models.StudioQueryInput) (*models.QueryStudiosResultType, error) {

--- a/internal/api/resolver_query_tag.go
+++ b/internal/api/resolver_query_tag.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/stashapp/stash-box/internal/dataloader"
 	"github.com/stashapp/stash-box/internal/models"
 )
 
@@ -22,6 +23,10 @@ func (r *queryResolver) FindTag(ctx context.Context, id *uuid.UUID, name *string
 
 func (r *queryResolver) FindTagOrAlias(ctx context.Context, name string) (*models.Tag, error) {
 	return r.services.Tag().FindByNameOrAlias(ctx, name)
+}
+
+func (r *queryResolver) FindTags(ctx context.Context, ids []uuid.UUID) ([]*models.Tag, error) {
+	return loadByIDs(ids, dataloader.For(ctx).TagByID.LoadAll)
 }
 
 func (r *queryResolver) QueryTags(ctx context.Context, input models.TagQueryInput) (*models.QueryTagsResultType, error) {

--- a/internal/models/generated_exec.go
+++ b/internal/models/generated_exec.go
@@ -473,14 +473,18 @@ type ComplexityRoot struct {
 		FindDrafts                    func(childComplexity int) int
 		FindEdit                      func(childComplexity int, id uuid.UUID) int
 		FindPerformer                 func(childComplexity int, id uuid.UUID) int
+		FindPerformers                func(childComplexity int, ids []uuid.UUID) int
 		FindScene                     func(childComplexity int, id uuid.UUID) int
+		FindScenes                    func(childComplexity int, ids []uuid.UUID) int
 		FindScenesBySceneFingerprints func(childComplexity int, fingerprints [][]FingerprintQueryInput) int
 		FindSite                      func(childComplexity int, id uuid.UUID) int
 		FindSiteCategory              func(childComplexity int, id int) int
 		FindStudio                    func(childComplexity int, id *uuid.UUID, name *string) int
+		FindStudios                   func(childComplexity int, ids []uuid.UUID) int
 		FindTag                       func(childComplexity int, id *uuid.UUID, name *string) int
 		FindTagCategory               func(childComplexity int, id uuid.UUID) int
 		FindTagOrAlias                func(childComplexity int, name string) int
+		FindTags                      func(childComplexity int, ids []uuid.UUID) int
 		FindUser                      func(childComplexity int, id *uuid.UUID, username *string) int
 		FingerprintClusters           func(childComplexity int, input FingerprintClustersInput) int
 		GetConfig                     func(childComplexity int) int
@@ -971,15 +975,19 @@ type PerformerEditResolver interface {
 }
 type QueryResolver interface {
 	FindPerformer(ctx context.Context, id uuid.UUID) (*Performer, error)
+	FindPerformers(ctx context.Context, ids []uuid.UUID) ([]*Performer, error)
 	QueryPerformers(ctx context.Context, input PerformerQueryInput) (*PerformerQuery, error)
 	FindStudio(ctx context.Context, id *uuid.UUID, name *string) (*Studio, error)
+	FindStudios(ctx context.Context, ids []uuid.UUID) ([]*Studio, error)
 	QueryStudios(ctx context.Context, input StudioQueryInput) (*QueryStudiosResultType, error)
 	FindTag(ctx context.Context, id *uuid.UUID, name *string) (*Tag, error)
+	FindTags(ctx context.Context, ids []uuid.UUID) ([]*Tag, error)
 	FindTagOrAlias(ctx context.Context, name string) (*Tag, error)
 	QueryTags(ctx context.Context, input TagQueryInput) (*QueryTagsResultType, error)
 	FindTagCategory(ctx context.Context, id uuid.UUID) (*TagCategory, error)
 	QueryTagCategories(ctx context.Context) (*QueryTagCategoriesResultType, error)
 	FindScene(ctx context.Context, id uuid.UUID) (*Scene, error)
+	FindScenes(ctx context.Context, ids []uuid.UUID) ([]*Scene, error)
 	FindScenesBySceneFingerprints(ctx context.Context, fingerprints [][]FingerprintQueryInput) ([][]*Scene, error)
 	QueryScenes(ctx context.Context, input SceneQueryInput) (*SceneQuery, error)
 	FindSite(ctx context.Context, id uuid.UUID) (*Site, error)
@@ -3208,6 +3216,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.FindPerformer(childComplexity, args["id"].(uuid.UUID)), true
+	case "Query.findPerformers":
+		if e.ComplexityRoot.Query.FindPerformers == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findPerformers_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.FindPerformers(childComplexity, args["ids"].([]uuid.UUID)), true
 	case "Query.findScene":
 		if e.ComplexityRoot.Query.FindScene == nil {
 			break
@@ -3219,6 +3238,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.FindScene(childComplexity, args["id"].(uuid.UUID)), true
+	case "Query.findScenes":
+		if e.ComplexityRoot.Query.FindScenes == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findScenes_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.FindScenes(childComplexity, args["ids"].([]uuid.UUID)), true
 	case "Query.findScenesBySceneFingerprints":
 		if e.ComplexityRoot.Query.FindScenesBySceneFingerprints == nil {
 			break
@@ -3263,6 +3293,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.FindStudio(childComplexity, args["id"].(*uuid.UUID), args["name"].(*string)), true
+	case "Query.findStudios":
+		if e.ComplexityRoot.Query.FindStudios == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findStudios_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.FindStudios(childComplexity, args["ids"].([]uuid.UUID)), true
 	case "Query.findTag":
 		if e.ComplexityRoot.Query.FindTag == nil {
 			break
@@ -3296,6 +3337,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.FindTagOrAlias(childComplexity, args["name"].(string)), true
+	case "Query.findTags":
+		if e.ComplexityRoot.Query.FindTags == nil {
+			break
+		}
+
+		args, err := ec.field_Query_findTags_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.FindTags(childComplexity, args["ids"].([]uuid.UUID)), true
 	case "Query.findUser":
 		if e.ComplexityRoot.Query.FindUser == nil {
 			break
@@ -6742,6 +6794,13 @@ type Query {
   # performer names may not be unique
   """Find a performer by ID"""
   findPerformer(id: ID!): Performer @hasRole(role: READ)
+  """
+  Find multiple performers by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findPerformers(ids: [ID!]!): [Performer]! @hasRole(role: READ)
   queryPerformers(input: PerformerQueryInput!): QueryPerformersResultType! @hasRole(role: READ)
 
   #### Studios ####
@@ -6749,6 +6808,13 @@ type Query {
   # studio names should be unique
   """Find a studio by ID or name"""
   findStudio(id: ID, name: String): Studio @hasRole(role: READ)
+  """
+  Find multiple studios by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findStudios(ids: [ID!]!): [Studio]! @hasRole(role: READ)
   queryStudios(input: StudioQueryInput!): QueryStudiosResultType! @hasRole(role: READ)
 
   #### Tags ####
@@ -6756,6 +6822,13 @@ type Query {
   # tag names will be unique
   """Find a tag by ID or name"""
   findTag(id: ID, name: String): Tag @hasRole(role: READ)
+  """
+  Find multiple tags by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findTags(ids: [ID!]!): [Tag]! @hasRole(role: READ)
   """Find a tag with a matching name or alias"""
   findTagOrAlias(name: String!): Tag @hasRole(role: READ)
   queryTags(input: TagQueryInput!): QueryTagsResultType! @hasRole(role: READ)
@@ -6769,6 +6842,13 @@ type Query {
   # ids should be unique
   """Find a scene by ID"""
   findScene(id: ID!): Scene @hasRole(role: READ)
+  """
+  Find multiple scenes by ID.
+  The results are returned in the same order as the provided ids, with null in
+  the place of any id that could not be found.
+  A maximum of 100 ids may be requested at a time.
+  """
+  findScenes(ids: [ID!]!): [Scene]! @hasRole(role: READ)
 
   """Finds scenes that match a list of hashes"""
   findScenesBySceneFingerprints(fingerprints: [[FingerprintQueryInput!]!]!): [[Scene]!]! @hasRole(role: READ)
@@ -9037,6 +9117,20 @@ func (ec *executionContext) field_Query_findPerformer_args(ctx context.Context, 
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_findPerformers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "ids",
+		func(ctx context.Context, v any) ([]uuid.UUID, error) {
+			return ec.unmarshalNID2ᚕgithubᚗcomᚋgofrsᚋuuidᚐUUIDᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["ids"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_findScene_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -9062,6 +9156,20 @@ func (ec *executionContext) field_Query_findScenesBySceneFingerprints_args(ctx c
 		return nil, err
 	}
 	args["fingerprints"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_findScenes_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "ids",
+		func(ctx context.Context, v any) ([]uuid.UUID, error) {
+			return ec.unmarshalNID2ᚕgithubᚗcomᚋgofrsᚋuuidᚐUUIDᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["ids"] = arg0
 	return args, nil
 }
 
@@ -9115,6 +9223,20 @@ func (ec *executionContext) field_Query_findStudio_args(ctx context.Context, raw
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_findStudios_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "ids",
+		func(ctx context.Context, v any) ([]uuid.UUID, error) {
+			return ec.unmarshalNID2ᚕgithubᚗcomᚋgofrsᚋuuidᚐUUIDᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["ids"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_findTagCategory_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -9162,6 +9284,20 @@ func (ec *executionContext) field_Query_findTag_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["name"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_findTags_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "ids",
+		func(ctx context.Context, v any) ([]uuid.UUID, error) {
+			return ec.unmarshalNID2ᚕgithubᚗcomᚋgofrsᚋuuidᚐUUIDᚄ(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["ids"] = arg0
 	return args, nil
 }
 
@@ -18831,6 +18967,68 @@ func (ec *executionContext) fieldContext_Query_findPerformer(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_findPerformers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_findPerformers(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().FindPerformers(ctx, fc.Args["ids"].([]uuid.UUID))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "READ")
+				if err != nil {
+					var zeroVal []*Performer
+					return zeroVal, err
+				}
+				if ec.Directives.HasRole == nil {
+					var zeroVal []*Performer
+					return zeroVal, errors.New("directive hasRole is not implemented")
+				}
+				return ec.Directives.HasRole(ctx, nil, directive0, role)
+			}
+
+			next = directive1
+			return next
+		},
+		func(ctx context.Context, selections ast.SelectionSet, v []*Performer) graphql.Marshaler {
+			return ec.marshalNPerformer2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐPerformer(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_findPerformers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Performer(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findPerformers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_queryPerformers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -18955,6 +19153,68 @@ func (ec *executionContext) fieldContext_Query_findStudio(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_findStudios(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_findStudios(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().FindStudios(ctx, fc.Args["ids"].([]uuid.UUID))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "READ")
+				if err != nil {
+					var zeroVal []*Studio
+					return zeroVal, err
+				}
+				if ec.Directives.HasRole == nil {
+					var zeroVal []*Studio
+					return zeroVal, errors.New("directive hasRole is not implemented")
+				}
+				return ec.Directives.HasRole(ctx, nil, directive0, role)
+			}
+
+			next = directive1
+			return next
+		},
+		func(ctx context.Context, selections ast.SelectionSet, v []*Studio) graphql.Marshaler {
+			return ec.marshalNStudio2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐStudio(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_findStudios(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Studio(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findStudios_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_queryStudios(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -19073,6 +19333,68 @@ func (ec *executionContext) fieldContext_Query_findTag(ctx context.Context, fiel
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_findTag_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_findTags(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_findTags(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().FindTags(ctx, fc.Args["ids"].([]uuid.UUID))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "READ")
+				if err != nil {
+					var zeroVal []*Tag
+					return zeroVal, err
+				}
+				if ec.Directives.HasRole == nil {
+					var zeroVal []*Tag
+					return zeroVal, errors.New("directive hasRole is not implemented")
+				}
+				return ec.Directives.HasRole(ctx, nil, directive0, role)
+			}
+
+			next = directive1
+			return next
+		},
+		func(ctx context.Context, selections ast.SelectionSet, v []*Tag) graphql.Marshaler {
+			return ec.marshalNTag2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐTag(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_findTags(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Tag(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findTags_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -19371,6 +19693,68 @@ func (ec *executionContext) fieldContext_Query_findScene(ctx context.Context, fi
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_findScene_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_findScenes(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_findScenes(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().FindScenes(ctx, fc.Args["ids"].([]uuid.UUID))
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				role, err := ec.unmarshalNRoleEnum2githubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐRoleEnum(ctx, "READ")
+				if err != nil {
+					var zeroVal []*Scene
+					return zeroVal, err
+				}
+				if ec.Directives.HasRole == nil {
+					var zeroVal []*Scene
+					return zeroVal, errors.New("directive hasRole is not implemented")
+				}
+				return ec.Directives.HasRole(ctx, nil, directive0, role)
+			}
+
+			next = directive1
+			return next
+		},
+		func(ctx context.Context, selections ast.SelectionSet, v []*Scene) graphql.Marshaler {
+			return ec.marshalNScene2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐScene(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_findScenes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Scene(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_findScenes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -37710,6 +38094,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findPerformers":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findPerformers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "queryPerformers":
 			field := field
 
@@ -37751,6 +38157,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findStudios":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findStudios(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "queryStudios":
 			field := field
 
@@ -37783,6 +38211,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_findTag(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findTags":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findTags(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -37884,6 +38334,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_findScene(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "findScenes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_findScenes(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -44091,6 +44563,16 @@ func (ec *executionContext) marshalNPerformer2ᚕgithubᚗcomᚋstashappᚋstash
 	return ret
 }
 
+func (ec *executionContext) marshalNPerformer2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐPerformer(ctx context.Context, sel ast.SelectionSet, v []*Performer) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalOPerformer2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐPerformer(ctx, sel, v[i])
+	})
+
+	return ret
+}
+
 func (ec *executionContext) marshalNPerformer2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐPerformer(ctx context.Context, sel ast.SelectionSet, v *Performer) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -44756,6 +45238,16 @@ func (ec *executionContext) marshalNStudio2ᚕgithubᚗcomᚋstashappᚋstashᚑ
 	return ret
 }
 
+func (ec *executionContext) marshalNStudio2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐStudio(ctx context.Context, sel ast.SelectionSet, v []*Studio) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalOStudio2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐStudio(ctx, sel, v[i])
+	})
+
+	return ret
+}
+
 func (ec *executionContext) marshalNStudio2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐStudio(ctx context.Context, sel ast.SelectionSet, v *Studio) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -44817,6 +45309,16 @@ func (ec *executionContext) marshalNTag2ᚕgithubᚗcomᚋstashappᚋstashᚑbox
 			return graphql.Null
 		}
 	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTag2ᚕᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐTag(ctx context.Context, sel ast.SelectionSet, v []*Tag) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalOTag2ᚖgithubᚗcomᚋstashappᚋstashᚑboxᚋinternalᚋmodelsᚐTag(ctx, sel, v[i])
+	})
 
 	return ret
 }


### PR DESCRIPTION
Adds findPerformers, findStudios, findTags and findScenes, each taking a list of ids and returning the entities positionally, with null for any id that was not found. Requests are capped at 100 ids and resolved through the existing dataloaders, so a bulk fetch is a single database query.