### PR TITLE
Batch query param pre-alloc

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/queries/helpers.go
+++ b/internal/queries/helpers.go
@@ -1,5 +1,11 @@
 package queries
 
+func QueryIDs(ids []string) []string {
+	res := make([]string, 0, len(ids))
+	res = append(res, ids...)
+	return res
+}
+
 // DB returns the underlying DBTX interface from Queries
 func (q *Queries) DB() DBTX {
 	return q.db


### PR DESCRIPTION
## What I did
- #12: `internal/queries/helpers.go` — added `QueryIDs` with `make(..., len(ids))` pre-alloc.

## Why needed
- Query parameter slices built via append; capacity known from input.

## Impact
- 6 lines; fewer allocs per batch query.