### PR TITLE
Lazy-load thumbnail images

### DIFF
--- a/frontend/src/components/fragments/Thumbnail.tsx
+++ b/frontend/src/components/fragments/Thumbnail.tsx
@@ -27,6 +27,7 @@ export const Thumbnail: FC<Props> = ({
     <img
       alt={alt ?? ""}
       className={className}
+      loading="lazy"
       src={image + (size ? `?size=${size}` : "")}
       srcSet={
         size ? `${image}?size=${doubleSize[size]} ${doubleSize[size]}w` : ""


### PR DESCRIPTION
 This reduces initial image requests on performer, scene, and search grids by deferring images until they approach the viewport.
 
 It is somehow trivial, I would be OK if this gets closed too.