### PR TITLE
fix(ui): render placeholder for deleted images in edit diffs

### DIFF
--- a/frontend/src/components/amendableEditCard/AmendableImageChangeRow.tsx
+++ b/frontend/src/components/amendableEditCard/AmendableImageChangeRow.tsx
@@ -2,7 +2,7 @@ import { faUndo, faXmark } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import type { FC } from "react";
 import { Button, Col, Row } from "react-bootstrap";
-import { Icon } from "src/components/fragments";
+import { DeletedImage, Icon } from "src/components/fragments";
 import ImageComponent from "src/components/image";
 import { useAmendment } from "./AmendmentContext";
 
@@ -65,7 +65,7 @@ const AmendableImageChangeRow: FC<AmendableImageChangeRowProps> = ({
                       })}
                     >
                       {image === null ? (
-                        <img className={CLASSNAME_IMAGE} alt="Deleted" />
+                        <DeletedImage />
                       ) : (
                         <div className={CLASSNAME_IMAGE}>
                           <ImageComponent
@@ -124,7 +124,7 @@ const AmendableImageChangeRow: FC<AmendableImageChangeRowProps> = ({
                     })}
                   >
                     {image === null ? (
-                      <img className={CLASSNAME_IMAGE} alt="Deleted" />
+                      <DeletedImage />
                     ) : (
                       <div className={CLASSNAME_IMAGE}>
                         <ImageComponent

--- a/frontend/src/components/editCard/__tests__/renderStudioDetails.test.tsx
+++ b/frontend/src/components/editCard/__tests__/renderStudioDetails.test.tsx
@@ -125,8 +125,9 @@ describe("renderStudioDetails", () => {
         {},
         true,
       );
-      const deleted = container.querySelector("img[alt='Deleted']");
+      const deleted = container.querySelector(".DeletedImage");
       expect(deleted).toBeInTheDocument();
+      expect(within(deleted as HTMLElement).getByText("Deleted"));
     });
   });
 

--- a/frontend/src/components/fragments/DeletedImage.tsx
+++ b/frontend/src/components/fragments/DeletedImage.tsx
@@ -1,0 +1,14 @@
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { FC } from "react";
+import Icon from "./Icon";
+
+const CLASSNAME = "DeletedImage";
+
+const DeletedImage: FC = () => (
+  <div className={CLASSNAME}>
+    <Icon icon={faXmark} />
+    <span>Deleted</span>
+  </div>
+);
+
+export default DeletedImage;

--- a/frontend/src/components/fragments/index.ts
+++ b/frontend/src/components/fragments/index.ts
@@ -1,3 +1,4 @@
+export { default as DeletedImage } from "./DeletedImage";
 export { default as ErrorMessage } from "./ErrorMessage";
 export { FavoriteStar } from "./Favorite";
 export { default as GenderIcon } from "./GenderIcon";

--- a/frontend/src/components/fragments/styles.scss
+++ b/frontend/src/components/fragments/styles.scss
@@ -145,3 +145,24 @@
     }
   }
 }
+
+.DeletedImage {
+  align-items: center;
+  background-color: $secondary;
+  border-radius: 4px;
+  color: var(--bs-gray-400);
+  display: flex;
+  flex-direction: column;
+  height: 150px;
+  justify-content: center;
+  margin: 5px;
+  padding: 0 1.25rem;
+
+  .fa-icon {
+    font-size: 1.75rem;
+  }
+
+  span {
+    font-size: 0.85rem;
+  }
+}

--- a/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
+++ b/frontend/src/components/imageChangeRow/ImageChangeRow.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Col, Row } from "react-bootstrap";
+import { DeletedImage } from "src/components/fragments";
 import ImageComponent from "src/components/image";
 
 type Image = {
@@ -28,7 +29,7 @@ const Images: FC<{
       {(images ?? []).map((image, i) =>
         image === null ? (
           // biome-ignore lint/suspicious/noArrayIndexKey: Image is deleted, no other key
-          <img className={CLASSNAME_IMAGE} alt="Deleted" key={`deleted-${i}`} />
+          <DeletedImage key={`deleted-${i}`} />
         ) : (
           <div key={image.id} className={CLASSNAME_IMAGE}>
             <ImageComponent


### PR DESCRIPTION
Split from #1218 

Removed images in edit diffs were rendered as srcless `<img alt="Deleted" />` tags. Without a `src` (or intrinsic dimensions) browsers draw these as zero-width boxes, leaving blank gaps where deleted thumbnails should appear in the change view.

Introduces a shared `DeletedImage` fragment — a muted tile (matching the existing empty-thumbnail style) with an X icon and a "Deleted" label — and uses it in `ImageChangeRow` and both sites in `AmendableImageChangeRow`.

A follow-up commit updates the `renderStudioDetails` test to query the new `.DeletedImage` element and asserts its label.
