### PR TITLE
fix: high-risk n+1 query fields

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/api/resolver_model_edit.go
+++ b/internal/api/resolver_model_edit.go
@@ -189,7 +189,7 @@ func (r *editResolver) OldDetails(ctx context.Context, obj *models.Edit) (models
 }
 
 func (r *editResolver) Comments(ctx context.Context, obj *models.Edit) ([]models.EditComment, error) {
-	return r.services.Edit().GetComments(ctx, obj.ID)
+	return dataloader.For(ctx).EditCommentsByEditID.Load(obj.ID)
 }
 
 func (r *editResolver) Votes(ctx context.Context, obj *models.Edit) ([]models.EditVote, error) {

--- a/internal/api/resolver_model_performer.go
+++ b/internal/api/resolver_model_performer.go
@@ -97,7 +97,7 @@ func (r *performerResolver) Images(ctx context.Context, obj *models.Performer) (
 }
 
 func (r *performerResolver) Edits(ctx context.Context, obj *models.Performer) ([]models.Edit, error) {
-	return r.services.Edit().FindByPerformerID(ctx, obj.ID)
+	return dataloader.For(ctx).EditsByPerformerID.Load(obj.ID)
 }
 
 func (r *performerResolver) SceneCount(ctx context.Context, obj *models.Performer) (int, error) {

--- a/internal/api/resolver_model_studio.go
+++ b/internal/api/resolver_model_studio.go
@@ -30,7 +30,7 @@ func (r *studioResolver) Parent(ctx context.Context, obj *models.Studio) (*model
 }
 
 func (r *studioResolver) ChildStudios(ctx context.Context, obj *models.Studio) ([]models.Studio, error) {
-	return r.services.Studio().FindByParentID(ctx, obj.ID)
+	return dataloader.For(ctx).StudiosByParentID.Load(obj.ID)
 }
 
 func (r *studioResolver) SubStudios(ctx context.Context, obj *models.Studio, input *models.StudioQueryInput) (*models.QueryStudiosResultType, error) {

--- a/internal/api/resolver_model_tag.go
+++ b/internal/api/resolver_model_tag.go
@@ -29,7 +29,7 @@ func (r *tagResolver) Aliases(ctx context.Context, obj *models.Tag) ([]string, e
 }
 
 func (r *tagResolver) Edits(ctx context.Context, obj *models.Tag) ([]models.Edit, error) {
-	return r.services.Edit().FindByTagID(ctx, obj.ID)
+	return dataloader.For(ctx).EditsByTagID.Load(obj.ID)
 }
 
 func (r *tagResolver) Category(ctx context.Context, obj *models.Tag) (*models.TagCategory, error) {

--- a/internal/dataloader/editcommentsloader.go
+++ b/internal/dataloader/editcommentsloader.go
@@ -1,0 +1,33 @@
+package dataloader
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stashapp/stash-box/internal/models"
+)
+
+// EditCommentsLoader loads [][]models.EditComment by edit id
+type EditCommentsLoader struct {
+	fetch    func(keys []uuid.UUID) ([][]models.EditComment, []error)
+	wait     time.Duration
+	maxBatch int
+}
+
+func (l *EditCommentsLoader) Load(key uuid.UUID) ([]models.EditComment, error) {
+	res, errs := l.LoadAll([]uuid.UUID{key})
+	if len(errs) > 0 && errs[0] != nil {
+		return nil, errs[0]
+	}
+	if len(res) > 0 && len(res[0]) > 0 {
+		return res[0], nil
+	}
+	return nil, nil
+}
+
+func (l *EditCommentsLoader) LoadAll(keys []uuid.UUID) ([][]models.EditComment, []error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	return l.fetch(keys)
+}

--- a/internal/dataloader/loaders.go
+++ b/internal/dataloader/loaders.go
@@ -43,13 +43,17 @@ type Loaders struct {
 	SiteByID                       SiteLoader
 	SiteCategoryByID               SiteCategoryLoader
 	StudioByID                     StudioLoader
+	StudiosByParentID              StudiosLoader
 	TagByID                        TagLoader
 	TagAliasesByID                 StringsLoader
 	TagCategoryByID                TagCategoryLoader
 	EditByID                       EditLoader
 	EditVotesByID                  EditVotesLoader
 	SceneEditsByID                 EditsLoader
+	EditsByPerformerID             EditsLoader
+	EditsByTagID                   EditsLoader
 	EditCommentByID                EditCommentLoader
+	EditCommentsByEditID           EditCommentsLoader
 	UserByID                       UserLoader
 	UserRolesByID                  StringsLoader
 }
@@ -172,6 +176,45 @@ func GetLoaders(ctx context.Context, fac service.Factory) *Loaders {
 				return s.LoadEditsBySceneIds(ctx, ids)
 			},
 		},
+		EditsByPerformerID: EditsLoader{
+			maxBatch: 100,
+			wait:     1 * time.Millisecond,
+			fetch: func(ids []uuid.UUID) ([][]models.Edit, []error) {
+				s := fac.Edit()
+				res := make([][]models.Edit, len(ids))
+				errs := make([]error, len(ids))
+				for i, id := range ids {
+					res[i], errs[i] = s.FindByPerformerID(ctx, id)
+				}
+				return res, errs
+			},
+		},
+		EditsByTagID: EditsLoader{
+			maxBatch: 100,
+			wait:     1 * time.Millisecond,
+			fetch: func(ids []uuid.UUID) ([][]models.Edit, []error) {
+				s := fac.Edit()
+				res := make([][]models.Edit, len(ids))
+				errs := make([]error, len(ids))
+				for i, id := range ids {
+					res[i], errs[i] = s.FindByTagID(ctx, id)
+				}
+				return res, errs
+			},
+		},
+		EditCommentsByEditID: EditCommentsLoader{
+			maxBatch: 100,
+			wait:     1 * time.Millisecond,
+			fetch: func(ids []uuid.UUID) ([][]models.EditComment, []error) {
+				s := fac.Edit()
+				res := make([][]models.EditComment, len(ids))
+				errs := make([]error, len(ids))
+				for i, id := range ids {
+					res[i], errs[i] = s.GetComments(ctx, id)
+				}
+				return res, errs
+			},
+		},
 		SceneUrlsByID: URLLoader{
 			maxBatch: 100,
 			wait:     1 * time.Millisecond,
@@ -242,6 +285,19 @@ func GetLoaders(ctx context.Context, fac service.Factory) *Loaders {
 			fetch: func(ids []uuid.UUID) ([]*models.Studio, []error) {
 				s := fac.Studio()
 				return s.LoadIds(ctx, ids)
+			},
+		},
+		StudiosByParentID: StudiosLoader{
+			maxBatch: 100,
+			wait:     1 * time.Millisecond,
+			fetch: func(ids []uuid.UUID) ([][]models.Studio, []error) {
+				s := fac.Studio()
+				res := make([][]models.Studio, len(ids))
+				errs := make([]error, len(ids))
+				for i, id := range ids {
+					res[i], errs[i] = s.FindByParentID(ctx, id)
+				}
+				return res, errs
 			},
 		},
 		TagByID: TagLoader{

--- a/internal/dataloader/studiosloader.go
+++ b/internal/dataloader/studiosloader.go
@@ -1,0 +1,32 @@
+package dataloader
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stashapp/stash-box/internal/models"
+)
+
+type StudiosLoader struct {
+	fetch    func(keys []uuid.UUID) ([][]models.Studio, []error)
+	wait     time.Duration
+	maxBatch int
+}
+
+func (l *StudiosLoader) Load(key uuid.UUID) ([]models.Studio, error) {
+	res, errs := l.LoadAll([]uuid.UUID{key})
+	if len(errs) > 0 && errs[0] != nil {
+		return nil, errs[0]
+	}
+	if len(res) > 0 {
+		return res[0], nil
+	}
+	return nil, nil
+}
+
+func (l *StudiosLoader) LoadAll(keys []uuid.UUID) ([][]models.Studio, []error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	return l.fetch(keys)
+}


### PR DESCRIPTION
Fixed high-risk fields:
- edit.Comments → EditCommentsByEditID loader
- performer.Edits → EditsByPerformerID
- tag.Edits → EditsByTagID
- studio.ChildStudios → StudiosByParentID