### PR TITLE
Pre-size edit merge slices

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/service/edit/edit.go
+++ b/internal/service/edit/edit.go
@@ -78,6 +78,8 @@ type editApplyer interface {
 }
 
 func urlCompare(subject []models.URL, against []models.URL) (added []models.URL, missing []models.URL) {
+	added = make([]models.URL, 0, len(subject))
+	missing = make([]models.URL, 0, len(against))
 	for _, s := range subject {
 		newMod := true
 		for _, a := range against {


### PR DESCRIPTION
## Summary
- `internal/service/edit/edit.go`: `urlCompare` built `added`/`missing` bare.
- Added `make([]models.URL, 0, len(subject))` and `make(..., 0, len(against))`.

## Why needed

- Merge loops append to slices of unknown cap; inputs bound results. Pre-alloc removes growth overhead.

## Impact
- 2 slices pre-sized; fewer allocs per URL compare

## For Future
We can use maps for in favor of algo.