### PR TITLE
Use dataloader for EditComment.Edit resolver to eliminate N+1 queries

### DIFF
--- a/internal/api/resolver_model_edit_comment.go
+++ b/internal/api/resolver_model_edit_comment.go
@@ -39,5 +39,5 @@ func (r *editCommentResolver) User(ctx context.Context, obj *models.EditComment)
 }
 
 func (r *editCommentResolver) Edit(ctx context.Context, obj *models.EditComment) (*models.Edit, error) {
-	return r.services.Edit().FindByID(ctx, obj.EditID)
+	return dataloader.For(ctx).EditByID.Load(obj.EditID)
 }


### PR DESCRIPTION
This is the same logic from previous PR. Just a follow-up for `EditComment.Edit`.