### PR TITLE
Wrap debounce in useMemo to prevent recreation on every render

### DIFF
--- a/frontend/src/components/list/TagList.tsx
+++ b/frontend/src/components/list/TagList.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import type { FC } from "react";
+import { type FC, useMemo } from "react";
 import { Card, Form, Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { ErrorMessage } from "src/components/fragments";
@@ -49,7 +49,7 @@ const TagList: FC<TagListProps> = ({ tagFilter, showCategoryLink = false }) => {
     </li>
   ));
 
-  const debouncedHandler = debounce(setParams, 200);
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
 
   const filters = (
     <Form.Control

--- a/frontend/src/components/list/TagList.tsx
+++ b/frontend/src/components/list/TagList.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import { Card, Form, Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { ErrorMessage } from "src/components/fragments";
@@ -50,6 +50,7 @@ const TagList: FC<TagListProps> = ({ tagFilter, showCategoryLink = false }) => {
   ));
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   const filters = (
     <Form.Control

--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import type { FC } from "react";
+import { type FC, useMemo } from "react";
 import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import Select from "react-select";
@@ -64,6 +64,8 @@ const PerformersComponent: FC = () => {
     },
   });
 
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+
   if (!loading && !data)
     return <ErrorMessage error="Failed to load performers" />;
 
@@ -74,8 +76,6 @@ const PerformersComponent: FC = () => {
       </Col>
     ),
   );
-
-  const debouncedHandler = debounce(setParams, 200);
 
   const filters = (
     <>

--- a/frontend/src/pages/performers/Performers.tsx
+++ b/frontend/src/pages/performers/Performers.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import Select from "react-select";
@@ -65,6 +65,7 @@ const PerformersComponent: FC = () => {
   });
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   if (!loading && !data)
     return <ErrorMessage error="Failed to load performers" />;

--- a/frontend/src/pages/performers/components/scenePairings.tsx
+++ b/frontend/src/pages/performers/components/scenePairings.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, Fragment } from "react";
+import { type FC, Fragment, useMemo } from "react";
 import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import Select from "react-select";
 import { Icon } from "src/components/fragments";
@@ -76,7 +76,7 @@ export const ScenePairings: FC<Props> = ({ id }) => {
 
   const performers = data?.queryPerformers.performers;
 
-  const debouncedHandler = debounce(setParams, 200);
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
 
   const filters = (
     <>

--- a/frontend/src/pages/performers/components/scenePairings.tsx
+++ b/frontend/src/pages/performers/components/scenePairings.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, Fragment, useMemo } from "react";
+import { type FC, Fragment, useEffect, useMemo } from "react";
 import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import Select from "react-select";
 import { Icon } from "src/components/fragments";
@@ -77,6 +77,7 @@ export const ScenePairings: FC<Props> = ({ id }) => {
   const performers = data?.queryPerformers.performers;
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   const filters = (
     <>

--- a/frontend/src/pages/studios/Studios.tsx
+++ b/frontend/src/pages/studios/Studios.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import type { FC } from "react";
+import { type FC, useMemo } from "react";
 import { Button, Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { FavoriteStar } from "src/components/fragments";
@@ -46,7 +46,7 @@ const StudiosComponent: FC = () => {
     </li>
   ));
 
-  const debouncedHandler = debounce(setParams, 200);
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
 
   const filters = (
     <>

--- a/frontend/src/pages/studios/Studios.tsx
+++ b/frontend/src/pages/studios/Studios.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import { Button, Card, Form } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { FavoriteStar } from "src/components/fragments";
@@ -47,6 +47,7 @@ const StudiosComponent: FC = () => {
   ));
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   const filters = (
     <>

--- a/frontend/src/pages/studios/components/studioPerformers.tsx
+++ b/frontend/src/pages/studios/components/studioPerformers.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, Fragment, useMemo } from "react";
+import { type FC, Fragment, useEffect, useMemo } from "react";
 import { Button, Form, InputGroup } from "react-bootstrap";
 import Select from "react-select";
 import { Icon } from "src/components/fragments";
@@ -71,6 +71,7 @@ export const StudioPerformers: FC<Props> = ({ id }) => {
   const performers = data?.queryPerformers.performers;
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   const filters = (
     <>

--- a/frontend/src/pages/studios/components/studioPerformers.tsx
+++ b/frontend/src/pages/studios/components/studioPerformers.tsx
@@ -3,7 +3,7 @@ import {
   faSortAmountUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, Fragment } from "react";
+import { type FC, Fragment, useMemo } from "react";
 import { Button, Form, InputGroup } from "react-bootstrap";
 import Select from "react-select";
 import { Icon } from "src/components/fragments";
@@ -70,7 +70,7 @@ export const StudioPerformers: FC<Props> = ({ id }) => {
 
   const performers = data?.queryPerformers.performers;
 
-  const debouncedHandler = debounce(setParams, 200);
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
 
   const filters = (
     <>

--- a/frontend/src/pages/users/Users.tsx
+++ b/frontend/src/pages/users/Users.tsx
@@ -1,6 +1,6 @@
 import { faUserEdit } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import type { FC } from "react";
+import { type FC, useMemo } from "react";
 import { Button, Form, Table } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { ErrorMessage, Icon } from "src/components/fragments";
@@ -29,6 +29,8 @@ const UsersComponent: FC = () => {
     },
   });
 
+  const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+
   if (!loading && !data) return <ErrorMessage error="Failed to load users." />;
 
   const users = data?.queryUsers.users.map((user) => (
@@ -51,8 +53,6 @@ const UsersComponent: FC = () => {
       <td>{user?.invite_tokens ?? ""}</td>
     </tr>
   ));
-
-  const debouncedHandler = debounce(setParams, 200);
 
   const filters = (
     <Form.Control

--- a/frontend/src/pages/users/Users.tsx
+++ b/frontend/src/pages/users/Users.tsx
@@ -1,6 +1,6 @@
 import { faUserEdit } from "@fortawesome/free-solid-svg-icons";
 import { debounce } from "lodash-es";
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import { Button, Form, Table } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { ErrorMessage, Icon } from "src/components/fragments";
@@ -30,6 +30,7 @@ const UsersComponent: FC = () => {
   });
 
   const debouncedHandler = useMemo(() => debounce(setParams, 200), [setParams]);
+  useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
 
   if (!loading && !data) return <ErrorMessage error="Failed to load users." />;
 


### PR DESCRIPTION
## Description
debounce(setParams, 200) was called directly in the render body of 6 components, creating a brand new debouncer on every render. This resets the debounce timer and defeats the debounce mechanism entirely.

Wrap each in useMemo with [setParams] dependency. In Performers.tsx and Users.tsx, move the hook before the early return to satisfy Rules of Hooks.

## Cleanup on unmount

Added a `useEffect` cleanup to cancel the pending debounced call when the
component unmounts, preventing a potential state update on an unmounted
component:

```tsx
useEffect(() => () => debouncedHandler.cancel(), [debouncedHandler]);
```

Applied to all six components touched by the `useMemo` fix above:
`TagList`, `Performers`, `ScenePairings`, `Studios`, `StudioPerformers`,
and `Users`.