### PR TITLE
fix(ui): repair react-select contrast failures

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -37,6 +37,11 @@
   color: $text-color;
   cursor: pointer;
 
+  .react-select__single-value,
+  .react-select__input {
+    color: $text-color;
+  }
+
   .react-select__multi-value {
     background-color: $muted-gray;
     color: $dark-text;

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -37,14 +37,9 @@
   color: $text-color;
   cursor: pointer;
 
-  .react-select__single-value,
-  .react-select__input {
-    color: black;
-  }
-
   .react-select__multi-value {
     background-color: $muted-gray;
-    color: $text-color;
+    color: $dark-text;
   }
 }
 

--- a/frontend/src/components/studioSelect/styles.scss
+++ b/frontend/src/components/studioSelect/styles.scss
@@ -2,10 +2,4 @@
   .parent-studio {
     color: $text-muted;
   }
-
-  .react-select__value-container {
-    .parent-studio {
-      color: rgba($black, 0.5);
-    }
-  }
 }


### PR DESCRIPTION
Split from #1218 

Selected values and input text in `.react-select__single-value` and `.react-select__input` were forced to `color: black` on the dark `$secondary` control (~2.3:1). They now use the control's `$text-color` token (~9.9:1).

Multi-value chips paired near-white text (`$text-color`) with a near-white background (`$muted-gray`); switched to `$dark-text` on the same chip for ~9.6:1.

`StudioSelect`'s `.parent-studio` label inside the value container used `rgba(black, 0.5)`, rendering near-invisible on the dark control. The override is dropped so the label inherits the outer `$text-muted`.

All select surfaces (filters, forms, search) now meet WCAG AA text contrast.

A follow-up commit pins the `.react-select__single-value` / `.react-select__input` color rule explicitly inside `.react-select__control` so it no longer depends on react-select emotion defaults surviving an upgrade.
