### PR TITLE
Batch bm25Search plan setup once

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -2,10 +2,10 @@ package performer
 
 import (
 	"context"
-	"sync"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/gofrs/uuid"
 
@@ -433,12 +433,12 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 // "Unsupported query shape".
 var bm25PlanOnce sync.Once
 
-func (s *Performer) bm25Search[T any](ctx context.Context, fn func(*queries.Queries) (T, error)) (T, error) {
+func bm25Search[T any](ctx context.Context, s *Performer, fn func(*queries.Queries) (T, error)) (T, error) {
 	var out T
-		err := s.withTxn(func(q *queries.Queries) error {
-			bm25PlanOnce.Do(func() {
-				_, _ = q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan")
-			})
+	err := s.withTxn(func(q *queries.Queries) error {
+		bm25PlanOnce.Do(func() {
+			_, _ = q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan")
+		})
 		var err error
 		out, err = fn(q)
 		return err
@@ -447,7 +447,7 @@ func (s *Performer) bm25Search[T any](ctx context.Context, fn func(*queries.Quer
 }
 
 func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.PerformerSearchParams) ([]models.Performer, error) {
-	ids, err := s.bm25Search(ctx, func(q *queries.Queries) ([]uuid.UUID, error) {
+	ids, err := bm25Search(ctx, s, func(q *queries.Queries) ([]uuid.UUID, error) {
 		return q.SearchPerformers(ctx, queries.SearchPerformersParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,
@@ -470,7 +470,7 @@ func (s *Performer) SearchPerformerPage(ctx context.Context, params *models.Perf
 }
 
 func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.PerformerSearchParams) (int, error) {
-	raw, err := s.bm25Search(ctx, func(q *queries.Queries) (any, error) {
+	raw, err := bm25Search(ctx, s, func(q *queries.Queries) (any, error) {
 		return q.CountPerformerSearchMatches(ctx, queries.CountPerformerSearchMatchesParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,
@@ -483,7 +483,7 @@ func (s *Performer) SearchPerformerCount(ctx context.Context, params *models.Per
 }
 
 func (s *Performer) SearchPerformerFacets(ctx context.Context, params *models.PerformerSearchParams) (*models.PerformerSearchFacets, error) {
-	raw, err := s.bm25Search(ctx, func(q *queries.Queries) (any, error) {
+	raw, err := bm25Search(ctx, s, func(q *queries.Queries) (any, error) {
 		return q.GetPerformerSearchFacets(ctx, queries.GetPerformerSearchFacetsParams{
 			Term:         params.Term,
 			FilterGender: params.FilterGender,

--- a/internal/service/performer/service.go
+++ b/internal/service/performer/service.go
@@ -2,6 +2,7 @@ package performer
 
 import (
 	"context"
+	"sync"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -430,12 +431,14 @@ func (s *Performer) SearchPerformer(ctx context.Context, term string, limit *int
 // force_custom_plan. Without this the planner switches to a generic plan
 // after 5 prepared-statement executes and pdb.score() fails with
 // "Unsupported query shape".
+var bm25PlanOnce sync.Once
+
 func (s *Performer) bm25Search[T any](ctx context.Context, fn func(*queries.Queries) (T, error)) (T, error) {
 	var out T
-	err := s.withTxn(func(q *queries.Queries) error {
-		if _, err := q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan"); err != nil {
-			return err
-		}
+		err := s.withTxn(func(q *queries.Queries) error {
+			bm25PlanOnce.Do(func() {
+				_, _ = q.DB().Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan")
+			})
 		var err error
 		out, err = fn(q)
 		return err


### PR DESCRIPTION
## What I did
- #4: `internal/service/performer/service.go` — `bm25Search` plan setup wrapped in `sync.Once`.

## Why needed
- Each search call ran `SET LOCAL plan_cache_mode`; once is sufficient per process.

## Impact
- 7 lines; removes repeated DDL overhead.