### PR TITLE
fix(login): replace navigate-during-render with <Navigate>

### DIFF
--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { type FC, useState } from "react";
 import { Button, Col, Form, Row } from "react-bootstrap";
 import { useForm } from "react-hook-form";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, Navigate, useLocation } from "react-router-dom";
 import { ROUTE_FORGOT_PASSWORD, ROUTE_REGISTER } from "src/constants/route";
 import { getCredentialsSetting, getPlatformURL } from "src/utils/createClient";
 import * as yup from "yup";
@@ -25,7 +25,6 @@ const Messages: Record<string, string> = {
 const Login: FC = () => {
   const [loading, setLoading] = useState(false);
   const location = useLocation();
-  const navigate = useNavigate();
   const [loginError, setLoginError] = useState("");
   const msg = new URLSearchParams(location.search).get("msg");
   const redirect = new URLSearchParams(location.search).get("redirect");
@@ -38,7 +37,7 @@ const Login: FC = () => {
     resolver: yupResolver(schema),
   });
 
-  if (isAuthenticated) navigate("/");
+  if (isAuthenticated) return <Navigate to="/" replace />;
 
   const onSubmit = async (formData: LoginFormData) => {
     setLoading(true);


### PR DESCRIPTION
Split from #1218

Calling navigate() in the component body triggers React updates during render and can loop while auth state resolves. Return a declarative <Navigate to=/ replace /> after all hooks instead.
