### PR TITLE
fix(ui): remove global 1210px body min-width

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -65,7 +65,7 @@ div.react-select__menu {
 
 .LoginPrompt {
   height: 70vh;
-  width: 960px;
+  max-width: 960px;
   margin-left: auto;
   margin-right: auto;
   display: flex;

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -88,7 +88,6 @@ body {
   color: $text-color;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  min-width: 1210px;
 }
 
 .table {


### PR DESCRIPTION
Split from #1218

The hard min-width on body, carried over from the Bootstrap 5 migration, locked every viewport narrower than 1210px into permanent horizontal scrolling of the entire app.

The navbar already wraps (react-bootstrap defaults to .navbar-expand), grids are auto-fill, and filter rows flex-wrap, so content degrades rather than breaking. The login prompt's fixed 960px width becomes a max-width so the auth pages - the first screen on small viewports - no longer overflow.

Wider tables can still overflow their page; full responsive pass is tracked separately.
