### PR TITLE
Skip unread count for anonymous users

### DIFF
--- a/frontend/src/Main.tsx
+++ b/frontend/src/Main.tsx
@@ -38,7 +38,7 @@ const Main: FC<Props> = ({ children }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { loading, user } = useAuth();
-  const { data: unreadNotifications } = useUnreadNotificationsCount();
+  const { data: unreadNotifications } = useUnreadNotificationsCount(!user);
   const unreadCounts = unreadNotifications?.getUnreadNotificationCount;
   const notificationCount = unreadCounts?.total || null;
   const hasUrgent = (unreadCounts?.urgent ?? 0) > 0;

--- a/frontend/src/graphql/queries/index.ts
+++ b/frontend/src/graphql/queries/index.ts
@@ -376,8 +376,8 @@ export const useNotifications = (variables: NotificationsQueryVariables) =>
     variables,
   });
 
-export const useUnreadNotificationsCount = () =>
-  useQuery(UnreadNotificationCountDocument);
+export const useUnreadNotificationsCount = (skip = false) =>
+  useQuery(UnreadNotificationCountDocument, { skip });
 
 export const useModAudits = (variables: ModAuditsQueryVariables) =>
   useQuery(ModAuditsDocument, {


### PR DESCRIPTION
When Main renders for a logged-out user, it was requesting unread notification counts even though the user cannot access notifications.

  This change:

  - Adds a skip option to useUnreadNotificationsCount.
  - Skips the query when no authenticated user exists.
  - Keeps the existing notification count behavior for authenticated users.