### PR TITLE
Pre-alloc draft slices

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/service/draft/service.go
+++ b/internal/service/draft/service.go
@@ -29,7 +29,7 @@ func NewDraft(queries *queries.Queries, withTxn queries.WithTxnFunc) *Draft {
 // FindPerformers takes a slice of DraftEntity performers and returns SceneDraftPerformer models
 // by using FindPerformersWithRedirects to resolve existing performers or keep as DraftEntity
 func (s *Draft) FindPerformers(ctx context.Context, draftPerformers []models.DraftEntity) ([]models.SceneDraftPerformer, error) {
-	var result []models.SceneDraftPerformer
+	var result = make([]models.SceneDraftPerformer, 0, len(draftPerformers))
 	for _, p := range draftPerformers {
 		if p.ID != nil {
 			dbPerformers, err := s.queries.FindPerformerWithRedirect(ctx, *p.ID)
@@ -51,7 +51,7 @@ func (s *Draft) FindPerformers(ctx context.Context, draftPerformers []models.Dra
 // FindTags takes a slice of DraftEntity tags and returns SceneDraftTag models
 // by using FindTagsWithRedirects to resolve existing tags or keep as DraftEntity
 func (s *Draft) FindTags(ctx context.Context, draftTags []models.DraftEntity) ([]models.SceneDraftTag, error) {
-	var result []models.SceneDraftTag
+	var result = make([]models.SceneDraftTag, 0, len(draftTags))
 	for _, t := range draftTags {
 		if t.ID != nil {
 			dbTags, err := s.queries.FindTagWithRedirect(ctx, *t.ID)
@@ -248,7 +248,7 @@ func (s *Draft) resolveTags(ctx context.Context, tags []models.DraftEntityInput)
 
 func (s *Draft) FindByUser(ctx context.Context, userID uuid.UUID) ([]models.Draft, error) {
 	dbDrafts, err := s.queries.FindDraftsByUser(ctx, userID)
-	var drafts []models.Draft
+	drafts := make([]models.Draft, 0, len(dbDrafts))
 	for _, draft := range dbDrafts {
 		drafts = append(drafts, converter.DraftToModel(draft))
 	}


### PR DESCRIPTION
## Summary
- Picked gain #1: `internal/service/draft/service.go` — bare `append` loops in `FindPerformers`, `FindTags`, `FindByUser`.
- Pre-allocated slices with `make([]T, 0, len(input))`.

## Why needed

- Loops build results with unknown capacity; Go grows exponentially. Input sizes are known (draft entities / DB counts), so `make` removes allocations and GC overhead.

## Impact

- 3 slices pre-allocated in draft query paths.
- Expected: fewer allocs / lower GC pressure per draft lookup