### PR TITLE
Require draft ownership on edit submission + consistent session cookie attributes

### DIFF
--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -23,6 +23,20 @@ func InitializeSession() {
 	sessionStore = sessions.NewCookieStore(config.GetSessionStoreKey())
 }
 
+// setSessionCookieOptions applies the session cookie attributes before the
+// session is saved, so that every Set-Cookie carries them consistently.
+func setSessionCookieOptions(session *sessions.Session, maxAge int) {
+	opts := session.Options
+	opts.MaxAge = maxAge
+	opts.HttpOnly = true
+	if config.GetIsProduction() {
+		opts.Secure = true
+	} else {
+		opts.Secure = false
+		opts.SameSite = http.SameSiteLaxMode
+	}
+}
+
 func handleLogin(fac service.Factory) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		newSession, err := sessionStore.Get(r, cookieName)
@@ -47,14 +61,7 @@ func handleLogin(fac service.Factory) func(http.ResponseWriter, *http.Request) {
 		}
 
 		newSession.Values[userIDKey] = userID
-		newSession.Options.MaxAge = maxCookieAge
-		newSession.Options.HttpOnly = true
-		if config.GetIsProduction() {
-			newSession.Options.Secure = true
-		} else {
-			newSession.Options.Secure = false
-			newSession.Options.SameSite = http.SameSiteLaxMode
-		}
+		setSessionCookieOptions(newSession, maxCookieAge)
 
 		err = newSession.Save(r, w)
 		if err != nil {
@@ -72,14 +79,7 @@ func handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	delete(session.Values, userIDKey)
-	session.Options.MaxAge = -1
-	session.Options.HttpOnly = true
-	if config.GetIsProduction() {
-		session.Options.Secure = true
-	} else {
-		session.Options.Secure = false
-		session.Options.SameSite = http.SameSiteLaxMode
-	}
+	setSessionCookieOptions(session, -1)
 
 	err = session.Save(r, w)
 	if err != nil {
@@ -94,7 +94,7 @@ func handleLogout(w http.ResponseWriter, r *http.Request) {
 func getSessionUserID(w http.ResponseWriter, r *http.Request) (string, error) {
 	session, err := sessionStore.Get(r, cookieName)
 	if err != nil {
-		session.Options.MaxAge = -1
+		setSessionCookieOptions(session, -1)
 		if err = session.Save(r, w); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -106,6 +106,7 @@ func getSessionUserID(w http.ResponseWriter, r *http.Request) (string, error) {
 		userID, _ := userIDInt.(string)
 
 		// refresh the cookie
+		setSessionCookieOptions(session, maxCookieAge)
 		err = session.Save(r, w)
 		if err != nil {
 			return "", err

--- a/internal/service/edit/service.go
+++ b/internal/service/edit/service.go
@@ -32,6 +32,24 @@ var ErrAmendPendingEdit = fmt.Errorf("cannot amend pending edit - only closed ed
 var ErrNoChangesToAmend = fmt.Errorf("must specify at least one field or item to remove")
 var ErrAmendEmptyResult = fmt.Errorf("cannot remove all fields - edit must retain some content")
 var ErrHidePrimaryComment = fmt.Errorf("cannot hide the edit's primary comment")
+var ErrUnauthorizedDraft = fmt.Errorf("you do not have permission to delete this draft")
+
+// destroySubmittedDraft deletes the draft an edit was submitted from, but
+// only if it belongs to userID. A missing draft is ignored so that stale
+// draft ids from clients remain non-fatal; a foreign-owned draft fails the
+// submission.
+func destroySubmittedDraft(ctx context.Context, tx *queries.Queries, draftID uuid.UUID, userID uuid.UUID) error {
+	draft, err := tx.FindDraft(ctx, draftID)
+	if err != nil {
+		return errutil.IgnoreNotFound(err)
+	}
+
+	if draft.UserID != userID {
+		return ErrUnauthorizedDraft
+	}
+
+	return tx.DeleteDraft(ctx, draftID)
+}
 
 // Edit handles edit-related operations
 type Edit struct {
@@ -726,7 +744,7 @@ func (s *Edit) CreateSceneEdit(ctx context.Context, input models.SceneEditInput)
 		}
 
 		if input.Details != nil && input.Details.DraftID != nil {
-			if err := tx.DeleteDraft(ctx, *input.Details.DraftID); err != nil {
+			if err := destroySubmittedDraft(ctx, tx, *input.Details.DraftID, currentUser.ID); err != nil {
 				return err
 			}
 		}
@@ -942,7 +960,7 @@ func (s *Edit) CreatePerformerEdit(ctx context.Context, input models.PerformerEd
 		}
 
 		if input.Details != nil && input.Details.DraftID != nil {
-			if err := tx.DeleteDraft(ctx, *input.Details.DraftID); err != nil {
+			if err := destroySubmittedDraft(ctx, tx, *input.Details.DraftID, currentUser.ID); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

Two targeted security fixes against `master`. Both were identified in a
security audit; other findings from the same audit (dependency CVEs,
`DestroyDraft` ownership, login/logout cookie flags) are already resolved
on `master`, so this PR contains only the remaining gaps.

## Changes

### 1. Draft deletion on edit submission required no ownership (`internal/service/edit/service.go`)

`SceneEdit` and `PerformerEdit` deleted the draft referenced by
`input.Details.DraftID` via `tx.DeleteDraft(...)` without verifying that
the submitting user owns it. Any user with EDIT rights could destroy
another user's draft by id.

- New `destroySubmittedDraft` helper fetches the draft inside the edit
  transaction and only deletes it when `draft.UserID` matches the caller;
  otherwise it fails with the new sentinel `ErrUnauthorizedDraft`.
- Missing drafts remain non-fatal (`errutil.IgnoreNotFound`) so clients
  submitting edits with stale/already-deleted draft ids keep working —
  matching prior behavior.
- Explicit `DestroyDraft` (already owner-checked in the draft service) is
  unchanged.

### 2. Cookie refresh path dropped secure attributes (`internal/api/session.go`)

Login and logout set `HttpOnly` / `Secure` / `SameSite` inline, but two
save sites bypassed them:

- the per-request cookie **refresh** in `getSessionUserID`
- the invalid-cookie clear in its error branch

Both re-saved with gorilla store defaults, so cookies issued or refreshed
through those paths went out without any of the flags.

- Extracted `setSessionCookieOptions(session, maxAge)` using the same
  production/dev logic as the existing inline blocks, and applied it to
  all four save sites. No behavior change beyond the two fixed paths.
