### PR TITLE
Fix accessibility and UX defects

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -37,6 +37,11 @@
   color: $text-color;
   cursor: pointer;
 
+  .react-select__single-value,
+  .react-select__input {
+    color: $text-color;
+  }
+
   .react-select__multi-value {
     background-color: $muted-gray;
     color: $dark-text;

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -60,7 +60,7 @@ div.react-select__menu {
 
 .LoginPrompt {
   height: 70vh;
-  width: 960px;
+  max-width: 960px;
   margin-left: auto;
   margin-right: auto;
   display: flex;

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -37,14 +37,9 @@
   color: $text-color;
   cursor: pointer;
 
-  .react-select__single-value,
-  .react-select__input {
-    color: black;
-  }
-
   .react-select__multi-value {
     background-color: $muted-gray;
-    color: $text-color;
+    color: $dark-text;
   }
 }
 

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { type FC, useState } from "react";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import { useForm } from "react-hook-form";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, Navigate, useLocation } from "react-router-dom";
 import { ROUTE_FORGOT_PASSWORD, ROUTE_REGISTER } from "src/constants/route";
 import { getCredentialsSetting, getPlatformURL } from "src/utils/createClient";
 import * as yup from "yup";
@@ -25,7 +25,6 @@ const Messages: Record<string, string> = {
 const Login: FC = () => {
   const [loading, setLoading] = useState(false);
   const location = useLocation();
-  const navigate = useNavigate();
   const [loginError, setLoginError] = useState("");
   const msg = new URLSearchParams(location.search).get("msg");
   const redirect = new URLSearchParams(location.search).get("redirect");
@@ -38,7 +37,7 @@ const Login: FC = () => {
     resolver: yupResolver(schema),
   });
 
-  if (isAuthenticated) navigate("/");
+  if (isAuthenticated) return <Navigate to="/" replace />;
 
   const onSubmit = async (formData: LoginFormData) => {
     setLoading(true);

--- a/frontend/src/components/amendableEditCard/AmendableImageChangeRow.tsx
+++ b/frontend/src/components/amendableEditCard/AmendableImageChangeRow.tsx
@@ -2,7 +2,7 @@ import { faUndo, faXmark } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import type { FC } from "react";
 import { Button, Col, Row } from "react-bootstrap";
-import { Icon } from "src/components/fragments";
+import { DeletedImage, Icon } from "src/components/fragments";
 import ImageComponent from "src/components/image";
 import { useAmendment } from "./AmendmentContext";
 
@@ -65,7 +65,7 @@ const AmendableImageChangeRow: FC<AmendableImageChangeRowProps> = ({
                       })}
                     >
                       {image === null ? (
-                        <img className={CLASSNAME_IMAGE} alt="Deleted" />
+                        <DeletedImage />
                       ) : (
                         <div className={CLASSNAME_IMAGE}>
                           <ImageComponent
@@ -124,7 +124,7 @@ const AmendableImageChangeRow: FC<AmendableImageChangeRowProps> = ({
                     })}
                   >
                     {image === null ? (
-                      <img className={CLASSNAME_IMAGE} alt="Deleted" />
+                      <DeletedImage />
                     ) : (
                       <div className={CLASSNAME_IMAGE}>
                         <ImageComponent

--- a/frontend/src/components/editCard/__tests__/renderStudioDetails.test.tsx
+++ b/frontend/src/components/editCard/__tests__/renderStudioDetails.test.tsx
@@ -125,8 +125,9 @@ describe("renderStudioDetails", () => {
         {},
         true,
       );
-      const deleted = container.querySelector("img[alt='Deleted']");
+      const deleted = container.querySelector(".DeletedImage");
       expect(deleted).toBeInTheDocument();
+      expect(within(deleted as HTMLElement).getByText("Deleted"));
     });
   });
 

--- a/frontend/src/components/fragments/DeletedImage.tsx
+++ b/frontend/src/components/fragments/DeletedImage.tsx
@@ -1,0 +1,14 @@
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { FC } from "react";
+import Icon from "./Icon";
+
+const CLASSNAME = "DeletedImage";
+
+const DeletedImage: FC = () => (
+  <div className={CLASSNAME}>
+    <Icon icon={faXmark} />
+    <span>Deleted</span>
+  </div>
+);
+
+export default DeletedImage;

--- a/frontend/src/components/fragments/index.ts
+++ b/frontend/src/components/fragments/index.ts
@@ -1,3 +1,4 @@
+export { default as DeletedImage } from "./DeletedImage";
 export { default as ErrorMessage } from "./ErrorMessage";
 export { FavoriteStar } from "./Favorite";
 export { default as GenderIcon } from "./GenderIcon";

--- a/frontend/src/components/fragments/styles.scss
+++ b/frontend/src/components/fragments/styles.scss
@@ -145,3 +145,24 @@
     }
   }
 }
