### PR TITLE
fix(query): recursive CTE ParentStudio filter

### DIFF
--- a/internal/api/graphql_client_test.go
+++ b/internal/api/graphql_client_test.go
@@ -538,7 +538,7 @@ func (c *graphqlClient) findPerformers(ids []uuid.UUID) ([]*performerOutput, err
 	q := `
 	query FindPerformers($ids: [ID!]!) {
 		findPerformers(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(performerOutput{})) + `
+			` + makeFragment(reflect.TypeFor[performerOutput]()) + `
 		}
 	}`
 
@@ -556,7 +556,7 @@ func (c *graphqlClient) findStudios(ids []uuid.UUID) ([]*studioOutput, error) {
 	q := `
 	query FindStudios($ids: [ID!]!) {
 		findStudios(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(studioOutput{})) + `
+			` + makeFragment(reflect.TypeFor[studioOutput]()) + `
 		}
 	}`
 
@@ -574,7 +574,7 @@ func (c *graphqlClient) findTags(ids []uuid.UUID) ([]*tagOutput, error) {
 	q := `
 	query FindTags($ids: [ID!]!) {
 		findTags(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(tagOutput{})) + `
+			` + makeFragment(reflect.TypeFor[tagOutput]()) + `
 		}
 	}`
 
@@ -592,7 +592,7 @@ func (c *graphqlClient) findScenes(ids []uuid.UUID) ([]*sceneOutput, error) {
 	q := `
 	query FindScenes($ids: [ID!]!) {
 		findScenes(ids: $ids) {
-			` + makeFragment(reflect.TypeOf(sceneOutput{})) + `
+			` + makeFragment(reflect.TypeFor[sceneOutput]()) + `
 		}
 	}`
 

--- a/internal/service/scene/query.go
+++ b/internal/service/scene/query.go
@@ -86,14 +86,9 @@ func (s *Scene) buildSceneQuery(psql sq.StatementBuilderType, input models.Scene
 			Where(sq.Eq{"scene_urls.url": *input.URL})
 	}
 
-	// Filter by parent studio
+	// Filter by parent studio (recursive CTE for full hierarchy)
 	if input.ParentStudio != nil {
-		query = query.
-			Join("studios ON scenes.studio_id = studios.id").
-			Where(sq.Or{
-				sq.Eq{"studios.parent_studio_id": *input.ParentStudio},
-				sq.Eq{"studios.id": *input.ParentStudio},
-			})
+		query = query.Where(sq.Expr("scenes.studio_id IN (WITH RECURSIVE studio_tree AS (SELECT id FROM studios WHERE id = ? UNION ALL SELECT s.id FROM studios s JOIN studio_tree st ON s.parent_studio_id = st.id) SELECT id FROM studio_tree)", *input.ParentStudio))
 	}
 
 	// Filter by performers


### PR DESCRIPTION
## What I did
- `internal/service/scene/query.go`: Replaced static `OR` (`parent_studio_id` / `id`) with recursive CTE `studio_tree` to include deep hierarchy scenes.


## Why needed
- `ParentStudio` filter only matched 1-level children; grand-child studio scenes excluded.

## Impact
- All descendant studio scenes included in network/studio lists.
- Closes #974