### PR TITLE
CI: Use setup-go native cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.27.x
+        cache: true
 
     - name: Install Node
       uses: actions/setup-node@v4
@@ -65,16 +66,6 @@ jobs:
       with:
         path: frontend/build
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('frontend/pnpm-lock.yaml', 'frontend/vite.config.js', 'frontend/src/**', 'graphql/**/*.graphql') }}
-
-    - name: Cache go build
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-go-cache-2
-      with:
-        path: |
-          ~/go/pkg/mod
-          .go-cache
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', '**/go.sum') }}
 
     - name: Pre-install
       run: make pre-ui

--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 


### PR DESCRIPTION
Replaces manual `actions/cache@v4` for Go modules with `actions/setup-go@v5` native cache (`cache: true`). Removes the separate `Cache go build` step from `.github/workflows/build.yml`.

## Why better
- **Fewer steps**: one config line instead of a 7-line manual cache block.
- **More reliable**: `setup-go` handles `go.sum` / module hash keys automatically; manual keys can miss when `go.sum` shifts.
- **Faster restore**: native cache uses optimized path caching rather than generic `actions/cache` upload/download.
- **Less maintenance**: no need to keep `~/go/pkg/mod` paths in sync across runners.


internal/api/graphql_client_test.go changes needed by `go fix`