+
+.DeletedImage {
+  align-items: center;
+  background-color: $secondary;
+  border-radius: 4px;
+  color: var(--bs-gray-400);
+  display: flex;
+  flex-direction: column;
+  height: 150px;
+  justify-content: center;
+  margin: 5px;
+  padding: 0 1.25rem;
+
+  .fa-icon {
+    font-size: 1.75rem;
+  }
+
+  span {
+    font-size: 0.85rem;
+  }
+}

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Col, Row } from "react-bootstrap";
+import { DeletedImage } from "src/components/fragments";
 import ImageComponent from "src/components/image";
 
 type Image = {
@@ -28,7 +29,7 @@ const Images: FC<{
       {(images ?? []).map((image, i) =>
         image === null ? (
           // biome-ignore lint/suspicious/noArrayIndexKey: Image is deleted, no other key
-          <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
+          <DeletedImage key={`deleted-${i}`} />
         ) : (
           <div key={image.id} className={CLASSNAME_IMAGE}>
             <ImageComponent

--- a/frontend/src/components/studioSelect/styles.scss
+++ b/frontend/src/components/studioSelect/styles.scss
@@ -2,10 +2,4 @@
   .parent-studio {
     color: $text-muted;
   }
-
-  .react-select__value-container {
-    .parent-studio {
-      color: rgba($black, 0.5);
-    }
-  }
 }

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -88,7 +88,6 @@ body {
   color: $text-color;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  min-width: 1210px;
 }
 
 .table {


### PR DESCRIPTION
#### 1. Auth redirect called during render (`Login.tsx`)

`if (isAuthenticated) navigate("/")` ran in the component body,
triggering React updates during render and risking a loop while auth
state resolves. Replaced with a declarative `<Navigate to="/" replace />`
returned after all hooks.

#### 2. react-select contrast failures (`App.scss`, `studioSelect/styles.scss`)

- Selected values and typed input text were forced to `color: black` on
  the dark `$secondary` control (~2.3:1). Now pinned explicitly to
  `$text-color` (~9.9:1).
- Multi-value chips paired near-white text with a near-white chip
  background; now `$dark-text` on the existing `$muted-gray` chip (~9.6:1).
- `StudioSelect`'s parent-studio label used `rgba(black, 0.5)` inside the
  value container, rendering near-invisible; dropped the override so it
  inherits the legible `$text-muted`.

All select surfaces (filters, forms, search) now meet WCAG AA text contrast.

#### 3. Deleted images invisible in edit diffs

Removed images were rendered as srcless `<img alt="Deleted">` tags, which
browsers draw as zero-width boxes — edit diffs showed blank gaps where
removed images should appear. Added a shared `DeletedImage` fragment
(muted tile, X icon, "Deleted" label, matching the existing
empty-thumbnail language) and used it in `ImageChangeRow` and
`AmendableImageChangeRow`.

#### 4. Global 1210px viewport lockout (`theme.scss`, `App.scss`)

`body { min-width: 1210px }` — carried over from the Bootstrap 5
migration — forced horizontal scrolling of the entire app on any narrower
viewport. Removed it: the navbar already wraps (`react-bootstrap`
defaults to `.navbar-expand`), grids auto-fill, and filter rows
flex-wrap. The login prompt's fixed `960px` width became `max-width` so
auth pages no longer overflow as the first screen seen at smaller sizes.
Wide tables can still overflow their own page; a full responsive pass is
out of scope here.