### PR TITLE
Use dataloader for Edit.User resolver to eliminate N+1 queries

### DIFF
--- a/internal/api/resolver_model_edit.go
+++ b/internal/api/resolver_model_edit.go
@@ -22,7 +22,7 @@ func (r *editResolver) User(ctx context.Context, obj *models.Edit) (*models.User
 		return nil, nil
 	}
 
-	return r.services.User().FindByID(ctx, obj.UserID.UUID)
+	return dataloader.For(ctx).UserByID.Load(obj.UserID.UUID)
 }
 
 func (r *editResolver) Created(ctx context.Context, obj *models.Edit) (*time.Time, error) {


### PR DESCRIPTION
## Description
The `editResolver.User()` field resolver was bypassing the dataloader and making a direct `FindByID` database call for each Edit object. On a page of 25 edits, this fired 25 individual SQL queries to load users — one per edit.

This is inconsistent with other resolvers in the same file which already uses the dataloader correctly.

## Impact

Eliminates N queries on every edit list view (global edits, scene edits, performer edits). On a page of 25 edits, this reduces 25 round-trips to 1 batched call.